### PR TITLE
test(db): add unit tests for untested query modules; wire up etl test runner

### DIFF
--- a/apps/etl/package.json
+++ b/apps/etl/package.json
@@ -7,6 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "node ../../scripts/wrangler-render.mjs wrangler.toml && wrangler deploy --config wrangler.deploy.toml",
     "build": "wrangler deploy --dry-run --outdir dist",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/db/src/queries/authorities.test.ts
+++ b/packages/db/src/queries/authorities.test.ts
@@ -18,6 +18,14 @@ const authorityRow = {
   sort_value: 1000000,
 };
 
+// listAuthorities chooses its FROM clause from the active filters (see authorities.ts `needsBase`):
+// the precomputed `authority_totals` rollup for a plain leaderboard, a scoped base aggregation over
+// `contracts` once a sector/year/EU cross-cut is set. There's no real D1 here, so the branch-selection
+// tests pin that choice by matching the table source in the prepared SQL. Naming the two markers keeps
+// the assertions reading as intent rather than raw query text, and localises any future table rename.
+const usesRollup = (sql: string) => sql.includes('FROM authority_totals');
+const usesBaseAggregation = (sql: string) => sql.includes('FROM contracts c');
+
 function fakeDb(): D1Database {
   return {
     prepare(sql: string) {
@@ -42,6 +50,31 @@ function fakeDb(): D1Database {
   } as D1Database;
 }
 
+// A SQL-capturing fake DB for the branch-selection tests: records every prepared statement and returns
+// one authority row regardless of query, so we can assert *which* table source ran. (Deliberately not a
+// wrapper over fakeDb above — its facet branch would hijack the base-aggregation page query, which also
+// contains `type_group` + `GROUP BY`, and feed back a facet-shaped row that toAuthorityListItem can't map.)
+function spyDb(): { db: D1Database; sql: string[] } {
+  const sql: string[] = [];
+  const db = {
+    prepare(q: string) {
+      sql.push(q);
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          return { results: [authorityRow] as T[] };
+        },
+        async first<T>() {
+          return { n: 1 } as T;
+        },
+      };
+    },
+  } as D1Database;
+  return { db, sql };
+}
+
 describe('listAuthorities', () => {
   it('returns a page with items and total for an unfiltered request', async () => {
     const page = await listAuthorities(fakeDb(), { pageSize: 10 });
@@ -59,40 +92,20 @@ describe('listAuthorities', () => {
   });
 
   it('uses the base aggregation source when sector filters are present', async () => {
-    const seenSql: string[] = [];
-    const db = {
-      prepare(sql: string) {
-        seenSql.push(sql);
-        return {
-          bind() { return this; },
-          async all<T>() { return { results: [authorityRow] as T[] }; },
-          async first<T>() { return { n: 1 } as T; },
-        };
-      },
-    } as D1Database;
+    const { db, sql } = spyDb();
 
     await listAuthorities(db, { sectors: ['45'], pageSize: 10 });
 
-    expect(seenSql.some((sql) => sql.includes('FROM contracts c'))).toBe(true);
+    expect(sql.some(usesBaseAggregation)).toBe(true);
   });
 
   it('uses the authority_totals rollup when no cross-cut filters are set', async () => {
-    const seenSql: string[] = [];
-    const db = {
-      prepare(sql: string) {
-        seenSql.push(sql);
-        return {
-          bind() { return this; },
-          async all<T>() { return { results: [authorityRow] as T[] }; },
-          async first<T>() { return { n: 1 } as T; },
-        };
-      },
-    } as D1Database;
+    const { db, sql } = spyDb();
 
     await listAuthorities(db, { pageSize: 10 });
 
-    expect(seenSql.some((sql) => sql.includes('FROM authority_totals'))).toBe(true);
-    expect(seenSql.every((sql) => !sql.includes('FROM contracts c'))).toBe(true);
+    expect(sql.some(usesRollup)).toBe(true);
+    expect(sql.every((s) => !usesBaseAggregation(s))).toBe(true);
   });
 });
 
@@ -123,8 +136,8 @@ describe('getAuthorityFacets', () => {
 
 describe('streamAuthoritiesCsv', () => {
   it('returns a Response with CSV content-type and attachment disposition', () => {
-    const db: D1Database = {
-      prepare() {
+    const db = {
+      prepare(_sql: string) {
         return {
           bind() { return this; },
           async all<T>() { return { results: [] as T[] }; },

--- a/packages/db/src/queries/authorities.test.ts
+++ b/packages/db/src/queries/authorities.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { getAuthorityFacets, listAuthorities, streamAuthoritiesCsv } from './authorities';
+
+const authorityRow = {
+  authority_id: 'auth:000695089',
+  name: 'Министерство на финансите',
+  type_group: 'министерство',
+  settlement: 'София',
+  region: 'Столична',
+  spent_eur: 1000000,
+  contracts: 100,
+  suppliers: 30,
+  avg_eur: 10000,
+  primary_sector: '45',
+  eu_eur: 200000,
+  first_date: '2020-01-01',
+  last_date: '2024-12-31',
+  sort_value: 1000000,
+};
+
+function fakeDb(): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          if (sql.includes('type_group') && sql.includes('GROUP BY')) {
+            return { results: [{ type_group: 'министерство', n: 10 }] as T[] };
+          }
+          if (sql.includes('sector_totals')) {
+            return { results: [{ division: '45', value_eur: 500000 }] as T[] };
+          }
+          return { results: [authorityRow] as T[] };
+        },
+        async first<T>() {
+          return { n: 1 } as T;
+        },
+      };
+    },
+  } as D1Database;
+}
+
+describe('listAuthorities', () => {
+  it('returns a page with items and total for an unfiltered request', async () => {
+    const page = await listAuthorities(fakeDb(), { pageSize: 10 });
+
+    expect(page.items).toHaveLength(1);
+    expect(page.total).toBe(1);
+    expect(page.items[0]!.slug).toBe('000695089');
+    expect(page.items[0]!.spentEur).toBe(1000000);
+  });
+
+  it('falls back to the default sort instead of throwing for an invalid sort key', async () => {
+    await expect(
+      listAuthorities(fakeDb(), { sort: 'invalid' as never, pageSize: 10 }),
+    ).resolves.toBeDefined();
+  });
+
+  it('uses the base aggregation source when sector filters are present', async () => {
+    const seenSql: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        seenSql.push(sql);
+        return {
+          bind() { return this; },
+          async all<T>() { return { results: [authorityRow] as T[] }; },
+          async first<T>() { return { n: 1 } as T; },
+        };
+      },
+    } as D1Database;
+
+    await listAuthorities(db, { sectors: ['45'], pageSize: 10 });
+
+    expect(seenSql.some((sql) => sql.includes('FROM contracts c'))).toBe(true);
+  });
+
+  it('uses the authority_totals rollup when no cross-cut filters are set', async () => {
+    const seenSql: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        seenSql.push(sql);
+        return {
+          bind() { return this; },
+          async all<T>() { return { results: [authorityRow] as T[] }; },
+          async first<T>() { return { n: 1 } as T; },
+        };
+      },
+    } as D1Database;
+
+    await listAuthorities(db, { pageSize: 10 });
+
+    expect(seenSql.some((sql) => sql.includes('FROM authority_totals'))).toBe(true);
+    expect(seenSql.every((sql) => !sql.includes('FROM contracts c'))).toBe(true);
+  });
+});
+
+describe('getAuthorityFacets', () => {
+  it('returns type and sector facets', async () => {
+    const facets = await getAuthorityFacets(fakeDb());
+
+    expect(facets.types).toHaveLength(1);
+    expect(facets.types[0]!.value).toBe('министерство');
+    expect(facets.types[0]!.count).toBe(10);
+  });
+
+  it('only returns sectors that have a non-zero value from sector_totals', async () => {
+    const facets = await getAuthorityFacets(fakeDb());
+
+    expect(facets.sectors.length).toBeGreaterThanOrEqual(1);
+    expect(facets.sectors.every((s) => s.count > 0)).toBe(true);
+  });
+
+  it('includes a valid CPV sector code and label in the sectors facet', async () => {
+    const facets = await getAuthorityFacets(fakeDb());
+    const sector45 = facets.sectors.find((s) => s.value === '45');
+
+    expect(sector45).toBeDefined();
+    expect(typeof sector45?.label).toBe('string');
+  });
+});
+
+describe('streamAuthoritiesCsv', () => {
+  it('returns a Response with CSV content-type and attachment disposition', () => {
+    const db: D1Database = {
+      prepare() {
+        return {
+          bind() { return this; },
+          async all<T>() { return { results: [] as T[] }; },
+        };
+      },
+    } as D1Database;
+
+    const response = streamAuthoritiesCsv(db, {});
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.headers.get('Content-Type')).toContain('text/csv');
+    expect(response.headers.get('Content-Disposition')).toContain('attachment');
+    expect(response.headers.get('Content-Disposition')).toContain('sigma-authorities.csv');
+  });
+});

--- a/packages/db/src/queries/flows.test.ts
+++ b/packages/db/src/queries/flows.test.ts
@@ -48,7 +48,7 @@ describe('getFlows', () => {
     await getFlows(db, {});
 
     expect(seenSql.some((sql) => sql.includes('FROM flow_pairs'))).toBe(true);
-    expect(seenSql.every((sql) => !sql.includes('JOIN contracts c'))).toBe(true);
+    expect(seenSql.every((sql) => !sql.includes('FROM contracts c'))).toBe(true);
   });
 
   it('falls back to a base aggregation when a sector filter is applied', async () => {
@@ -135,10 +135,12 @@ describe('getFlows', () => {
     const data20 = await getFlows(fakeDb(), { top: 20 });
     const data50 = await getFlows(fakeDb(), { top: 50 });
     const dataDefault = await getFlows(fakeDb(), {});
+    const dataOther = await getFlows(fakeDb(), { top: 100 });
 
     expect(data20.scope.top).toBe(20);
     expect(data50.scope.top).toBe(50);
     expect(dataDefault.scope.top).toBe(20);
+    expect(dataOther.scope.top).toBe(20);
   });
 
   it('includes available sectors in the response', async () => {

--- a/packages/db/src/queries/flows.test.ts
+++ b/packages/db/src/queries/flows.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { getFlows } from './flows';
+
+const pairRow = {
+  authority_id: 'auth:000695089',
+  bidder_id: 'eik:103267194',
+  authority_name: 'Министерство на финансите',
+  bidder_name: 'ТЕСТ ООД',
+  bidder_kind: 'company' as const,
+  won_eur: 500000,
+  contracts: 10,
+};
+
+function fakeDb(rows: typeof pairRow[] = [pairRow]): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          if (sql.includes('sector_totals')) {
+            return { results: [{ division: '45' }] as T[] };
+          }
+          return { results: rows as T[] };
+        },
+      };
+    },
+  } as D1Database;
+}
+
+describe('getFlows', () => {
+  it('uses the flow_pairs rollup for an unfiltered request', async () => {
+    const seenSql: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        seenSql.push(sql);
+        return {
+          bind() { return this; },
+          async all<T>() {
+            if (sql.includes('sector_totals')) return { results: [] as T[] };
+            return { results: [pairRow] as T[] };
+          },
+        };
+      },
+    } as D1Database;
+
+    await getFlows(db, {});
+
+    expect(seenSql.some((sql) => sql.includes('FROM flow_pairs'))).toBe(true);
+    expect(seenSql.every((sql) => !sql.includes('JOIN contracts c'))).toBe(true);
+  });
+
+  it('falls back to a base aggregation when a sector filter is applied', async () => {
+    const seenSql: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        seenSql.push(sql);
+        return {
+          bind() { return this; },
+          async all<T>() {
+            if (sql.includes('sector_totals')) return { results: [] as T[] };
+            return { results: [pairRow] as T[] };
+          },
+        };
+      },
+    } as D1Database;
+
+    await getFlows(db, { sector: '45' });
+
+    expect(seenSql.some((sql) => sql.includes('FROM contracts c'))).toBe(true);
+  });
+
+  it('falls back to a base aggregation when a year filter is applied', async () => {
+    const seenSql: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        seenSql.push(sql);
+        return {
+          bind() { return this; },
+          async all<T>() {
+            if (sql.includes('sector_totals')) return { results: [] as T[] };
+            return { results: [pairRow] as T[] };
+          },
+        };
+      },
+    } as D1Database;
+
+    await getFlows(db, { year: '2024' });
+
+    expect(seenSql.some((sql) => sql.includes('substr(c.signed_at, 1, 4) = ?'))).toBe(true);
+  });
+
+  it('returns pairs with rank, slugs, names, and amounts', async () => {
+    const data = await getFlows(fakeDb(), {});
+
+    expect(data.pairs).toHaveLength(1);
+    const pair = data.pairs[0]!;
+    expect(pair.rank).toBe(1);
+    expect(pair.authoritySlug).toBe('000695089');
+    expect(pair.bidderSlug).toBe('103267194');
+    expect(pair.wonEur).toBe(500000);
+    expect(pair.contracts).toBe(10);
+  });
+
+  it('returns a sankey layout with nodes and ribbons', async () => {
+    const data = await getFlows(fakeDb(), {});
+
+    expect(data.sankey.nodes.length).toBeGreaterThan(0);
+    expect(data.sankey.ribbons).toHaveLength(1);
+    expect(typeof data.sankey.viewBox).toBe('string');
+  });
+
+  it('assigns each node a side ("authority" or "company") and a valid href', async () => {
+    const data = await getFlows(fakeDb(), {});
+
+    const authorityNode = data.sankey.nodes.find((n) => n.side === 'authority');
+    const companyNode = data.sankey.nodes.find((n) => n.side === 'company');
+
+    expect(authorityNode).toBeDefined();
+    expect(authorityNode?.href).toMatch(/^\/authorities\//);
+    expect(companyNode).toBeDefined();
+    expect(companyNode?.href).toMatch(/^\/companies\//);
+  });
+
+  it('returns an empty sankey for an empty pair set', async () => {
+    const data = await getFlows(fakeDb([]), {});
+
+    expect(data.pairs).toHaveLength(0);
+    expect(data.sankey.nodes).toHaveLength(0);
+    expect(data.sankey.ribbons).toHaveLength(0);
+  });
+
+  it('clamps the top parameter to 20 or 50', async () => {
+    const data20 = await getFlows(fakeDb(), { top: 20 });
+    const data50 = await getFlows(fakeDb(), { top: 50 });
+    const dataDefault = await getFlows(fakeDb(), {});
+
+    expect(data20.scope.top).toBe(20);
+    expect(data50.scope.top).toBe(50);
+    expect(dataDefault.scope.top).toBe(20);
+  });
+
+  it('includes available sectors in the response', async () => {
+    const data = await getFlows(fakeDb(), {});
+
+    expect(Array.isArray(data.sectors)).toBe(true);
+  });
+});

--- a/packages/db/src/queries/flows.test.ts
+++ b/packages/db/src/queries/flows.test.ts
@@ -11,6 +11,15 @@ const pairRow = {
   contracts: 10,
 };
 
+// getFlows picks its source from the active filters (see flows.ts `topPairs`): the precomputed
+// `flow_pairs` rollup top-N for an unfiltered view, a scoped base aggregation over `contracts` once a
+// sector/year/funding filter is set. There's no real D1 here, so the branch-selection tests pin that
+// choice by matching the table source (and the year predicate) in the prepared SQL. Naming the markers
+// keeps the assertions reading as intent rather than raw query text, and localises any future change.
+const usesFlowPairsRollup = (sql: string) => sql.includes('FROM flow_pairs');
+const usesBaseAggregation = (sql: string) => sql.includes('FROM contracts c');
+const filtersByYear = (sql: string) => sql.includes('substr(c.signed_at, 1, 4) = ?');
+
 function fakeDb(rows: typeof pairRow[] = [pairRow]): D1Database {
   return {
     prepare(sql: string) {
@@ -29,66 +38,51 @@ function fakeDb(rows: typeof pairRow[] = [pairRow]): D1Database {
   } as D1Database;
 }
 
+// SQL-capturing fake DB for the branch-selection tests: records every prepared statement, returns no
+// available sectors and a single flow pair otherwise — enough to assert which source query ran.
+function spyDb(): { db: D1Database; sql: string[] } {
+  const sql: string[] = [];
+  const db = {
+    prepare(q: string) {
+      sql.push(q);
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          if (q.includes('sector_totals')) return { results: [] as T[] };
+          return { results: [pairRow] as T[] };
+        },
+      };
+    },
+  } as D1Database;
+  return { db, sql };
+}
+
 describe('getFlows', () => {
   it('uses the flow_pairs rollup for an unfiltered request', async () => {
-    const seenSql: string[] = [];
-    const db = {
-      prepare(sql: string) {
-        seenSql.push(sql);
-        return {
-          bind() { return this; },
-          async all<T>() {
-            if (sql.includes('sector_totals')) return { results: [] as T[] };
-            return { results: [pairRow] as T[] };
-          },
-        };
-      },
-    } as D1Database;
+    const { db, sql } = spyDb();
 
     await getFlows(db, {});
 
-    expect(seenSql.some((sql) => sql.includes('FROM flow_pairs'))).toBe(true);
-    expect(seenSql.every((sql) => !sql.includes('FROM contracts c'))).toBe(true);
+    expect(sql.some(usesFlowPairsRollup)).toBe(true);
+    expect(sql.every((s) => !usesBaseAggregation(s))).toBe(true);
   });
 
   it('falls back to a base aggregation when a sector filter is applied', async () => {
-    const seenSql: string[] = [];
-    const db = {
-      prepare(sql: string) {
-        seenSql.push(sql);
-        return {
-          bind() { return this; },
-          async all<T>() {
-            if (sql.includes('sector_totals')) return { results: [] as T[] };
-            return { results: [pairRow] as T[] };
-          },
-        };
-      },
-    } as D1Database;
+    const { db, sql } = spyDb();
 
     await getFlows(db, { sector: '45' });
 
-    expect(seenSql.some((sql) => sql.includes('FROM contracts c'))).toBe(true);
+    expect(sql.some(usesBaseAggregation)).toBe(true);
   });
 
   it('falls back to a base aggregation when a year filter is applied', async () => {
-    const seenSql: string[] = [];
-    const db = {
-      prepare(sql: string) {
-        seenSql.push(sql);
-        return {
-          bind() { return this; },
-          async all<T>() {
-            if (sql.includes('sector_totals')) return { results: [] as T[] };
-            return { results: [pairRow] as T[] };
-          },
-        };
-      },
-    } as D1Database;
+    const { db, sql } = spyDb();
 
     await getFlows(db, { year: '2024' });
 
-    expect(seenSql.some((sql) => sql.includes('substr(c.signed_at, 1, 4) = ?'))).toBe(true);
+    expect(sql.some(filtersByYear)).toBe(true);
   });
 
   it('returns pairs with rank, slugs, names, and amounts', async () => {

--- a/packages/db/src/queries/home.test.ts
+++ b/packages/db/src/queries/home.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { getHomeData } from './home';
+
+const authorityRow = {
+  authority_id: 'auth:000695089',
+  name: 'Министерство на финансите',
+  type_group: 'министерство',
+  settlement: 'София',
+  region: 'Столична',
+  spent_eur: 1000000,
+  contracts: 100,
+  suppliers: 30,
+  avg_eur: 10000,
+  primary_sector: '45',
+  eu_eur: 200000,
+  first_date: '2020-01-01',
+  last_date: '2024-12-31',
+};
+
+const companyRow = {
+  bidder_id: 'eik:103267194',
+  name: 'ТЕСТ ООД',
+  kind: 'company',
+  ownership_kind: null,
+  eik: '103267194',
+  eik_valid: 1,
+  settlement: 'София',
+  won_eur: 50000,
+  contracts: 5,
+  authorities: 2,
+  primary_sector: '45',
+  eu_eur: 10000,
+  first_date: '2022-01-01',
+  last_date: '2024-06-01',
+};
+
+const contractRow = {
+  id: 'c:1',
+  subject: 'Тестов договор',
+  unp: 'UNP-1',
+  cpv_code: '45000000',
+  eu_funded: 0,
+  authority_id: 'auth:000695089',
+  authority_name: 'Министерство на финансите',
+  bidder_id: 'eik:103267194',
+  bidder_name: 'ТЕСТ ООД',
+  bidder_kind: 'company',
+  procedure_type: 'Открита процедура',
+  signed_at: '2024-01-01',
+  bids_received: 1,
+  amount_eur: 5000,
+};
+
+const totalsRow = {
+  contracts: 500,
+  value_eur: 1000000,
+  authorities: 50,
+  bidders: 200,
+  suspect: 5,
+  as_of: '2024-06-01',
+  refreshed_at: '2024-06-02T10:00:00Z',
+};
+
+function fakeDb(totals: typeof totalsRow | null): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return this;
+        },
+        async all<T>() {
+          if (sql.includes('company_totals')) return { results: [companyRow] as T[] };
+          if (sql.includes('type_group = \'община\'')) return { results: [authorityRow] as T[] };
+          if (sql.includes('type_group IN')) return { results: [authorityRow] as T[] };
+          // listSingleOfferContracts (two calls: 'recent' by date, 'value' by amount)
+          if (sql.includes('bids_received = 1') && sql.includes('JOIN')) {
+            return { results: [contractRow] as T[] };
+          }
+          return { results: [] as T[] };
+        },
+        async first<T>() {
+          if (sql.includes('home_totals')) return (totals as T) ?? (null as T);
+          // single-offer aggregate
+          if (sql.includes('COALESCE(SUM(amount_eur)')) return { value_eur: 50000, contracts: 1 } as T;
+          return null as T;
+        },
+      };
+    },
+  } as D1Database;
+}
+
+describe('getHomeData', () => {
+  it('returns zero-value fallback totals when home_totals has no row', async () => {
+    const data = await getHomeData(fakeDb(null));
+
+    expect(data.totals.contracts).toBe(0);
+    expect(data.totals.valueEur).toBe(0);
+    expect(data.totals.authorities).toBe(0);
+    expect(data.totals.asOf).toBeNull();
+  });
+
+  it('maps home_totals row to HomeData.totals', async () => {
+    const data = await getHomeData(fakeDb(totalsRow));
+
+    expect(data.totals.contracts).toBe(500);
+    expect(data.totals.valueEur).toBe(1000000);
+    expect(data.totals.asOf).toBe('2024-06-01');
+    expect(data.totals.refreshedAt).toBe('2024-06-02T10:00:00Z');
+  });
+
+  it('includes top companies, ministries, and municipalities', async () => {
+    const data = await getHomeData(fakeDb(totalsRow));
+
+    expect(data.topCompanies).toHaveLength(1);
+    expect(data.topCompanies[0]!.slug).toBe('103267194');
+
+    expect(data.topMinistries).toHaveLength(1);
+    expect(data.topMinistries[0]!.slug).toBe('000695089');
+
+    expect(data.topMunicipalities).toHaveLength(1);
+  });
+
+  it('includes single-offer contract lists', async () => {
+    const data = await getHomeData(fakeDb(totalsRow));
+
+    expect(Array.isArray(data.recentSingleOffer)).toBe(true);
+    expect(Array.isArray(data.topSingleOffer)).toBe(true);
+  });
+
+  it('includes single-offer aggregate stats', async () => {
+    const data = await getHomeData(fakeDb(totalsRow));
+
+    expect(data.singleOffer.contracts).toBe(1);
+    expect(data.singleOffer.valueEur).toBe(50000);
+  });
+});

--- a/packages/db/src/queries/methodology.test.ts
+++ b/packages/db/src/queries/methodology.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { getMethodologyStats } from './methodology';
+
+function fakeDb(opts: {
+  totalsRow?: object | null;
+  coverageRow?: object | null;
+  sectorsRow?: object | null;
+}): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        async first<T>() {
+          if (sql.includes('home_totals')) return (opts.totalsRow ?? null) as T;
+          if (sql.includes('COUNT(bids_received)')) return (opts.coverageRow ?? null) as T;
+          if (sql.includes('sector_totals')) return (opts.sectorsRow ?? null) as T;
+          return null as T;
+        },
+      };
+    },
+  } as D1Database;
+}
+
+describe('getMethodologyStats', () => {
+  it('returns zero-value fallback totals when home_totals is empty', async () => {
+    const db = fakeDb({ totalsRow: null, coverageRow: null, sectorsRow: null });
+    const stats = await getMethodologyStats(db);
+
+    expect(stats.totals.contracts).toBe(0);
+    expect(stats.totals.valueEur).toBe(0);
+    expect(stats.totals.authorities).toBe(0);
+    expect(stats.totals.asOf).toBeNull();
+    expect(stats.coverage.bids).toBe(0);
+    expect(stats.sectors).toBe(0);
+  });
+
+  it('maps home_totals row to the totals shape', async () => {
+    const db = fakeDb({
+      totalsRow: {
+        contracts: 12345,
+        value_eur: 9876543,
+        authorities: 200,
+        bidders: 1500,
+        suspect: 10,
+        first_date: '2018-01-01',
+        last_date: '2024-12-31',
+        as_of: '2024-06-01',
+        refreshed_at: '2024-06-02T10:00:00Z',
+      },
+      coverageRow: null,
+      sectorsRow: null,
+    });
+
+    const stats = await getMethodologyStats(db);
+    expect(stats.totals.contracts).toBe(12345);
+    expect(stats.totals.valueEur).toBe(9876543);
+    expect(stats.totals.asOf).toBe('2024-06-01');
+    expect(stats.firstDate).toBe('2018-01-01');
+    expect(stats.lastDate).toBe('2024-12-31');
+  });
+
+  it('computes field coverage ratios relative to total row count', async () => {
+    const db = fakeDb({
+      totalsRow: {
+        contracts: 100,
+        value_eur: 0,
+        authorities: 0,
+        bidders: 0,
+        suspect: 0,
+        first_date: null,
+        last_date: null,
+        as_of: null,
+        refreshed_at: '',
+      },
+      coverageRow: { total: 100, bids: 80, eu: 50, dur: 60, lot: 20 },
+      sectorsRow: { n: 15 },
+    });
+
+    const stats = await getMethodologyStats(db);
+    expect(stats.coverage.bids).toBeCloseTo(0.8);
+    expect(stats.coverage.eu).toBeCloseTo(0.5);
+    expect(stats.coverage.duration).toBeCloseTo(0.6);
+    expect(stats.coverage.lot).toBeCloseTo(0.2);
+    expect(stats.sectors).toBe(15);
+  });
+
+  it('returns zero ratios when total is 0 (avoids division by zero)', async () => {
+    const db = fakeDb({
+      totalsRow: null,
+      coverageRow: { total: 0, bids: 0, eu: 0, dur: 0, lot: 0 },
+      sectorsRow: { n: 0 },
+    });
+
+    const stats = await getMethodologyStats(db);
+    expect(stats.coverage.bids).toBe(0);
+    expect(stats.coverage.eu).toBe(0);
+  });
+});

--- a/packages/db/src/queries/rows.test.ts
+++ b/packages/db/src/queries/rows.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { toAuthorityListItem, toCompanyListItem, typeLabel } from './rows';
+
+describe('typeLabel', () => {
+  it('returns the display label for a known type group', () => {
+    expect(typeLabel('министерство')).toBe('министерство');
+    expect(typeLabel('община')).toBe('община');
+    expect(typeLabel('държавна компания')).toBe('държ. компания');
+  });
+
+  it('returns the input unchanged for an unknown type group', () => {
+    expect(typeLabel('неизвестен тип')).toBe('неизвестен тип');
+  });
+
+  it('returns null for null input', () => {
+    expect(typeLabel(null)).toBeNull();
+  });
+});
+
+describe('toCompanyListItem', () => {
+  const base = {
+    bidder_id: 'eik:103267194',
+    name: 'ТЕСТ ООД',
+    kind: 'company' as const,
+    ownership_kind: null,
+    eik: '103267194',
+    eik_valid: 1,
+    settlement: 'София',
+    won_eur: 50000,
+    contracts: 5,
+    authorities: 2,
+    primary_sector: '45',
+    eu_eur: 10000,
+    first_date: '2022-01-01',
+    last_date: '2024-06-01',
+  };
+
+  it('maps core fields', () => {
+    const item = toCompanyListItem(base);
+    expect(item.slug).toBe('103267194');
+    expect(item.name).toBe('ТЕСТ ООД');
+    expect(item.kind).toBe('company');
+    expect(item.wonEur).toBe(50000);
+    expect(item.contracts).toBe(5);
+    expect(item.authorities).toBe(2);
+    expect(item.settlement).toBe('София');
+  });
+
+  it('sets hasEik true when eik_valid=1 and eik is set', () => {
+    expect(toCompanyListItem(base).hasEik).toBe(true);
+  });
+
+  it('sets hasEik false when eik_valid=0', () => {
+    expect(toCompanyListItem({ ...base, eik_valid: 0 }).hasEik).toBe(false);
+  });
+
+  it('sets hasEik false when eik is null', () => {
+    expect(toCompanyListItem({ ...base, eik: null }).hasEik).toBe(false);
+  });
+
+  it('sets isConsortium true for consortium kind', () => {
+    expect(toCompanyListItem({ ...base, kind: 'consortium' }).isConsortium).toBe(true);
+  });
+
+  it('sets isConsortium false for company kind', () => {
+    expect(toCompanyListItem(base).isConsortium).toBe(false);
+  });
+
+  it('resolves the sector ref when primary_sector is a valid CPV division', () => {
+    const item = toCompanyListItem(base);
+    expect(item.sector).not.toBeNull();
+    expect(item.sector?.code).toBe('45');
+  });
+
+  it('sets sector to null when primary_sector is null', () => {
+    expect(toCompanyListItem({ ...base, primary_sector: null }).sector).toBeNull();
+  });
+});
+
+describe('toAuthorityListItem', () => {
+  const base = {
+    authority_id: 'auth:000695089',
+    name: 'Министерство на финансите',
+    type_group: 'министерство' as const,
+    settlement: 'София',
+    region: 'Столична',
+    spent_eur: 1000000,
+    contracts: 100,
+    suppliers: 30,
+    avg_eur: 10000,
+    primary_sector: '45',
+    eu_eur: 200000,
+    first_date: '2020-01-01',
+    last_date: '2024-12-31',
+  };
+
+  it('maps core fields', () => {
+    const item = toAuthorityListItem(base);
+    expect(item.slug).toBe('000695089');
+    expect(item.name).toBe('Министерство на финансите');
+    expect(item.typeGroup).toBe('министерство');
+    expect(item.typeLabel).toBe('министерство');
+    expect(item.settlement).toBe('София');
+    expect(item.spentEur).toBe(1000000);
+    expect(item.contracts).toBe(100);
+    expect(item.avgEur).toBe(10000);
+  });
+
+  it('resolves typeLabel for unknown type groups', () => {
+    const item = toAuthorityListItem({ ...base, type_group: 'неизвестен' });
+    expect(item.typeLabel).toBe('неизвестен');
+  });
+
+  it('sets typeLabel to null when type_group is null', () => {
+    const item = toAuthorityListItem({ ...base, type_group: null });
+    expect(item.typeGroup).toBeNull();
+    expect(item.typeLabel).toBeNull();
+  });
+});

--- a/packages/db/src/queries/sectors.test.ts
+++ b/packages/db/src/queries/sectors.test.ts
@@ -26,8 +26,9 @@ describe('sectorRef', () => {
     expect(sectorRef('99')).toBeNull();
   });
 
-  it('short is present and matches label when no short form exists, otherwise is shorter', () => {
+  it('always returns a non-empty short field', () => {
     const ref = sectorRef('45');
-    expect(ref?.short).toBeDefined();
+    expect(typeof ref?.short).toBe('string');
+    expect(ref!.short.length).toBeGreaterThan(0);
   });
 });

--- a/packages/db/src/queries/sectors.test.ts
+++ b/packages/db/src/queries/sectors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { sectorRef } from './sectors';
+
+describe('sectorRef', () => {
+  it('resolves a valid 2-digit CPV division to a SectorRef', () => {
+    const ref = sectorRef('45');
+    expect(ref).not.toBeNull();
+    expect(ref?.code).toBe('45');
+    expect(typeof ref?.label).toBe('string');
+    expect(ref?.label.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for a null input', () => {
+    expect(sectorRef(null)).toBeNull();
+  });
+
+  it('returns null for an undefined input', () => {
+    expect(sectorRef(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(sectorRef('')).toBeNull();
+  });
+
+  it('returns null for an unrecognised division code', () => {
+    expect(sectorRef('99')).toBeNull();
+  });
+
+  it('short is present and matches label when no short form exists, otherwise is shorter', () => {
+    const ref = sectorRef('45');
+    expect(ref?.short).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **`packages/db`** — 6 new test files covering the 6 query modules that had no tests (`rows`, `sectors`, `home`, `methodology`, `authorities`, `flows`). The suite grows from 9 test files to 15, and from ~80 tests to 113 tests.
- **`apps/etl`** — adds the missing `"test": "vitest run"` script to `package.json` so the existing `eop.test.ts` (2 tests) is actually executed; it was silently skipped before.

### What's covered per module

| Module | Tests added | Key behaviours verified |
|--------|-------------|------------------------|
| `rows` | 11 | `typeLabel` known/unknown/null; `toCompanyListItem` field mapping, `hasEik`, `isConsortium`, sector resolution; `toAuthorityListItem` field mapping, null type group |
| `sectors` | 6 | Valid CPV division resolves to `SectorRef`; `null`/`undefined`/empty string/unknown code all return `null` |
| `home` | 5 | Fallback zero totals when table is empty; row mapping; top companies/ministries/municipalities; single-offer list and aggregate |
| `methodology` | 4 | Fallback totals; row mapping with dates; coverage ratios; zero-division guard |
| `authorities` | 8 | Unfiltered page; invalid sort falls back gracefully; sector filter triggers base aggregation; no filter stays on rollup; facet types and sectors; CSV `Response` headers |
| `flows` | 9 | Unfiltered → `flow_pairs` rollup; sector/year filter → base aggregation; pair fields; Sankey nodes/ribbons structure; empty-pair case; `top` clamping; sectors array |

## Test plan

- [x] `pnpm --filter @sigma/db test` — 113 passed, 0 failed
- [x] `pnpm --filter @sigma/etl test` — 2 passed, 0 failed