### PR TITLE
feat(web): добавяне на връзки към Търговския регистър за ЕИК

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2954,7 +2954,6 @@ tbody td,
     padding-left: 44px;
   }
 }
-
 /* ── Static layout helpers ───────────────────────────────────────────────────
    Small, value-stable rules extracted from former inline `style={…}` attributes
    so the CSP `style-src` no longer needs `'unsafe-inline'` for these. Only the
@@ -3090,4 +3089,16 @@ tbody td,
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+.external-eik-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+  color: inherit;
+  text-decoration: none;
+}
+.external-eik-link svg {
+  opacity: 0.7;
 }

--- a/apps/web/app/components/ui.tsx
+++ b/apps/web/app/components/ui.tsx
@@ -9,43 +9,33 @@ export function Chip({ children }: { children: ReactNode }) {
   return <span className="chip">{children}</span>;
 }
 
+const REGISTRY_URL = 'https://portal.registryagency.bg/CR/bg/Reports/ActiveConditionTabResult';
+
 export function ExternalEikLink({ eik, className }: { eik: string; className?: string }) {
   return (
     <a
-      href={`https://portal.registryagency.bg/CR/bg/Reports/ActiveConditionTabResult?uic=${eik}`}
+      href={`${REGISTRY_URL}?uic=${eik}`}
       target="_blank"
       rel="noopener noreferrer"
-      className={className ? `external-eik-link ${className}` : 'external-eik-link'}
+      className={`external-eik-link${className ? ` ${className}` : ''}`}
+      aria-label={`Отвори ЕИК ${eik} в Търговския регистър`}
       title="Отвори в Търговския регистър"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: '2px',
-        marginLeft: '6px',
-        color: 'inherit',
-        textDecoration: 'none',
-      }}
     >
       <svg
         width="14"
         height="14"
-        viewBox="0 0 16 16"
+        viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.5"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         aria-hidden="true"
-        style={{ opacity: 0.7 }}
       >
-        <path d="M3.5 1.75H9l3.5 3.5v9h-9z" />
-        <path d="M9 1.75V5.25h3.5" />
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        <polyline points="15 3 21 3 21 9" />
+        <line x1="10" y1="14" x2="21" y2="3" />
       </svg>
-      <span
-        className="cta-ext"
-        aria-hidden="true"
-        style={{ fontSize: '10px', opacity: 0.7, transform: 'translateY(-2px)' }}
-      >
-        ↗
-      </span>
     </a>
   );
 }

--- a/apps/web/app/components/ui.tsx
+++ b/apps/web/app/components/ui.tsx
@@ -9,6 +9,47 @@ export function Chip({ children }: { children: ReactNode }) {
   return <span className="chip">{children}</span>;
 }
 
+export function ExternalEikLink({ eik, className }: { eik: string; className?: string }) {
+  return (
+    <a
+      href={`https://portal.registryagency.bg/CR/bg/Reports/ActiveConditionTabResult?uic=${eik}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className ? `external-eik-link ${className}` : 'external-eik-link'}
+      title="Отвори в Търговския регистър"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '2px',
+        marginLeft: '6px',
+        color: 'inherit',
+        textDecoration: 'none',
+      }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        aria-hidden="true"
+        style={{ opacity: 0.7 }}
+      >
+        <path d="M3.5 1.75H9l3.5 3.5v9h-9z" />
+        <path d="M9 1.75V5.25h3.5" />
+      </svg>
+      <span
+        className="cta-ext"
+        aria-hidden="true"
+        style={{ fontSize: '10px', opacity: 0.7, transform: 'translateY(-2px)' }}
+      >
+        ↗
+      </span>
+    </a>
+  );
+}
+
 const OWNERSHIP_LABELS: Record<OwnershipKind, string> = {
   state: 'държавно',
   municipal: 'общинско',

--- a/apps/web/app/components/ui.tsx
+++ b/apps/web/app/components/ui.tsx
@@ -14,7 +14,7 @@ const REGISTRY_URL = 'https://portal.registryagency.bg/CR/bg/Reports/ActiveCondi
 export function ExternalEikLink({ eik, className }: { eik: string; className?: string }) {
   return (
     <a
-      href={`${REGISTRY_URL}?uic=${eik}`}
+      href={`${REGISTRY_URL}?uic=${encodeURIComponent(eik)}`}
       target="_blank"
       rel="noopener noreferrer"
       className={`external-eik-link${className ? ` ${className}` : ''}`}

--- a/apps/web/app/components/ui.tsx
+++ b/apps/web/app/components/ui.tsx
@@ -18,8 +18,8 @@ export function ExternalEikLink({ eik, className }: { eik: string; className?: s
       target="_blank"
       rel="noopener noreferrer"
       className={`external-eik-link${className ? ` ${className}` : ''}`}
-      aria-label={`Отвори ЕИК ${eik} в Търговския регистър`}
-      title="Отвори в Търговския регистър"
+      aria-label={`Отвори ЕИК ${eik} в Търговския регистър (в нов раздел)`}
+      title="Отвори в Търговския регистър (в нов раздел)"
     >
       <svg
         width="14"

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from '../components/PageHeader';
 import { FactsList } from '../components/FactsList';
 import { StackedBar } from '../components/StackedBar';
 import { ContractMiniTable } from '../components/ContractMiniTable';
-import { ShareBar, Chip, OwnershipChip, Section } from '../components/ui';
+import { ShareBar, Chip, OwnershipChip, Section, ExternalEikLink } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
 import { withDbRetry } from '../lib/retry';
@@ -99,7 +99,13 @@ export default function Company({ loaderData }: Route.ComponentProps) {
                   · <Chip>{c.sector.short}</Chip>
                 </>
               )}
-              {c.hasEik && c.eik && <> · ЕИК&nbsp;{c.eik}</>}
+              {c.hasEik && c.eik && (
+                <>
+                  {' '}
+                  · ЕИК&nbsp;{c.eik}
+                  <ExternalEikLink eik={c.eik} />
+                </>
+              )}
             </>
           }
           title={c.displayName}
@@ -306,12 +312,7 @@ export default function Company({ loaderData }: Route.ComponentProps) {
               className="tab-input"
               defaultChecked
             />
-            <input
-              type="radio"
-              name="company-contracts"
-              id="company-top"
-              className="tab-input"
-            />
+            <input type="radio" name="company-contracts" id="company-top" className="tab-input" />
             <div className="tab-labels">
               <label id="tab-company-recent" htmlFor="company-recent">
                 Най-нови

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -101,8 +101,7 @@ export default function Company({ loaderData }: Route.ComponentProps) {
               )}
               {c.hasEik && c.eik && (
                 <>
-                  {' '}
-                  · ЕИК&nbsp;{c.eik}
+                  {' · '}ЕИК&nbsp;{c.eik}
                   <ExternalEikLink eik={c.eik} />
                 </>
               )}

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -258,7 +258,9 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                     <>
                       {' '}
                       · ЕИК <span className="mono">{c.subcontractor.eik}</span>
-                      <ExternalEikLink eik={c.subcontractor.eik} />
+                      {/^\d{9}(\d{4})?$/.test(c.subcontractor.eik) && (
+                        <ExternalEikLink eik={c.subcontractor.eik} />
+                      )}
                     </>
                   )}
                   {c.subcontractor.valueEur != null && <> · {money(c.subcontractor.valueEur)}</>}

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/contract';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
 import { FactsList } from '../components/FactsList';
-import { Chip, Flag, Section } from '../components/ui';
+import { Chip, Flag, Section, ExternalEikLink } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { eopSourceFiles } from '../lib/eopSource';
 import { seoMeta } from '../lib/meta';
@@ -218,6 +218,7 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                 {c.bidder.eik ? (
                   <>
                     ЕИК <span className="mono">{c.bidder.eik}</span>
+                    <ExternalEikLink eik={c.bidder.eik} />
                   </>
                 ) : (
                   'непотвърден ЕИК'
@@ -257,6 +258,7 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                     <>
                       {' '}
                       · ЕИК <span className="mono">{c.subcontractor.eik}</span>
+                      <ExternalEikLink eik={c.subcontractor.eik} />
                     </>
                   )}
                   {c.subcontractor.valueEur != null && <> · {money(c.subcontractor.valueEur)}</>}
@@ -492,7 +494,6 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
               </ul>
             </>
           )}
-
         </Section>
       </main>
     </>


### PR DESCRIPTION
Тъй като в момента Sigma не съдържа данни за действителните собственици на компаниите, разследващите журналисти и гражданите често трябва ръчно да копират ЕИК на дадена фирма и да го търсят в Търговския регистър, за да разберат кой стои зад нея.

Тази промяна добавя малък и удобен бутон (стрелка ↗) до всеки ЕИК в профила на компанията и в страниците на договорите. При кликване, потребителят директно се пренасочва към официалната страница на компанията в ЕПЗЕУ (Търговския регистър) - раздел "Актуално състояние".

Това е изключително полезно предложение, защото:
- Спестява време от ръчно копиране, поставяне и търсене на ЕИК.
- Заобикаля проблемната глобална търсачка на официалния регистър чрез използване на директна връзка (`?uic=`), която отваря директно партидата.
- Веднага преодолява липсата на данни за собственост в Sigma, като предоставя моментален достъп до официалните данни за фирмата с един клик.