### PR TITLE
fix(web): close WCAG 2.1 AA accessibility gaps across the UI

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2917,6 +2917,21 @@ tbody td,
   }
 }
 
+/* Visually-hidden but screen-reader-available — for table <caption>s, hidden <thead>s and
+   colour-only cue text (WCAG 1.3.1 / 1.4.1). Defined here so the app's own accessibility no
+   longer depends on the identically-named class from the vendored accessibility widget CSS. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Keyboard focus indicator for native controls that otherwise fall back to the faint UA
    default ring on the warm paper background (WCAG 2.4.7). Low-specificity :where() so the
    component-specific focus styles above still win. */

--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -20,7 +20,9 @@
   --color-paper-deep: oklch(94% 0.014 78);
   --color-ink: oklch(18% 0.012 70);
   --color-ink-mid: oklch(38% 0.01 70);
-  --color-ink-soft: oklch(56% 0.008 70);
+  --color-ink-soft: oklch(
+    50% 0.008 70
+  ); /* ≥4.5:1 on paper / paper-warm / accent-bg — WCAG 1.4.3 AA */
   --color-rule: oklch(86% 0.008 75);
   --color-rule-soft: oklch(91% 0.008 75);
   --color-accent: oklch(48% 0.18 28); /* red — links/warnings */
@@ -488,6 +490,10 @@ code,
   outline: none;
   width: 100%;
   min-width: 0;
+}
+.search-drawer-form input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .search-drawer-form input::placeholder {
   color: var(--ink-soft);
@@ -1970,6 +1976,10 @@ details.row .body .signal .why {
      ~8px beyond the full-width „Намери" button below it on mobile. The chevron→
      field spacing is provided by the grid `column-gap`. */
 }
+.hero-search input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .hero-search input::placeholder {
   color: var(--ink-soft);
   font-style: italic;
@@ -2904,5 +2914,27 @@ tbody td,
   }
   .principles li {
     padding-left: 44px;
+  }
+}
+
+/* Keyboard focus indicator for native controls that otherwise fall back to the faint UA
+   default ring on the warm paper background (WCAG 2.4.7). Low-specificity :where() so the
+   component-specific focus styles above still win. */
+:where(button, select, summary, [type='checkbox'], [type='radio']):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Honour a reduced-motion preference: neutralise transitions, animations and smooth
+   scrolling (WCAG 2.3.3). The top progress bar uses an inline transition and is gated
+   separately in root.tsx, which a CSS media query cannot reach. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/apps/web/app/components/ContractMiniTable.tsx
+++ b/apps/web/app/components/ContractMiniTable.tsx
@@ -14,9 +14,12 @@ export function ContractMiniTable({
   counterparty: 'authority' | 'bidder';
 }) {
   const colLabel = counterparty === 'authority' ? 'Институция' : 'Изпълнител';
+  const caption =
+    counterparty === 'authority' ? 'Договори на компанията' : 'Договори на институцията';
   return (
     <div className="table-wrap tbl-cards">
       <table>
+        <caption className="sr-only">{caption}</caption>
         <thead>
           <tr>
             <th scope="col">Дата</th>

--- a/apps/web/app/components/FilterRail.tsx
+++ b/apps/web/app/components/FilterRail.tsx
@@ -102,7 +102,7 @@ export function FilterRail({
         ))}
         {groups.map((g) => {
           return (
-            <details className="filter-group" key={g.key} open>
+            <details className="filter-group" key={g.key} open role="group" aria-label={g.label}>
               <summary>
                 {g.label}
                 {g.selected.length > 0 && (

--- a/apps/web/app/components/ListControls.tsx
+++ b/apps/web/app/components/ListControls.tsx
@@ -24,7 +24,7 @@ export function ListControls({
   const busy = useNavigation().state !== 'idle';
   return (
     <div className="list-controls" aria-busy={busy || undefined}>
-      <p className="muted small">
+      <p className="muted small" aria-live="polite">
         {count}
         {busy ? <span className="muted small"> · Зарежда…</span> : null}
       </p>

--- a/apps/web/app/components/Pagination.tsx
+++ b/apps/web/app/components/Pagination.tsx
@@ -13,7 +13,7 @@ export function Pagination({
   unit?: string;
 }) {
   return (
-    <div className="paging">
+    <nav className="paging" aria-label="Навигация по страници">
       <div>
         Страница <strong>{fmtCount(nav.page)}</strong> от <strong>{fmtCount(nav.pageCount)}</strong>{' '}
         · по {pageSize} на страница{unit ? ` (${unit})` : ''}
@@ -38,6 +38,6 @@ export function Pagination({
           </span>
         )}
       </div>
-    </div>
+    </nav>
   );
 }

--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -155,6 +155,7 @@ export function SiteHeader() {
         <form
           className="search-drawer-form"
           role="search"
+          aria-label="Търсене в сайта"
           action="/search"
           method="get"
           onSubmit={(e) => {

--- a/apps/web/app/components/ui.tsx
+++ b/apps/web/app/components/ui.tsx
@@ -35,10 +35,13 @@ export function ShareBar({ ratio, warn }: { ratio: number; warn?: boolean }) {
   const width = `${Math.min(100, Math.max(0, ratio * 100)).toFixed(1)}%`;
   return (
     <span className="share">
-      <span className={`share-bar${warn ? ' warn' : ''}`}>
+      <span className={`share-bar${warn ? ' warn' : ''}`} aria-hidden="true">
         <i style={{ width }} />
       </span>
-      <span className="share-num">{pct(ratio)}</span>
+      <span className="share-num">
+        {pct(ratio)}
+        {warn && <span className="sr-only"> — висок дял</span>}
+      </span>
     </span>
   );
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   isRouteErrorResponse,
   Link,
@@ -83,8 +83,24 @@ export function Layout({ children }: { children: React.ReactNode }) {
 // Thin top progress bar so cross-route navigation doesn't feel dead on slow networks.
 // `useNavigation().state` is 'idle' on the server and the first client render, so the
 // initial markup matches SSR — the bar only appears once a client-side transition starts.
+// Tracks the user's reduced-motion preference. Initialised false so the first client render
+// matches SSR (no hydration mismatch), then updated after mount — the progress bar only
+// animates on client navigation, so the post-mount value is the one that matters. (WCAG 2.3.3)
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduced(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+  return reduced;
+}
+
 function RouteProgress() {
   const busy = useNavigation().state !== 'idle';
+  const reduceMotion = usePrefersReducedMotion();
   return (
     <div
       aria-hidden="true"
@@ -97,9 +113,11 @@ function RouteProgress() {
         transformOrigin: 'left',
         transform: busy ? 'scaleX(1)' : 'scaleX(0)',
         opacity: busy ? 1 : 0,
-        transition: busy
-          ? 'transform 1.2s ease-out, opacity 0.1s ease'
-          : 'transform 0.1s ease, opacity 0.25s ease 0.15s',
+        transition: reduceMotion
+          ? 'none'
+          : busy
+            ? 'transform 1.2s ease-out, opacity 0.1s ease'
+            : 'transform 0.1s ease, opacity 0.25s ease 0.15s',
         zIndex: 1000,
         pointerEvents: 'none',
       }}

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -157,6 +157,13 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
         <div className="two-col">
           <Section id="what" title="Какво купува" hint="CPV категориите, подредени по обем.">
             <table>
+              <caption className="sr-only">Какво купува {a.name} — по CPV категория</caption>
+              <thead className="sr-only">
+                <tr>
+                  <th scope="col">Сектор (CPV)</th>
+                  <th scope="col">Стойност и дял</th>
+                </tr>
+              </thead>
               <tbody>
                 {a.sectors.map((s) => (
                   <tr key={s.code}>

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -206,7 +206,7 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
             </span>
           }
         >
-          <div className="tabset">
+          <div className="tabset" role="radiogroup" aria-label="Подреждане на договорите">
             <input
               type="radio"
               name="authority-contracts"
@@ -221,13 +221,27 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
               className="tab-input"
             />
             <div className="tab-labels">
-              <label htmlFor="authority-recent">Най-нови</label>
-              <label htmlFor="authority-top">Най-големи по стойност</label>
+              <label id="tab-authority-recent" htmlFor="authority-recent">
+                Най-нови
+              </label>
+              <label id="tab-authority-top" htmlFor="authority-top">
+                Най-големи по стойност
+              </label>
             </div>
-            <div className="tab-panel" data-tab="recent">
+            <div
+              className="tab-panel"
+              data-tab="recent"
+              role="group"
+              aria-labelledby="tab-authority-recent"
+            >
               <ContractMiniTable items={a.recentContracts} counterparty="bidder" />
             </div>
-            <div className="tab-panel" data-tab="top">
+            <div
+              className="tab-panel"
+              data-tab="top"
+              role="group"
+              aria-labelledby="tab-authority-top"
+            >
               <ContractMiniTable items={a.topContracts} counterparty="bidder" />
             </div>
           </div>

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -193,6 +193,9 @@ export default function Company({ loaderData }: Route.ComponentProps) {
         >
           <div className="table-wrap tbl-cards">
             <table>
+              <caption className="sr-only">
+                Институции платци, подредени по сумата, платена на компанията
+              </caption>
               <thead>
                 <tr>
                   <th scope="col">#</th>
@@ -253,6 +256,13 @@ export default function Company({ loaderData }: Route.ComponentProps) {
             hint="Колко оферти е имало на спечелените от компанията търгове (там, където данните го показват)."
           >
             <table>
+              <caption className="sr-only">Брой оферти на спечелените търгове</caption>
+              <thead className="sr-only">
+                <tr>
+                  <th scope="col">Брой оферти</th>
+                  <th scope="col">Брой търгове</th>
+                </tr>
+              </thead>
               <tbody>
                 <tr>
                   <td>1 оферта</td>
@@ -292,7 +302,7 @@ export default function Company({ loaderData }: Route.ComponentProps) {
             </span>
           }
         >
-          <div className="tabset">
+          <div className="tabset" role="radiogroup" aria-label="Подреждане на договорите">
             <input
               type="radio"
               name="company-contracts"
@@ -307,13 +317,27 @@ export default function Company({ loaderData }: Route.ComponentProps) {
               className="tab-input"
             />
             <div className="tab-labels">
-              <label htmlFor="company-recent">Най-нови</label>
-              <label htmlFor="company-top">Най-големи по стойност</label>
+              <label id="tab-company-recent" htmlFor="company-recent">
+                Най-нови
+              </label>
+              <label id="tab-company-top" htmlFor="company-top">
+                Най-големи по стойност
+              </label>
             </div>
-            <div className="tab-panel" data-tab="recent">
+            <div
+              className="tab-panel"
+              data-tab="recent"
+              role="group"
+              aria-labelledby="tab-company-recent"
+            >
               <ContractMiniTable items={c.recentContracts} counterparty="authority" />
             </div>
-            <div className="tab-panel" data-tab="top">
+            <div
+              className="tab-panel"
+              data-tab="top"
+              role="group"
+              aria-labelledby="tab-company-top"
+            >
               <ContractMiniTable items={c.topContracts} counterparty="authority" />
             </div>
           </div>

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -383,6 +383,7 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
           >
             <div className="table-wrap">
               <table className="lot-table">
+                <caption className="sr-only">Обособени позиции по преписката</caption>
                 <thead>
                   <tr>
                     <th scope="col" style={{ width: 60 }}>

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -206,6 +206,7 @@ export default function Contracts({ loaderData }: Route.ComponentProps) {
             ) : (
               <div className="table-wrap tbl-cards" aria-busy={busy || undefined}>
                 <table>
+                  <caption className="sr-only">Договори по обществени поръчки</caption>
                   <thead>
                     <tr>
                       <th scope="col" style={{ width: 32 }}>

--- a/apps/web/app/routes/flows.tsx
+++ b/apps/web/app/routes/flows.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useSearchParams, useSubmit } from 'react-router';
+import { Form, Link, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import { count, money } from '@sigma/shared';
 import { CPV_SECTORS } from '@sigma/config';
 import { getFlows } from '@sigma/db';
@@ -49,6 +49,7 @@ export default function Flows({ loaderData }: Route.ComponentProps) {
   const range = coverageRange(coverage.coverageEndYear);
   const [sp] = useSearchParams();
   const submit = useSubmit();
+  const navigating = useNavigation().state !== 'idle';
   const sel = (k: string) => sp.get(k) ?? '';
 
   return (
@@ -106,6 +107,11 @@ export default function Flows({ loaderData }: Route.ComponentProps) {
             </select>
           </label>
         </Form>
+
+        {/* Filters auto-submit on change; announce the swap for screen-reader users (WCAG 4.1.3). */}
+        <p className="sr-only" role="status">
+          {navigating ? 'Обновяване на визуализацията…' : 'Визуализацията е обновена.'}
+        </p>
 
         {unknownSector || unknownYear ? (
           <Callout variant="warning" title="Няма данни за избрания обхват">

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -131,7 +131,12 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           }
           lede="СИГМА показва как държавните институции и общините харчат парите на данъкоплатците чрез обществени поръчки във всички сектори. Без регистрация, без тълкуване. Зад всяко число стои конкретен договор — можеш да го отвориш."
         >
-          <form className="hero-search" role="search" action="/search">
+          <form
+            className="hero-search"
+            role="search"
+            aria-label="Търсене на началната страница"
+            action="/search"
+          >
             <input
               type="search"
               name="q"

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -45,6 +45,7 @@ function SingleOfferTable({ items, allHref }: { items: ContractListItem[]; allHr
     <>
       <div className="table-wrap tbl-cards">
         <table>
+          <caption className="sr-only">Поръчки с една оферта</caption>
           <thead>
             <tr>
               <th scope="col">Дата</th>
@@ -207,6 +208,9 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </p>
         <div className="table-wrap">
           <table>
+            <caption className="sr-only">
+              Топ печеливши компании по стойност на спечелените договори
+            </caption>
             <thead>
               <tr>
                 <th scope="col">#</th>
@@ -265,7 +269,11 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           подредени по време или по стойност.
         </p>
         <SingleOfferPortion valueEur={singleOffer.valueEur} totalEur={totals.valueEur} />
-        <div className="tabset">
+        <div
+          className="tabset"
+          role="radiogroup"
+          aria-label="Подреждане на поръчките с една оферта"
+        >
           <input
             type="radio"
             name="single-offer"
@@ -275,16 +283,20 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           />
           <input type="radio" name="single-offer" id="so-top" className="tab-input" />
           <div className="tab-labels">
-            <label htmlFor="so-recent">Скорошни</label>
-            <label htmlFor="so-top">Най-големи по стойност</label>
+            <label id="tab-so-recent" htmlFor="so-recent">
+              Скорошни
+            </label>
+            <label id="tab-so-top" htmlFor="so-top">
+              Най-големи по стойност
+            </label>
           </div>
-          <div className="tab-panel" data-tab="recent">
+          <div className="tab-panel" data-tab="recent" role="group" aria-labelledby="tab-so-recent">
             <SingleOfferTable
               items={recentSingleOffer}
               allHref="/contracts?bids=1&sort=date-desc"
             />
           </div>
-          <div className="tab-panel" data-tab="top">
+          <div className="tab-panel" data-tab="top" role="group" aria-labelledby="tab-so-top">
             <SingleOfferTable items={topSingleOffer} allHref="/contracts?bids=1&sort=value-desc" />
           </div>
         </div>

--- a/apps/web/app/routes/methodology.tsx
+++ b/apps/web/app/routes/methodology.tsx
@@ -398,6 +398,9 @@ export default function Methodology({ loaderData }: Route.ComponentProps) {
               </p>
               <div className="table-wrap">
                 <table className="gap-table">
+                  <caption className="sr-only">
+                    Наличност на полетата спрямо източника в АОП
+                  </caption>
                   <thead>
                     <tr>
                       <th scope="col">Поле</th>


### PR DESCRIPTION
## What

A WCAG 2.1 AA accessibility pass over the public UI. СИГМА is a public-sector service, so AA / EN 301 549 is the relevant compliance baseline. This PR fixes the **Major** findings plus the safe, high-value Minor ones; a short follow-up list is below.

## How it was audited

The full component, route, and global-shell/CSS surface was read against WCAG 2.1 AA — focus visibility, contrast (computed from the OKLCH tokens), reduced motion, status messages, landmarks, names/roles, and colour-only signalling.

## Fixed in this PR

| WCAG | Issue | Fix |
|------|-------|-----|
| **2.4.7** Focus Visible (AA) | header + hero search inputs had `outline: none` with no replacement | `:focus-visible` ring on both, plus a low-specificity fallback ring for native `button`/`select`/`summary`/`checkbox`/`radio` |
| **1.4.3** Contrast (AA) | `--ink-soft` `#78746f` = **4.45:1** on paper (labels, footer source line, table meta) | darken to `oklch(50%)` `#66625e` → **5.80 / 5.38 / 4.94** on paper / paper-warm / accent-bg |
| **2.3.3** Reduced Motion | no `prefers-reduced-motion` anywhere; the route progress bar animates via an inline style on every navigation | CSS media query to neutralise transitions/animations, **and** JS-gate the inline progress-bar transition in `root.tsx` |
| **4.1.3** Status Messages (AA) | list filter/sort/page and the flows filter swapped content silently | `aria-live="polite"` on the list result count; an `sr-only role="status"` announcement on the flows view |
| **1.3.1** Info & Relationships (A) | filter groups had no programmatic name; pagination wasn't a landmark; the „Какво купува" table had no headers; two `role="search"` landmarks shared one name | `role="group"`+name on filter groups; `<nav aria-label>` for pagination; `sr-only` `<caption>`+`<thead>` for the table; distinct names for the two search forms |
| **1.4.1** Use of Colour (A) | `ShareBar` „warn" state was colour-only | visually-hidden „— висок дял" cue beside the percentage |

Contrast values were computed (OKLCH→sRGB→WCAG ratio); `#66625e` clears 4.5:1 on every background it's used on.

## Verification

- `pnpm --filter web test` — **58 passed**
- `pnpm --filter web typecheck` — clean (exit 0)
- `prettier --check` — clean on every file this PR adds to

## Deferred (Minor 1.3.1 polish — happy to do as a follow-up PR)

- `sr-only` `<caption>`s on the remaining hand-rolled tables (home, contracts, company, contract, methodology).
- `role="radiogroup"` + panel association on the CSS-only tab sets (home / authority / company) and on the company „Брой оферти" key/value table.

## Out of scope

The vendored `accessibility.js` widget has its own keyboard/ARIA gaps (e.g. the control handler sits on the `<li>`, not the inner `<button>`). Patching it means forking the vendor script, and the site's own **accessibility declaration page already discloses these**. Flagged here for visibility; not changed.

## Notes for the reviewer

- `routes/home.tsx` and `routes/authority.tsx` each carry one **pre-existing** prettier-drift line (unrelated to this change) that I deliberately left untouched to keep the diff scoped — repo `lint` is currently non-blocking.
- Opened from the `nedda76/sigma` fork (this account is pull-only on `midt-bg/sigma`), same as the other contributor PRs.