### PR TITLE
fix(web): retry transient D1 read failures on entity loaders

### DIFF
--- a/apps/web/app/lib/retry.test.ts
+++ b/apps/web/app/lib/retry.test.ts
@@ -33,4 +33,12 @@ describe('withDbRetry', () => {
     await expect(withDbRetry(fn)).rejects.toBe(notFound);
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it('runs once and surfaces the real error when attempts <= 0 (never throws undefined)', async () => {
+    const err = new Error('down');
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withDbRetry(fn, 0)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/app/lib/retry.test.ts
+++ b/apps/web/app/lib/retry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withDbRetry } from './retry';
+
+describe('withDbRetry', () => {
+  it('returns the result without retrying when the fetch succeeds', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    await expect(withDbRetry(fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient error and resolves once it succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('D1_ERROR: Network connection lost'))
+      .mockResolvedValue('recovered');
+
+    await expect(withDbRetry(fn)).resolves.toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up and throws the last error after exhausting attempts', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('still down'));
+
+    await expect(withDbRetry(fn, 3)).rejects.toThrow('still down');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('never retries a thrown Response (404/redirect control flow)', async () => {
+    const notFound = new Response('Not Found', { status: 404 });
+    const fn = vi.fn().mockRejectedValue(notFound);
+
+    await expect(withDbRetry(fn)).rejects.toBe(notFound);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/lib/retry.ts
+++ b/apps/web/app/lib/retry.ts
@@ -1,0 +1,41 @@
+// Read-only loaders fan out several D1 queries per request (an entity detail page issues ~8, each
+// `listContracts` a couple more). D1, like any networked store, occasionally throws a transient
+// fault — a dropped connection, a momentary internal error, a brief timeout. Without a retry, one
+// such blip on any single query rejects the whole loader and renders the full-page error boundary
+// („Грешка"), even though an immediate re-read would have succeeded. This wraps a loader's data
+// fetch in a bounded retry so a transient fault self-heals into a normal response instead of a 500.
+//
+// Safe only because these loaders are read-only and idempotent — re-running them has no side
+// effects. Thrown `Response`s (404 / redirect) are intentional control flow, never transient, so
+// they pass straight through without consuming a retry.
+
+const BACKOFF_MS = [50, 150];
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run an idempotent, read-only data fetch, retrying on transient faults. A thrown `Response` (the
+ * React Router idiom for 404/redirect) is re-thrown immediately. Any other error is retried up to
+ * `attempts` times total with a short backoff; the last error propagates if every attempt fails.
+ */
+export async function withDbRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      // 404 / redirect — intentional, not a fault. Never retry; surface it on the first throw.
+      if (error instanceof Response) throw error;
+      lastError = error;
+      if (attempt < attempts - 1) {
+        // Logged so the otherwise-silent transient faults are visible in Workers logs.
+        console.warn(
+          `[withDbRetry] read failed (attempt ${attempt + 1}/${attempts}), retrying:`,
+          error instanceof Error ? error.message : error,
+        );
+        await delay(BACKOFF_MS[attempt] ?? 150);
+      }
+    }
+  }
+  throw lastError;
+}

--- a/apps/web/app/lib/retry.ts
+++ b/apps/web/app/lib/retry.ts
@@ -19,18 +19,20 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
  * `attempts` times total with a short backoff; the last error propagates if every attempt fails.
  */
 export async function withDbRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  // Clamp so a caller passing attempts <= 0 still runs once and never `throw undefined`.
+  const total = Math.max(1, attempts);
   let lastError: unknown;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
+  for (let attempt = 0; attempt < total; attempt += 1) {
     try {
       return await fn();
     } catch (error) {
       // 404 / redirect — intentional, not a fault. Never retry; surface it on the first throw.
       if (error instanceof Response) throw error;
       lastError = error;
-      if (attempt < attempts - 1) {
+      if (attempt < total - 1) {
         // Logged so the otherwise-silent transient faults are visible in Workers logs.
         console.warn(
-          `[withDbRetry] read failed (attempt ${attempt + 1}/${attempts}), retrying:`,
+          `[withDbRetry] read failed (attempt ${attempt + 1}/${total}), retrying:`,
           error instanceof Error ? error.message : error,
         );
         await delay(BACKOFF_MS[attempt] ?? 150);

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -21,6 +21,7 @@ import { SiteFooter } from './components/SiteFooter';
 import { AccessibilityWidget } from './components/AccessibilityWidget';
 import { PageHeader } from './components/PageHeader';
 import { getCoverageMeta } from './lib/coverage';
+import { withDbRetry } from './lib/retry';
 import './app.css';
 
 // The editorial design uses a system serif/mono/sans stack (see app.css @theme) — no webfont request.
@@ -41,7 +42,9 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
     throw redirect(url.pathname.replace(/\/+$/, '') + url.search, 301);
   }
-  const coverage = await getCoverageMeta(context.cloudflare.env.DB);
+  // Wrapped like the leaf loaders: this chrome read runs on every route, so a transient D1 fault
+  // here would 500 the whole page (incl. the entity pages this PR targets) without the retry.
+  const coverage = await withDbRetry(() => getCoverageMeta(context.cloudflare.env.DB));
   return { ...coverage, origin: url.origin };
 }
 

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -10,6 +10,7 @@ import { ContractMiniTable } from '../components/ContractMiniTable';
 import { ShareBar, Chip, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
+import { withDbRetry } from '../lib/retry';
 
 export function meta({ data }: Route.MetaArgs) {
   const name = data?.authority.name ?? 'Институция';
@@ -25,14 +26,17 @@ export function headers() {
 }
 
 export async function loader({ params, context }: Route.LoaderArgs) {
-  if (!params.eik?.trim()) throw new Response('Not Found', { status: 404 });
+  const eik = params.eik;
+  if (!eik?.trim()) throw new Response('Not Found', { status: 404 });
   const db = context.cloudflare.env.DB;
-  const [authority, coverage] = await Promise.all([
-    getAuthority(db, authorityIdFromSlug(params.eik)),
-    getCoverageMeta(db),
-  ]);
-  if (!authority) throw new Response('Not Found', { status: 404 });
-  return { authority, coverage };
+  return withDbRetry(async () => {
+    const [authority, coverage] = await Promise.all([
+      getAuthority(db, authorityIdFromSlug(eik)),
+      getCoverageMeta(db),
+    ]);
+    if (!authority) throw new Response('Not Found', { status: 404 });
+    return { authority, coverage };
+  });
 }
 
 export default function Authority({ loaderData }: Route.ComponentProps) {

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -10,6 +10,7 @@ import { ContractMiniTable } from '../components/ContractMiniTable';
 import { ShareBar, Chip, OwnershipChip, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
+import { withDbRetry } from '../lib/retry';
 
 function isSingleNaturalPersonProfile(kind: string, legalForm: string | null): boolean {
   if (kind === 'consortium' || !legalForm) return false;
@@ -50,9 +51,11 @@ export async function loader({ params, context }: Route.LoaderArgs) {
   const id = bidderIdFromSlug(params.eik);
   if (!id) throw new Response('Not Found', { status: 404 });
   const db = context.cloudflare.env.DB;
-  const [company, coverage] = await Promise.all([getCompany(db, id), getCoverageMeta(db)]);
-  if (!company) throw new Response('Not Found', { status: 404 });
-  return { company, coverage };
+  return withDbRetry(async () => {
+    const [company, coverage] = await Promise.all([getCompany(db, id), getCoverageMeta(db)]);
+    if (!company) throw new Response('Not Found', { status: 404 });
+    return { company, coverage };
+  });
 }
 
 export default function Company({ loaderData }: Route.ComponentProps) {

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -17,6 +17,7 @@ import {
   PAGE_SIZE,
 } from '../lib/filters';
 import { publicCache } from '../lib/cache';
+import { withDbRetry } from '../lib/retry';
 
 const VALUE_BUCKETS = [
   { value: 'lt100k', label: 'Под 100 хил. €' },
@@ -59,12 +60,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   };
   const { env } = context.cloudflare;
   // Page `Cache-Control` (publicCache(1800)) memoises full responses at the edge — no per-query cache.
-  const [summary, facets] = await Promise.all([
-    contractsSummary(env.DB, params),
-    getContractFacets(env.DB),
-  ]);
-  const result = await listContracts(env.DB, params, summary);
-  return { result, facets };
+  return withDbRetry(async () => {
+    const [summary, facets] = await Promise.all([
+      contractsSummary(env.DB, params),
+      getContractFacets(env.DB),
+    ]);
+    const result = await listContracts(env.DB, params, summary);
+    return { result, facets };
+  });
 }
 
 export default function Contracts({ loaderData }: Route.ComponentProps) {


### PR DESCRIPTION
## What

Wraps the `company`, `authority`, and `contracts` route loaders in a bounded retry (`withDbRetry`) so a transient D1 fault on a single query no longer 500s the whole page.

## Why — issue #2

[#2](https://github.com/midt-bg/sigma/issues/2) reports that the „виж всички договори" link on a company page (→ `/contracts?bidder=<eik>`) leads to the „Грешка" error page.

Investigation (probing production):

- The failure was **real but intermittent and per-entity**: for a given entity, *both* its detail page and its entity-filtered contracts list 500'd together, while other entities returned 200. It has since self-healed with no deploy.
- It localizes to one shared path: `getCompany` / `getAuthority` both internally call `listContracts({bidder|authority})` — the same function the `/contracts` loader uses. Facet-filtered lists (`?year=`, `?value=`) never failed, and the CSV export (separate `streamContractsCsv`) returned full, clean data for the "failing" entities — so it is **not a data or SQL bug**.
- A 500→200 flip with no code change points to a **transient D1 / Worker fault** (dropped connection, momentary internal error, timeout) on these multi-query read loaders, which today have no retry: one blip rejects the whole loader and renders the full-page error boundary.

## The change

`withDbRetry(fn)` — a bounded retry (3 attempts, 50/150 ms backoff) around each read-only loader's data fetch:

- Read-only and idempotent, so re-running is safe.
- Thrown `Response`s (404 / redirect) pass straight through — never retried.
- Retries are `console.warn`-logged, which also makes these otherwise-silent transient faults visible in Workers logs.

Applied to the `contracts`, `company`, and `authority` loaders — the exact pages in the issue. The helper is generic and can be extended to the other D1-backed loaders later.

## Honest caveat

I could **not deterministically reproduce** the fault (production self-healed; the underlying data is clean). This is **resilience hardening for the observed transient failure**, not a confirmed-root-cause fix. Marked `Closes #2` to resolve the issue on merge; since the fault was not deterministically reproduced, confirm the error is gone against Workers logs / production after deploy. If failures recur after this merges, the retry warnings will surface the actual D1 error in logs; the next step would be to check whether a specific slow query needs indexing or the ~8-wide loader fan-out needs trimming.

## Tests

`apps/web/app/lib/retry.test.ts` covers success (no retry), retry-then-succeed, give-up-after-attempts, and `Response` passthrough. `pnpm --filter web test` (62 passed), `typecheck`, and `prettier --check .` all green.
Closes #2
