### PR TITLE
fix(web): prevent scroll reset when toggling authority filters

### DIFF
--- a/apps/web/app/components/FilterRail.tsx
+++ b/apps/web/app/components/FilterRail.tsx
@@ -62,7 +62,7 @@ export function FilterRail({
     for (const key of groupKeys) {
       overrides[key] = data.getAll(key).map(String).filter(Boolean);
     }
-    navigate(withParams(sp, overrides));
+    navigate(withParams(sp, overrides), { preventScrollReset: true });
   };
   const onChange = (e: FormEvent<HTMLFormElement>) => {
     submitForm(e.currentTarget);

--- a/apps/web/app/components/FilterRail.tsx
+++ b/apps/web/app/components/FilterRail.tsx
@@ -201,7 +201,9 @@ export function FilterRail({
           </button>
         </noscript>
         <p className="small muted" style={{ marginTop: 'var(--s-4)' }}>
-          <Link to={clearHref}>Изчисти филтрите</Link>
+          <Link to={clearHref} preventScrollReset>
+            Изчисти филтрите
+          </Link>
           {csvHref && (
             <>
               {' · '}


### PR DESCRIPTION
## Summary

- Clicking a checkbox in the `FilterRail` sidebar called `navigate()` without `preventScrollReset`, causing React Router to scroll the page back to the top on every filter change.
- Fix: pass `{ preventScrollReset: true }` to `navigate()` so the viewport stays in place while filters update.

## Root cause

React Router resets scroll to the top by default on every navigation. The `submitForm()` function built a new search-param URL and called `navigate(url)`, which triggered this reset. Passing `preventScrollReset: true` suppresses it for filter-only navigations.

## Test plan

- [ ] Open `/authorities`, scroll down past the first few results
- [ ] Click any checkbox in the left filter rail — page should remain at the current scroll position
- [ ] Repeat for radio buttons (EU funding filter)
- [ ] Verify filters are still applied correctly after clicking

Fixes #13