### PR TITLE
feat(web): link company EIK numbers to the Trade Register

### DIFF
--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -93,7 +93,19 @@ export default function Company({ loaderData }: Route.ComponentProps) {
                   · <Chip>{c.sector.short}</Chip>
                 </>
               )}
-              {c.hasEik && c.eik && <> · ЕИК&nbsp;{c.eik}</>}
+              {c.hasEik && c.eik && (
+                <>
+                  {' · ЕИК '}
+                  <a
+                    href={`https://portal.registryagency.bg/CR/Reports/ActiveConditionTabResult?uic=${c.eik}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mono"
+                  >
+                    {c.eik}
+                  </a>
+                </>
+              )}
             </>
           }
           title={c.displayName}

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -217,7 +217,15 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
               <p className="small muted" style={{ margin: '0 0 8px' }}>
                 {c.bidder.eik ? (
                   <>
-                    ЕИК <span className="mono">{c.bidder.eik}</span>
+                    ЕИК{' '}
+                    <a
+                      href={`https://portal.registryagency.bg/CR/Reports/ActiveConditionTabResult?uic=${c.bidder.eik}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mono"
+                    >
+                      {c.bidder.eik}
+                    </a>
                   </>
                 ) : (
                   'непотвърден ЕИК'
@@ -256,7 +264,15 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                   {c.subcontractor.eik && (
                     <>
                       {' '}
-                      · ЕИК <span className="mono">{c.subcontractor.eik}</span>
+                      · ЕИК{' '}
+                      <a
+                        href={`https://portal.registryagency.bg/CR/Reports/ActiveConditionTabResult?uic=${c.subcontractor.eik}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="mono"
+                      >
+                        {c.subcontractor.eik}
+                      </a>
                     </>
                   )}
                   {c.subcontractor.valueEur != null && <> · {money(c.subcontractor.valueEur)}</>}


### PR DESCRIPTION
## Summary

Implements the suggestion from @Hard-system in [#3](https://github.com/midt-bg/sigma/pull/3): wrap each displayed EIK number with a link to the company's page in the Registry Agency's Trade Register portal (`portal.registryagency.bg`).

Links open in a new tab (`target="_blank" rel="noreferrer"`).

### Affected surfaces

| Page | Location |
|------|----------|
| `/companies/:eik` | EIK in the page header kicker |
| `/contracts/:id` | Bidder EIK in the parties section |
| `/contracts/:id` | Subcontractor EIK in the parties section (when present) |

### URL pattern

```
https://portal.registryagency.bg/CR/Reports/ActiveConditionTabResult?uic=<ЕИК>
```

Only rendered when `hasEik` is true and an EIK value is present — consortium and no-EIK profiles are unaffected.

## Test plan

- [ ] Open a company detail page for a company with a known EIK (e.g. `/companies/104693344`) — EIK in the header should be a clickable link leading to the Registry Agency report
- [ ] Open a contract detail page — bidder EIK should link to the Trade Register
- [ ] Open a contract with a subcontractor that has an EIK — subcontractor EIK should also link
- [ ] Verify links open in a new tab
- [ ] Verify companies without EIK (`без ЕИК` / `непотвърден ЕИК`) are unchanged