### PR TITLE
refactor(ingest): harden offline SQL literal escaping

### DIFF
--- a/packages/ingest/src/base.test.ts
+++ b/packages/ingest/src/base.test.ts
@@ -151,6 +151,15 @@ describe('offline SQL literal hardening', () => {
     expect(() => escapeSqlText(quoteHeavy)).not.toThrow();
   });
 
+  it('drops a trailing lone high surrogate when truncation splits a pair', () => {
+    // 💩 is a surrogate pair (2 code units) placed astride the cap; a code-unit slice would keep
+    // only its high surrogate. Assert the lone surrogate is dropped — no U+FFFD, still well-formed.
+    const literal = escapeSqlText('a'.repeat(MAX_SQL_TEXT_LEN - 1) + '💩');
+    expect(literal).not.toContain('�');
+    expect(/[\uD800-\uDBFF]'$/.test(literal)).toBe(false);
+    expect(() => assertWellFormedSqlLiteral(literal)).not.toThrow();
+  });
+
   it('asserts a well-formed quoted literal and rejects malformed ones', () => {
     expect(() => assertWellFormedSqlLiteral("'ok'")).not.toThrow();
     expect(() => assertWellFormedSqlLiteral("'O''Brien'")).not.toThrow();

--- a/packages/ingest/src/base.test.ts
+++ b/packages/ingest/src/base.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   BASE_CONTRACT_COLS,
   MAX_PLAUSIBLE_VALUE,
+  MAX_SQL_TEXT_LEN,
+  assertWellFormedSqlLiteral,
   baseSqlLiteral,
+  escapeSqlText,
   mapBaseRecord,
   toEventDate,
   toISODate,
@@ -107,5 +110,54 @@ describe('base EOP mapper', () => {
     expect(toPeriodDate('9999-01-01', FIXED_NOW)).toBeNull();
     expect(toPeriodDate('2025-06-01', FIXED_NOW)).toBe('2025-06-01');
     expect(baseSqlLiteral('tenders', 'end_date', '2043-12-31')).toBe("'2043-12-31'");
+  });
+});
+
+describe('offline SQL literal hardening', () => {
+  it('doubles single quotes so injection-shaped input stays a single literal', () => {
+    expect(escapeSqlText("O'Brien")).toBe("'O''Brien'");
+    expect(escapeSqlText("'; DROP TABLE x;--")).toBe("'''; DROP TABLE x;--'");
+    // A literal payload that would close the string then run SQL stays fully quoted.
+    expect(escapeSqlText("x' OR '1'='1")).toBe("'x'' OR ''1''=''1'");
+  });
+
+  it('routes text columns through escapeSqlText via baseSqlLiteral', () => {
+    expect(baseSqlLiteral('contracts', 'contractor_name', "O'Brien")).toBe("'O''Brien'");
+    expect(baseSqlLiteral('contracts', 'procurement_subject', "'; DROP TABLE x;--")).toBe(
+      "'''; DROP TABLE x;--'",
+    );
+  });
+
+  it('strips NUL and every C0/C1 control char while preserving printable Unicode', () => {
+    expect(escapeSqlText('a\x00b')).toBe("'ab'");
+    // One char from each C0 boundary, DEL, and a C1 control — all removed.
+    expect(escapeSqlText('\x01a\x1Fb\x7Fc\x9Fd')).toBe("'abcd'");
+    // Tabs/newlines are C0 controls and are stripped, not preserved.
+    expect(escapeSqlText('line1\n\tline2')).toBe("'line1line2'");
+    // Cyrillic and other printable Unicode pass through untouched.
+    expect(escapeSqlText('Държавна агенция — №42')).toBe("'Държавна агенция — №42'");
+  });
+
+  it('caps absurdly long input at MAX_SQL_TEXT_LEN and stays well-formed', () => {
+    const huge = 'a'.repeat(MAX_SQL_TEXT_LEN + 5000);
+    const literal = escapeSqlText(huge);
+    // Inner length is exactly the cap (no quote escaping needed for plain 'a').
+    expect(literal.length).toBe(MAX_SQL_TEXT_LEN + 2);
+    expect(literal.startsWith("'")).toBe(true);
+    expect(literal.endsWith("'")).toBe(true);
+    // Truncation happens before escaping, so a trailing quote can't be split mid-pair.
+    expect(() => assertWellFormedSqlLiteral(literal)).not.toThrow();
+    const quoteHeavy = "'".repeat(MAX_SQL_TEXT_LEN + 10);
+    expect(() => escapeSqlText(quoteHeavy)).not.toThrow();
+  });
+
+  it('asserts a well-formed quoted literal and rejects malformed ones', () => {
+    expect(() => assertWellFormedSqlLiteral("'ok'")).not.toThrow();
+    expect(() => assertWellFormedSqlLiteral("'O''Brien'")).not.toThrow();
+    expect(() => assertWellFormedSqlLiteral("''")).not.toThrow();
+    expect(() => assertWellFormedSqlLiteral('no-quotes')).toThrow();
+    expect(() => assertWellFormedSqlLiteral("'unterminated")).toThrow();
+    // An odd-run (unescaped) interior single quote must be rejected.
+    expect(() => assertWellFormedSqlLiteral("'a'b'")).toThrow();
   });
 });

--- a/packages/ingest/src/base.ts
+++ b/packages/ingest/src/base.ts
@@ -367,6 +367,57 @@ export function mapBaseRecord(
   return row;
 }
 
+// Hard ceiling on a single text literal's character length. EOP/registry text fields
+// (subjects, descriptions, names) are well under this; anything larger is corrupt or
+// hostile and is truncated rather than passed to sqlite (avoids SQLITE_TOOBIG / abuse of
+// the offline `.sql` files). Chosen well below SQLite's default 1e9-byte string limit.
+export const MAX_SQL_TEXT_LEN = 1_000_000;
+
+// Strip NUL and every C0 (\x00-\x1F) and C1 (\x7F-\x9F) control character. These have no
+// place in a one-line SQL literal and DEL/C1 in particular can corrupt the generated file
+// or confuse downstream tooling. Printable text (incl. all Cyrillic / Unicode) is untouched.
+const SQL_CONTROL_CHARS = /[\x00-\x1F\x7F-\x9F]/g;
+
+/**
+ * Assert that `literal` is a well-formed single-quoted SQL string literal: it starts and
+ * ends with a single quote and contains no unescaped (odd-run) single quote. Throws on
+ * violation so a broken escape can never silently reach sqlite.
+ */
+export function assertWellFormedSqlLiteral(literal: string): void {
+  if (literal.length < 2 || literal[0] !== "'" || literal[literal.length - 1] !== "'") {
+    throw new Error('escapeSqlText produced a literal not delimited by single quotes');
+  }
+  // Inner content must contain only paired single quotes (each `'` doubled as `''`).
+  const inner = literal.slice(1, -1);
+  for (let i = 0; i < inner.length; i += 1) {
+    if (inner[i] !== "'") continue;
+    if (inner[i + 1] !== "'") {
+      throw new Error('escapeSqlText produced a literal with an unescaped single quote');
+    }
+    i += 1; // skip the paired quote
+  }
+}
+
+/**
+ * Build a safely-escaped single-quoted SQL string literal for OFFLINE `.sql` generation
+ * (executed via `wrangler d1 execute --file` / `sqlite3`, never from an HTTP request).
+ *
+ * Hardening invariants:
+ *  - input is truncated to {@link MAX_SQL_TEXT_LEN} characters before escaping;
+ *  - all NUL / C0 / C1 control chars are removed;
+ *  - every single quote is doubled;
+ *  - the result is asserted to be a well-formed quoted literal (delimited by single
+ *    quotes with no unescaped single quote inside) and throws otherwise — a cheap
+ *    invariant that catches future escaping regressions before they reach sqlite.
+ */
+export function escapeSqlText(value: string): string {
+  const truncated = value.length > MAX_SQL_TEXT_LEN ? value.slice(0, MAX_SQL_TEXT_LEN) : value;
+  const escaped = truncated.replace(SQL_CONTROL_CHARS, '').replace(/'/g, "''");
+  const literal = `'${escaped}'`;
+  assertWellFormedSqlLiteral(literal);
+  return literal;
+}
+
 export function baseSqlLiteral(
   cat: BaseCategory,
   column: string,
@@ -377,9 +428,7 @@ export function baseSqlLiteral(
   if (['int', 'real', 'bool', 'secured_inverse', 'variants_enum'].includes(kind)) {
     return String(value);
   }
-  return `'${String(value)
-    .replace(/[\x00-\x1F]/g, '')
-    .replace(/'/g, "''")}'`;
+  return escapeSqlText(String(value));
 }
 
 export const BASE_CONTRACT_COLS = baseInsertColumns('contracts');

--- a/packages/ingest/src/base.ts
+++ b/packages/ingest/src/base.ts
@@ -411,7 +411,14 @@ export function assertWellFormedSqlLiteral(literal: string): void {
  *    invariant that catches future escaping regressions before they reach sqlite.
  */
 export function escapeSqlText(value: string): string {
-  const truncated = value.length > MAX_SQL_TEXT_LEN ? value.slice(0, MAX_SQL_TEXT_LEN) : value;
+  let truncated = value;
+  if (value.length > MAX_SQL_TEXT_LEN) {
+    truncated = value.slice(0, MAX_SQL_TEXT_LEN);
+    // A code-unit slice can split a surrogate pair; drop a trailing lone high surrogate so the cut
+    // text stays well-formed UTF-16 (otherwise the UTF-8 file write silently yields U+FFFD).
+    const last = truncated.charCodeAt(truncated.length - 1);
+    if (last >= 0xd800 && last <= 0xdbff) truncated = truncated.slice(0, -1);
+  }
   const escaped = truncated.replace(SQL_CONTROL_CHARS, '').replace(/'/g, "''");
   const literal = `'${escaped}'`;
   assertWellFormedSqlLiteral(literal);

--- a/scripts/load-eop.mjs
+++ b/scripts/load-eop.mjs
@@ -429,15 +429,17 @@ async function ocdsPackageForDay(day, failures, skips) {
 }
 
 export function deleteSqlForEopSources(table, cat, days) {
-  if (days.length === 1) return `DELETE FROM ${table} WHERE source = 'eop:${cat}:${days[0]}';\n`;
-  const sources = days.map((day) => `'eop:${cat}:${day}'`).join(',\n  ');
+  const lit = (day) => escapeSqlText(`eop:${cat}:${day}`);
+  if (days.length === 1) return `DELETE FROM ${table} WHERE source = ${lit(days[0])};\n`;
+  const sources = days.map(lit).join(',\n  ');
   return `DELETE FROM ${table} WHERE source IN (\n  ${sources}\n);\n`;
 }
 
 function deleteSqlForSources(table, sources) {
-  if (sources.length === 1) return `DELETE FROM ${table} WHERE source = '${sources[0]}';\n`;
+  if (sources.length === 1)
+    return `DELETE FROM ${table} WHERE source = ${escapeSqlText(sources[0])};\n`;
   return `DELETE FROM ${table} WHERE source IN (
-  ${sources.map((source) => `'${source}'`).join(',\n  ')}
+  ${sources.map((source) => escapeSqlText(source)).join(',\n  ')}
 );\n`;
 }
 

--- a/scripts/load-eop.mjs
+++ b/scripts/load-eop.mjs
@@ -22,6 +22,7 @@ import {
   BASE_CATEGORIES,
   baseInsertColumns,
   baseSqlLiteral,
+  escapeSqlText,
   mapBaseRecord,
 } from '../packages/ingest/src/base.ts';
 import {
@@ -90,9 +91,8 @@ function sqlLiteral(col, value) {
     const n = Number(value);
     return Number.isFinite(n) ? String(n) : 'NULL';
   }
-  return `'${String(value)
-    .replace(/[\x00-\x1F]/g, '')
-    .replace(/'/g, "''")}'`;
+  // Shared hardened text escaping: length cap + NUL/C0/C1 stripping + output invariant.
+  return escapeSqlText(String(value));
 }
 
 const fetchedAt = new Date().toISOString().replace('.000Z', 'Z');


### PR DESCRIPTION
## Problem

`baseSqlLiteral` (`packages/ingest/src/base.ts`) and `sqlLiteral` (`scripts/load-eop.mjs`) hand-roll single-quoted SQL string literals from third-party registry data (НАП / Търговски регистър / АОП / OCDS) for **offline** generation of `.sql` files that are later run via `wrangler d1 execute --file` / `sqlite3`. The previous mitigation — double single-quotes + strip `\x00-\x1F` — was brittle: it missed DEL and C1 control characters, had no upper bound on literal size, and had no check that the escape actually produced a valid literal.

This is **not reachable from HTTP requests**: the in-Worker ingest path (`packages/ingest/src/staging.ts`) already uses parameterized `.bind()`. So this is **Low severity / defense-in-depth**, a follow-up from the security-audit PR midt-bg/sigma#6.

## Fix

Introduced a single hardened helper `escapeSqlText(value)` in `base.ts` and routed both call sites through it (the `load-eop.mjs` `sqlLiteral` now imports it, eliminating the duplicate inline regex; its numeric-column handling is unchanged). New invariants:

- **Length cap** — input is truncated to `MAX_SQL_TEXT_LEN` (1,000,000 chars) before escaping, well below SQLite's ~1e9-byte string limit, to avoid `SQLITE_TOOBIG` / abuse via absurdly long fields. Truncation happens *before* quote-doubling, so a `''` pair can never be split mid-sequence.
- **Control-char stripping widened** — `SQL_CONTROL_CHARS = /[\x00-\x1F\x7F-\x9F]/g` now removes NUL, all C0, DEL, **and** C1 controls (the old regex stopped at `\x1F`). Printable Unicode, including Cyrillic, is untouched.
- **Output invariant** — `assertWellFormedSqlLiteral()` verifies the result is delimited by single quotes and contains no unescaped (odd-run) interior quote, throwing otherwise. A cheap guard that catches any future escaping regression before it reaches sqlite.

This stays a focused hardening of the literal helpers — it does **not** convert to parameterized binding, since these emit `.sql` TEXT executed by sqlite3/wrangler, where binding is out of scope.

## Tests

Extended `packages/ingest/src/base.test.ts` with an `offline SQL literal hardening` suite covering:

- single-quote injection shapes — `O'Brien`, `'; DROP TABLE x;--`, `x' OR '1'='1` — staying a single quoted literal;
- `baseSqlLiteral` routing text columns through the helper;
- NUL / C0 / DEL / C1 stripping with printable-Unicode (Cyrillic) preserved, and tabs/newlines removed;
- the length cap producing a well-formed literal, including a quote-heavy input that exercises the truncate-before-escape ordering;
- `assertWellFormedSqlLiteral` accepting valid literals (`'ok'`, `'O''Brien'`, `''`) and rejecting malformed ones (no quotes, unterminated, odd-run interior quote).

The helper logic was additionally verified in isolation outside the suite; all assertions pass.