### PR TITLE
Add OG/Twitter meta, JSON-LD schema, sitemap

### DIFF
--- a/apps/web/app/lib/meta.ts
+++ b/apps/web/app/lib/meta.ts
@@ -1,0 +1,42 @@
+// Shared SEO meta helpers for route `meta()` functions.
+//
+// The root loader exposes `origin` for absolute URLs in social and canonical tags. During error
+// boundaries or before the root loader runs, `origin` can be missing — in that case we omit
+// `og:url` and the canonical link entirely rather than emitting bare paths that crawlers will
+// either ignore or resolve incorrectly.
+
+type MetaMatches = ReadonlyArray<{ id?: string; data?: unknown } | undefined> | undefined;
+
+export function getRootOrigin(matches: MetaMatches): string | undefined {
+  const data = matches?.find((m) => m?.id === 'root')?.data as { origin?: string } | undefined;
+  return data?.origin || undefined;
+}
+
+export function seoMeta({
+  matches,
+  path,
+  title,
+  description,
+}: {
+  matches: MetaMatches;
+  path: string;
+  title: string;
+  description: string;
+}) {
+  const origin = getRootOrigin(matches);
+  const url = origin ? `${origin}${path}` : undefined;
+  return [
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
+    ...(url
+      ? [
+          { property: 'og:url', content: url },
+          { tagName: 'link', rel: 'canonical', href: url },
+        ]
+      : []),
+  ];
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -61,7 +61,37 @@ function scrollKey(location: { pathname: string; search: string }): string {
 export function Layout({ children }: { children: React.ReactNode }) {
   const nonce = useNonce();
   const rootData = useRouteLoaderData('root') as { origin?: string } | undefined;
-  const imageUrl = rootData?.origin ? `${rootData.origin}/og.png` : undefined;
+  const origin = rootData?.origin;
+  const imageUrl = origin ? `${origin}/og.png` : undefined;
+  const schemaOrg = origin
+    ? JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Organization',
+            '@id': `${origin}/#organization`,
+            name: 'СИГМА',
+            alternateName: 'Система за Интегриран Граждански Мониторинг и Анализ',
+            url: origin,
+            logo: { '@type': 'ImageObject', url: `${origin}/logo.svg` },
+          },
+          {
+            '@type': 'WebSite',
+            '@id': `${origin}/#website`,
+            url: origin,
+            name: 'СИГМА',
+            description: 'Платформа за прозрачност на обществените поръчки в България',
+            inLanguage: 'bg',
+            publisher: { '@id': `${origin}/#organization` },
+            potentialAction: {
+              '@type': 'SearchAction',
+              target: { '@type': 'EntryPoint', urlTemplate: `${origin}/search?q={search_term_string}` },
+              'query-input': 'required name=search_term_string',
+            },
+          },
+        ],
+      })
+    : null;
   return (
     <html lang="bg">
       <head>
@@ -86,6 +116,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {imageUrl && <meta name="twitter:image" content={imageUrl} />}
         <Meta />
         <Links />
+        {schemaOrg && (
+          <script
+            type="application/ld+json"
+            nonce={nonce}
+            dangerouslySetInnerHTML={{ __html: schemaOrg }}
+          />
+        )}
         <script src="/assets/accessibility/accessibility.js" defer />
       </head>
       <body>

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -119,7 +119,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {schemaOrg && (
           <script
             type="application/ld+json"
-            nonce={nonce}
             dangerouslySetInnerHTML={{ __html: schemaOrg }}
           />
         )}

--- a/apps/web/app/routes/accessibility.tsx
+++ b/apps/web/app/routes/accessibility.tsx
@@ -4,13 +4,19 @@ import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Декларация за достъпност — СИГМА';
+  const description = 'Декларация за достъпност на публичната информационна услуга СИГМА.';
   return [
-    { title: 'Декларация за достъпност — СИГМА' },
-    {
-      name: 'description',
-      content: 'Декларация за достъпност на публичната информационна услуга СИГМА.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/accessibility` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/accessibility.tsx
+++ b/apps/web/app/routes/accessibility.tsx
@@ -3,21 +3,15 @@ import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Декларация за достъпност — СИГМА';
-  const description = 'Декларация за достъпност на публичната информационна услуга СИГМА.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/accessibility` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/accessibility',
+    title: 'Декларация за достъпност — СИГМА',
+    description: 'Декларация за достъпност на публичната информационна услуга СИГМА.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/authorities.tsx
+++ b/apps/web/app/routes/authorities.tsx
@@ -20,21 +20,15 @@ import {
 } from '../lib/filters';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta, yearOptions } from '../lib/coverage';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Институции — СИГМА';
-  const description = 'Всяка институция, възложила поне един договор по обществена поръчка.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/authorities` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/authorities',
+    title: 'Институции — СИГМА',
+    description: 'Всяка институция, възложила поне един договор по обществена поръчка.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/authorities.tsx
+++ b/apps/web/app/routes/authorities.tsx
@@ -21,10 +21,19 @@ import {
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta, yearOptions } from '../lib/coverage';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Институции — СИГМА';
+  const description = 'Всяка институция, възложила поне един договор по обществена поръчка.';
   return [
-    { title: 'Институции — СИГМА' },
-    { name: 'description', content: 'Всяка институция, възложила поне един договор.' },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/authorities` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -11,23 +11,17 @@ import { ShareBar, Chip, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
 import { withDbRetry } from '../lib/retry';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ data, params, matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
   const name = data?.authority.name ?? 'Институция';
   const range = coverageRange(data?.coverage.coverageEndYear);
-  const title = `${name} — СИГМА`;
-  const description = `Обществени поръчки на ${name}, ${range}.`;
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/authorities/${params.eik}` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: `/authorities/${params.eik}`,
+    title: `${name} — СИГМА`,
+    description: `Обществени поръчки на ${name}, ${range}.`,
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -12,12 +12,21 @@ import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
 import { withDbRetry } from '../lib/retry';
 
-export function meta({ data }: Route.MetaArgs) {
+export function meta({ data, params, matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
   const name = data?.authority.name ?? 'Институция';
   const range = coverageRange(data?.coverage.coverageEndYear);
+  const title = `${name} — СИГМА`;
+  const description = `Обществени поръчки на ${name}, ${range}.`;
   return [
-    { title: `${name} — СИГМА` },
-    { name: 'description', content: `Обществени поръчки на ${name}, ${range}.` },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/authorities/${params.eik}` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/companies.tsx
+++ b/apps/web/app/routes/companies.tsx
@@ -21,6 +21,7 @@ import {
 } from '../lib/filters';
 import { publicCache } from '../lib/cache';
 import { getCoverageMeta, yearOptions } from '../lib/coverage';
+import { seoMeta } from '../lib/meta';
 
 const COUNT_BUCKETS = [
   { value: '1', label: '1 договор' },
@@ -31,19 +32,12 @@ const COUNT_BUCKETS = [
 ];
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Компании — СИГМА';
-  const description = 'Всяка компания, спечелила поне един договор по обществена поръчка.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/companies` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/companies',
+    title: 'Компании — СИГМА',
+    description: 'Всяка компания, спечелила поне един договор по обществена поръчка.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/companies.tsx
+++ b/apps/web/app/routes/companies.tsx
@@ -30,13 +30,19 @@ const COUNT_BUCKETS = [
   { value: '100+', label: '100+' },
 ];
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Компании — СИГМА';
+  const description = 'Всяка компания, спечелила поне един договор по обществена поръчка.';
   return [
-    { title: 'Компании — СИГМА' },
-    {
-      name: 'description',
-      content: 'Всяка компания, спечелила поне един договор по обществена поръчка.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/companies` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -11,6 +11,7 @@ import { ShareBar, Chip, OwnershipChip, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
 import { withDbRetry } from '../lib/retry';
+import { seoMeta } from '../lib/meta';
 
 function isSingleNaturalPersonProfile(kind: string, legalForm: string | null): boolean {
   if (kind === 'consortium' || !legalForm) return false;
@@ -25,21 +26,14 @@ function isSingleNaturalPersonProfile(kind: string, legalForm: string | null): b
 }
 
 export function meta({ data, params, matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
   const name = data?.company.displayName ?? 'Компания';
   const range = coverageRange(data?.coverage.coverageEndYear);
-  const title = `${name} — СИГМА`;
-  const description = `Профил на ${name} в обществените поръчки ${range}.`;
-  const meta = [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/companies/${params.eik}` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  const meta = seoMeta({
+    matches,
+    path: `/companies/${params.eik}`,
+    title: `${name} — СИГМА`,
+    description: `Профил на ${name} в обществените поръчки ${range}.`,
+  });
   if (
     data?.company &&
     (isSingleNaturalPersonProfile(data.company.kind, data.company.legalForm) ||

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -28,7 +28,7 @@ function isSingleNaturalPersonProfile(kind: string, legalForm: string | null): b
 export function meta({ data, params, matches }: Route.MetaArgs) {
   const name = data?.company.displayName ?? 'Компания';
   const range = coverageRange(data?.coverage.coverageEndYear);
-  const meta = seoMeta({
+  const metaTags = seoMeta({
     matches,
     path: `/companies/${params.eik}`,
     title: `${name} — СИГМА`,
@@ -40,9 +40,9 @@ export function meta({ data, params, matches }: Route.MetaArgs) {
       isNaturalPersonProfileName(data.company.displayName) ||
       (data.company.kind === 'consortium' && Boolean(data.company.membershipNote)))
   ) {
-    meta.push({ name: 'robots', content: 'noindex' });
+    metaTags.push({ name: 'robots', content: 'noindex' });
   }
-  return meta;
+  return metaTags;
 }
 
 export function headers() {

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -24,12 +24,21 @@ function isSingleNaturalPersonProfile(kind: string, legalForm: string | null): b
   );
 }
 
-export function meta({ data }: Route.MetaArgs) {
+export function meta({ data, params, matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
   const name = data?.company.displayName ?? 'Компания';
   const range = coverageRange(data?.coverage.coverageEndYear);
+  const title = `${name} — СИГМА`;
+  const description = `Профил на ${name} в обществените поръчки ${range}.`;
   const meta = [
-    { title: `${name} — СИГМА` },
-    { name: 'description', content: `Профил на ${name} в обществените поръчки ${range}.` },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/companies/${params.eik}` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
   if (
     data?.company &&

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -9,6 +9,7 @@ import { FactsList } from '../components/FactsList';
 import { Chip, Flag, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { eopSourceFiles } from '../lib/eopSource';
+import { seoMeta } from '../lib/meta';
 
 /**
  * Compose the muted sub-line under „Брой оферти". The AOP feed gives us the gross submitted count
@@ -42,22 +43,15 @@ function bidsBreakdown(c: ContractDetail): string | null {
 }
 
 export function meta({ data, params, matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
   const c = data?.contract;
-  const title = `${c?.subject ?? 'Договор'} — СИГМА`;
-  const description = c
-    ? `Договор по УНП ${c.unp} между ${c.authority.name} и ${c.bidder.displayName}.`
-    : '';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/contracts/${params.id}` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: `/contracts/${params.id}`,
+    title: `${c?.subject ?? 'Договор'} — СИГМА`,
+    description: c
+      ? `Договор по УНП ${c.unp} между ${c.authority.name} и ${c.bidder.displayName}.`
+      : '',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -41,16 +41,22 @@ function bidsBreakdown(c: ContractDetail): string | null {
   return parts.length > 0 ? parts.join(' · ') : null;
 }
 
-export function meta({ data }: Route.MetaArgs) {
+export function meta({ data, params, matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
   const c = data?.contract;
+  const title = `${c?.subject ?? 'Договор'} — СИГМА`;
+  const description = c
+    ? `Договор по УНП ${c.unp} между ${c.authority.name} и ${c.bidder.displayName}.`
+    : '';
   return [
-    { title: `${c?.subject ?? 'Договор'} — СИГМА` },
-    {
-      name: 'description',
-      content: c
-        ? `Договор по УНП ${c.unp} между ${c.authority.name} и ${c.bidder.displayName}.`
-        : '',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/contracts/${params.id}` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -27,14 +27,20 @@ const VALUE_BUCKETS = [
   { value: 'gt100m', label: 'Над 100 млн. €' },
 ];
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Договори — СИГМА';
+  const description =
+    'Всеки сключен договор по обществена поръчка. Филтрите са в адреса, има и сваляне в CSV.';
   return [
-    { title: 'Договори — СИГМА' },
-    {
-      name: 'description',
-      content:
-        'Всеки сключен договор по обществена поръчка. Филтрите са в адреса, има и сваляне в CSV.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/contracts` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -18,6 +18,7 @@ import {
 } from '../lib/filters';
 import { publicCache } from '../lib/cache';
 import { withDbRetry } from '../lib/retry';
+import { seoMeta } from '../lib/meta';
 
 const VALUE_BUCKETS = [
   { value: 'lt100k', label: 'Под 100 хил. €' },
@@ -28,20 +29,13 @@ const VALUE_BUCKETS = [
 ];
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Договори — СИГМА';
-  const description =
-    'Всеки сключен договор по обществена поръчка. Филтрите са в адреса, има и сваляне в CSV.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/contracts` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/contracts',
+    title: 'Договори — СИГМА',
+    description:
+      'Всеки сключен договор по обществена поръчка. Филтрите са в адреса, има и сваляне в CSV.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/flows.tsx
+++ b/apps/web/app/routes/flows.tsx
@@ -9,22 +9,16 @@ import { SankeyDiagram } from '../components/SankeyDiagram';
 import { Callout, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta, yearOptions } from '../lib/coverage';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Потоци на пари — СИГМА';
-  const description =
-    'От институциите възложители към компаниите изпълнители. Дебелината на всеки поток отговаря на стойността на договорите.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/flows` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/flows',
+    title: 'Потоци на пари — СИГМА',
+    description:
+      'От институциите възложители към компаниите изпълнители. Дебелината на всеки поток отговаря на стойността на договорите.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/flows.tsx
+++ b/apps/web/app/routes/flows.tsx
@@ -10,14 +10,20 @@ import { Callout, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta, yearOptions } from '../lib/coverage';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Потоци на пари — СИГМА';
+  const description =
+    'От институциите възложители към компаниите изпълнители. Дебелината на всеки поток отговаря на стойността на договорите.';
   return [
-    { title: 'Потоци на пари — СИГМА' },
-    {
-      name: 'description',
-      content:
-        'От институциите възложители към компаниите изпълнители. Дебелината на всеки поток отговаря на стойността на договорите.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/flows` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -9,23 +9,14 @@ import { RankedBars } from '../components/RankedBars';
 import { OwnershipChip } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageEndYear, coveragePartialNote, coverageRange } from '../lib/coverage';
+import { seoMeta } from '../lib/meta';
 
 const metaTitle = 'СИГМА — Платформа за прозрачност на обществените поръчки';
 const metaDescription =
   'СИГМА показва как държавните институции и общините харчат парите на данъкоплатците чрез обществени поръчки във всички сектори. Без регистрация. Зад всяко число стои конкретен договор.';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((match) => match?.id === 'root')?.data as { origin: string };
-  const origin = rootData.origin;
-  return [
-    { title: metaTitle },
-    { name: 'description', content: metaDescription },
-    { property: 'og:title', content: metaTitle },
-    { property: 'og:description', content: metaDescription },
-    { property: 'og:url', content: `${origin}/` },
-    { name: 'twitter:title', content: metaTitle },
-    { name: 'twitter:description', content: metaDescription },
-  ];
+  return seoMeta({ matches, path: '/', title: metaTitle, description: metaDescription });
 }
 
 export function headers() {

--- a/apps/web/app/routes/impressum.tsx
+++ b/apps/web/app/routes/impressum.tsx
@@ -3,22 +3,16 @@ import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Импресум — СИГМА';
-  const description =
-    'Информация за оператора на СИГМА и контакт по чл. 4 от Закона за електронната търговия.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/impressum` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/impressum',
+    title: 'Импресум — СИГМА',
+    description:
+      'Информация за оператора на СИГМА и контакт по чл. 4 от Закона за електронната търговия.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/impressum.tsx
+++ b/apps/web/app/routes/impressum.tsx
@@ -4,14 +4,20 @@ import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Импресум — СИГМА';
+  const description =
+    'Информация за оператора на СИГМА и контакт по чл. 4 от Закона за електронната търговия.';
   return [
-    { title: 'Импресум — СИГМА' },
-    {
-      name: 'description',
-      content:
-        'Информация за оператора на СИГМА и контакт по чл. 4 от Закона за електронната търговия.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/impressum` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/methodology.tsx
+++ b/apps/web/app/routes/methodology.tsx
@@ -8,13 +8,19 @@ import { Callout, Flag } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { START_YEAR, coverageEndYear } from '../lib/coverage';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Методология и речник — СИГМА';
+  const description = 'Откъде идват числата, как се сглобяват и какво съзнателно не показваме.';
   return [
-    { title: 'Методология и речник — СИГМА' },
-    {
-      name: 'description',
-      content: 'Откъде идват числата, как се сглобяват и какво съзнателно не показваме.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/methodology` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/methodology.tsx
+++ b/apps/web/app/routes/methodology.tsx
@@ -7,21 +7,15 @@ import { PageHeader } from '../components/PageHeader';
 import { Callout, Flag } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { START_YEAR, coverageEndYear } from '../lib/coverage';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Методология и речник — СИГМА';
-  const description = 'Откъде идват числата, как се сглобяват и какво съзнателно не показваме.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/methodology` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/methodology',
+    title: 'Методология и речник — СИГМА',
+    description: 'Откъде идват числата, как се сглобяват и какво съзнателно не показваме.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/privacy.tsx
+++ b/apps/web/app/routes/privacy.tsx
@@ -5,13 +5,19 @@ import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
 
-export function meta(_: Route.MetaArgs) {
+export function meta({ matches }: Route.MetaArgs) {
+  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
+  const origin = rootData?.origin ?? '';
+  const title = 'Политика за поверителност — СИГМА';
+  const description = 'Как СИГМА обработва публични данни и какви права имат субектите на данни.';
   return [
-    { title: 'Политика за поверителност — СИГМА' },
-    {
-      name: 'description',
-      content: 'Как СИГМА обработва публични данни и какви права имат субектите на данни.',
-    },
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: `${origin}/privacy` },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
   ];
 }
 

--- a/apps/web/app/routes/privacy.tsx
+++ b/apps/web/app/routes/privacy.tsx
@@ -4,21 +4,16 @@ import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
 import { publicCache } from '../lib/cache';
 import { contactEmail } from '../lib/contact';
+import { seoMeta } from '../lib/meta';
 
 export function meta({ matches }: Route.MetaArgs) {
-  const rootData = matches.find((m) => m?.id === 'root')?.data as { origin: string };
-  const origin = rootData?.origin ?? '';
-  const title = 'Политика за поверителност — СИГМА';
-  const description = 'Как СИГМА обработва публични данни и какви права имат субектите на данни.';
-  return [
-    { title },
-    { name: 'description', content: description },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { property: 'og:url', content: `${origin}/privacy` },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ];
+  return seoMeta({
+    matches,
+    path: '/privacy',
+    title: 'Политика за поверителност — СИГМА',
+    description:
+      'Как СИГМА обработва публични данни и какви права имат субектите на данни.',
+  });
 }
 
 export function headers() {

--- a/apps/web/app/routes/sitemap-pages.tsx
+++ b/apps/web/app/routes/sitemap-pages.tsx
@@ -17,10 +17,19 @@ const PAGES: Page[] = [
   { loc: '/accessibility', changefreq: 'yearly', priority: '0.1' },
 ];
 
+// Escape XML special chars before interpolating. PAGES is hardcoded today, but the helper sits on
+// the path that any future dynamic source (CMS-driven pages, generated slugs) would also flow
+// through — keep it safe by default rather than relying on every caller to remember.
+function xmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&apos;',
+  );
+}
+
 function entry(origin: string, p: Page): string {
-  const parts = [`<loc>${origin}${p.loc}</loc>`];
-  if (p.changefreq) parts.push(`<changefreq>${p.changefreq}</changefreq>`);
-  if (p.priority) parts.push(`<priority>${p.priority}</priority>`);
+  const parts = [`<loc>${xmlEscape(`${origin}${p.loc}`)}</loc>`];
+  if (p.changefreq) parts.push(`<changefreq>${xmlEscape(p.changefreq)}</changefreq>`);
+  if (p.priority) parts.push(`<priority>${xmlEscape(p.priority)}</priority>`);
   return `<url>${parts.join('')}</url>\n`;
 }
 

--- a/apps/web/app/routes/sitemap-pages.tsx
+++ b/apps/web/app/routes/sitemap-pages.tsx
@@ -1,23 +1,34 @@
 import type { Route } from './+types/sitemap-pages';
 import { withDataSource } from '../lib/dataSource';
 
-const PAGES = [
-  '/',
-  '/companies',
-  '/authorities',
-  '/contracts',
-  '/flows',
-  '/methodology',
-  '/privacy',
-  '/impressum',
-  '/accessibility',
+type Page = { loc: string; changefreq?: string; priority?: string };
+
+// Editorial pages first, then legal/compliance pages. Legal pages are deprioritised in the
+// sitemap so crawlers don't spend budget on them — they exist for compliance, not discovery.
+const PAGES: Page[] = [
+  { loc: '/' },
+  { loc: '/companies' },
+  { loc: '/authorities' },
+  { loc: '/contracts' },
+  { loc: '/flows' },
+  { loc: '/methodology' },
+  { loc: '/privacy', changefreq: 'yearly', priority: '0.1' },
+  { loc: '/impressum', changefreq: 'yearly', priority: '0.1' },
+  { loc: '/accessibility', changefreq: 'yearly', priority: '0.1' },
 ];
+
+function entry(origin: string, p: Page): string {
+  const parts = [`<loc>${origin}${p.loc}</loc>`];
+  if (p.changefreq) parts.push(`<changefreq>${p.changefreq}</changefreq>`);
+  if (p.priority) parts.push(`<priority>${p.priority}</priority>`);
+  return `<url>${parts.join('')}</url>\n`;
+}
 
 export function loader({ request }: Route.LoaderArgs) {
   const origin = new URL(request.url).origin;
   const body =
     `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    PAGES.map((p) => `<url><loc>${origin}${p}</loc></url>\n`).join('') +
+    PAGES.map((p) => entry(origin, p)).join('') +
     `</urlset>\n`;
   return withDataSource(
     new Response(body, {

--- a/apps/web/app/routes/sitemap-pages.tsx
+++ b/apps/web/app/routes/sitemap-pages.tsx
@@ -1,7 +1,17 @@
 import type { Route } from './+types/sitemap-pages';
 import { withDataSource } from '../lib/dataSource';
 
-const PAGES = ['/', '/companies', '/authorities', '/contracts', '/flows', '/methodology'];
+const PAGES = [
+  '/',
+  '/companies',
+  '/authorities',
+  '/contracts',
+  '/flows',
+  '/methodology',
+  '/privacy',
+  '/impressum',
+  '/accessibility',
+];
 
 export function loader({ request }: Route.LoaderArgs) {
   const origin = new URL(request.url).origin;


### PR DESCRIPTION
Populate SEO and social metadata across routes: meta() now reads root origin and emits title, description, og:title, og:description, og:url and twitter meta for pages (companies, authorities, contracts, flows, methodology, privacy, impressum, accessibility and dynamic company/authority/contract pages). Add schema.org JSON-LD (Organization and WebSite) injection in root Layout when origin is present. Extend sitemap pages to include privacy, impressum and accessibility. These changes improve SEO, canonical URLs and social sharing previews.