### PR TITLE
fix(devcontainer): pin installer downloads to fixed versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,22 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm
+# Digest-pinned to the 22-bookworm multi-arch index resolved on 2026-06-16.
+# The tag is kept for readability; the @sha256 is what actually pins the image.
+# Re-resolve with: curl -fsSL -D - -o /dev/null \
+#   -H 'Accept: application/vnd.oci.image.index.v1+json' \
+#   https://mcr.microsoft.com/v2/devcontainers/typescript-node/manifests/22-bookworm \
+#   | grep -i docker-content-digest
+FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm@sha256:59e8c044af4ed4795967188c3d0b9bc677f42d42b0ff41f98c8be5333defeb64
 
 ARG WRANGLER_VERSION=4
+# uv installer is fetched from a version-pinned path (astral.sh/uv/<ver>/install.sh),
+# not a mutable branch, and the installer verifies the binary checksum itself.
 ARG UV_VERSION=0.5.11
+# act release tag to install. The installer self-verifies the binary's SHA256
+# against the upstream checksums file for this tag (see install.sh execute()).
+ARG ACT_VERSION=v0.2.89
+# Claude Code CLI version. Pinned instead of the default "stable" channel so the
+# build is reproducible; claude.ai/install.sh verifies the binary checksum against
+# the per-version manifest.json it downloads.
+ARG CLAUDE_VERSION=2.1.153
 # Pin pnpm's major to avoid `@latest` drift silently changing build behavior
 # (e.g. the global-bin-dir convention). Bump deliberately.
 ARG PNPM_VERSION=10
@@ -40,8 +55,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install act (run GitHub Actions locally) — use -b to install directly into /usr/local/bin
 # instead of the installer's default ./bin (which would otherwise need cleanup and is risky
 # at this point in the build because WORKDIR is still /).
-RUN curl -fsSL https://raw.githubusercontent.com/nektos/act/master/install.sh \
-    | bash -s -- -b /usr/local/bin
+# The install script is pinned to the commit that ${ACT_VERSION} points to (was `master`),
+# and the trailing tag arg pins the act binary. The script downloads the upstream
+# checksums file and verifies the binary's SHA256 before installing.
+RUN curl -fsSL https://raw.githubusercontent.com/nektos/act/4f411281417e88660bea1c1a1749aa71ae0bd60f/install.sh \
+    | bash -s -- -b /usr/local/bin "${ACT_VERSION}"
 
 # Make zsh node's default login shell
 RUN usermod -s /usr/bin/zsh node
@@ -64,7 +82,12 @@ RUN corepack prepare pnpm@${PNPM_VERSION} --activate \
 RUN pnpm add -g wrangler@${WRANGLER_VERSION}
 
 # AI coding agents
-RUN curl -fsSL https://claude.ai/install.sh | bash
+# Pass ${CLAUDE_VERSION} so the build pins an exact release instead of the moving
+# "stable" channel. The installer (claude.ai/install.sh) downloads that version's
+# manifest.json and verifies the binary's SHA256 against it before installing.
+# Note: the installer *script* URL is not version-addressable upstream, so it
+# remains an unavoidable trust anchor (same as the Astral uv bootstrap above).
+RUN curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_VERSION}"
 RUN pnpm add -g @openai/codex
 
 # Playwright MCP server + pre-fetched Chromium so the agent can inspect UI in a
@@ -74,8 +97,11 @@ RUN pnpm add -g @playwright/mcp playwright \
 
 # Headline theme — oh-my-zsh is pre-installed in the typescript-node base image,
 # so we only drop the theme in and switch ZSH_THEME.
-RUN curl -fsSL https://raw.githubusercontent.com/moarram/headline/main/headline.zsh-theme \
+# Pinned to a specific commit (was the moving `main` ref); upstream ships no tags
+# or checksums, so we verify the downloaded file against a known-good SHA256.
+RUN curl -fsSL https://raw.githubusercontent.com/moarram/headline/eabc85636f4dbf23927d2f2f6890af715c7e94a2/headline.zsh-theme \
         -o /home/node/.oh-my-zsh/themes/headline.zsh-theme \
+    && echo '9719cb7a2ef38b5b04aef3d7b5300e6ef70952c5eda55c5565641d65832715c5  /home/node/.oh-my-zsh/themes/headline.zsh-theme' | sha256sum -c - \
     && sed -i "s/'echo \$USER'/'whoami'/g" /home/node/.oh-my-zsh/themes/headline.zsh-theme \
     && sed -i 's/^ZSH_THEME=.*/ZSH_THEME="headline"/' /home/node/.zshrc
 


### PR DESCRIPTION
## Problem

`.devcontainer/Dockerfile` installed several tools via `curl … | bash`/`sh` from **mutable** refs, and the base image was tag-pinned only:

- `nektos/act` install script fetched from `master`
- Claude Code CLI installed from the moving **`stable`** channel (`claude.ai/install.sh` with no version arg)
- `moarram/headline` zsh theme fetched from `main`
- base image `mcr.microsoft.com/devcontainers/typescript-node:22-bookworm` — tag-pinned, not digest-pinned
- Astral `uv` was already fetched from a version-pinned path, but it wasn't documented as such

This is a **dev-only** image, but it bind-mounts the host `~/.claude` and has `ANTHROPIC_API_KEY` in scope, so unpinned remote code is a supply-chain risk. Follow-up to the security audit (#6).

## Fix

Pin every mutable ref to a specific commit/version, keep what's installed identical, and verify checksums where possible. Changes are confined to `.devcontainer/Dockerfile`.

| Item | Before | After |
|------|--------|-------|
| Base image | `:22-bookworm` (tag) | `:22-bookworm@sha256:59e8c044af4ed4795967188c3d0b9bc677f42d42b0ff41f98c8be5333defeb64` (multi-arch index digest) |
| `act` install script | `nektos/act@master/install.sh` | `nektos/act@4f411281417e88660bea1c1a1749aa71ae0bd60f/install.sh` (commit that `v0.2.89` points to) |
| `act` binary | latest (implicit) | `v0.2.89` passed as tag arg; installer self-verifies the binary's SHA256 against the upstream checksums file |
| Claude Code CLI | `stable` channel (implicit) | `2.1.153` pinned; installer verifies the binary against the per-version `manifest.json` |
| `headline` theme | `moarram/headline@main` | `moarram/headline@eabc85636f4dbf23927d2f2f6890af715c7e94a2`, verified with `sha256sum -c` (`9719cb7a2ef38b5b04aef3d7b5300e6ef70952c5eda55c5565641d65832715c5`) since upstream ships no tags/checksums |
| `uv` | `astral.sh/uv/0.5.11/install.sh` | unchanged — already a version-pinned path; added a clarifying comment |

Behaviour is unchanged: same tools, same versions, same install locations. `act v0.2.89` is the current latest release, `uv 0.5.11` is untouched, `2.1.153` is the current `stable` Claude release, and the pinned-commit `headline.zsh-theme` is byte-identical to the previous `main` fetch (verified by sha256).

## Severity

**Low** — dev-only devcontainer image, not a production/runtime artifact.

## Verification / caveats

- The image was **not** rebuilt here (no Docker build in this environment). It should be rebuilt to confirm the pinned digest pulls and all installers succeed with the version args.
- The `act` and Claude installers self-verify their downloaded **binaries** via SHA256. The headline theme is guarded by an explicit `sha256sum -c`.
- **Could not fully pin two installer *scripts*** because upstream serves them from non-version-addressable URLs:
  - `claude.ai/install.sh` — no commit/tag/versioned path exists; only the *version argument* could be pinned. The script fetch remains a trust anchor (it does, however, verify the binary it downloads).
  - `astral.sh/uv/<ver>/install.sh` — the path is version-scoped (so not a moving branch), but it's a redirector, not a content-addressed ref.
  - In both cases the binary each script installs is checksum-verified by the script itself, so the residual exposure is limited to the bootstrap script content.