### PR TITLE
fix(web): preserve scroll position on sort change

### DIFF
--- a/apps/web/app/components/ListControls.tsx
+++ b/apps/web/app/components/ListControls.tsx
@@ -34,11 +34,11 @@ export function ListControls({
           <span key={s.value}>
             {i > 0 ? ' · ' : ''}
             {s.value === activeSort ? (
-              <Link to={sortHref(base, s.value)} aria-current="true">
+              <Link to={sortHref(base, s.value)} aria-current="true" preventScrollReset>
                 <strong>{s.label}</strong>
               </Link>
             ) : (
-              <Link to={sortHref(base, s.value)}>{s.label}</Link>
+              <Link to={sortHref(base, s.value)} preventScrollReset>{s.label}</Link>
             )}
           </span>
         ))}


### PR DESCRIPTION
## Preserve scroll position on sort change

The `ListControls` sort links navigate via `<Link to={sortHref(...)}>`, which resets scroll to the
top of the page on every sort change. This adds `preventScrollReset` to both the active and inactive
sort links, so changing the sort order keeps the visitor's scroll position — matching the filter
rail, which gained the same behaviour in #15.

- Scope: `apps/web/app/components/ListControls.tsx` only (the two sort `<Link>`s).
- `Pagination.tsx` is intentionally left as-is — resetting scroll to the top on page change is
  conventional and expected.

Follow-up to the filter-rail scroll fix (#15). UX consistency; no behavioural change beyond the
preserved scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
