### PR TITLE
style(web): move € unit to column headers across all tables

### DIFF
--- a/apps/web/app/components/ContractMiniTable.tsx
+++ b/apps/web/app/components/ContractMiniTable.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { count, date, money } from '@sigma/shared';
+import { count, date, moneyBare } from '@sigma/shared';
 import type { ContractListItem } from '@sigma/api-contract';
 import { Chip } from './ui';
 
@@ -30,7 +30,7 @@ export function ContractMiniTable({
               Оферти
             </th>
             <th scope="col" className="num">
-              Стойност
+              Стойност (€)
             </th>
           </tr>
         </thead>
@@ -58,9 +58,9 @@ export function ContractMiniTable({
               <td className="num-left" data-label="Оферти">
                 {c.bidsReceived != null ? count(c.bidsReceived) : '—'}
               </td>
-              <td className="money" data-label="Стойност">
+              <td className="money" data-label="Стойност (€)">
                 {c.valueEur != null ? (
-                  money(c.valueEur)
+                  moneyBare(c.valueEur)
                 ) : (
                   <span className="suspect">проверяват</span>
                 )}

--- a/apps/web/app/routes/authorities.tsx
+++ b/apps/web/app/routes/authorities.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
-import { count, money } from '@sigma/shared';
+import { count, money, moneyBare } from '@sigma/shared';
 import { getAuthorityFacets, listAuthorities, normalizeAuthoritySort } from '@sigma/db';
 import type { AuthorityListItem } from '@sigma/api-contract';
 import type { Route } from './+types/authorities';
@@ -130,9 +130,9 @@ export default function Authorities({ loaderData }: Route.ComponentProps) {
       secondary: true,
       cell: (a) => (a.typeLabel ? <Chip>{a.typeLabel}</Chip> : null),
     },
-    { key: 'spent', header: 'Похарчено', align: 'money', cell: (a) => money(a.spentEur) },
+    { key: 'spent', header: 'Похарчено (€)', align: 'money', cell: (a) => moneyBare(a.spentEur) },
     { key: 'contracts', header: 'Договори', align: 'money', cell: (a) => count(a.contracts) },
-    { key: 'avg', header: 'Средна стойност', align: 'money', cell: (a) => money(a.avgEur) },
+    { key: 'avg', header: 'Средна стойност (€)', align: 'money', cell: (a) => moneyBare(a.avgEur) },
   ];
 
   return (

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { count, money, pct, periodRange, plural } from '@sigma/shared';
+import { count, money, moneyBare, pct, periodRange, plural } from '@sigma/shared';
 import { authorityIdFromSlug, getAuthority } from '@sigma/db';
 import type { Route } from './+types/authority';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -115,7 +115,7 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
                   <th scope="col">#</th>
                   <th scope="col">Компания</th>
                   <th scope="col" className="num">
-                    Спечелено
+                    Спечелено (€)
                   </th>
                   <th scope="col" className="num">
                     Договори
@@ -138,8 +138,8 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
                         </>
                       )}
                     </td>
-                    <td className="money" data-label="Спечелено">
-                      {money(co.wonEur)}
+                    <td className="money" data-label="Спечелено (€)">
+                      {moneyBare(co.wonEur)}
                     </td>
                     <td className="money" data-label="Договори">
                       {count(co.contracts)}

--- a/apps/web/app/routes/companies.tsx
+++ b/apps/web/app/routes/companies.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
-import { count, money, parseConsortiumMembers } from '@sigma/shared';
+import { count, money, moneyBare, parseConsortiumMembers } from '@sigma/shared';
 import { getCompanyFacets, listCompanies } from '@sigma/db';
 import type { CompanyListItem } from '@sigma/api-contract';
 import type { Route } from './+types/companies';
@@ -163,7 +163,7 @@ export default function Companies({ loaderData }: Route.ComponentProps) {
         </>
       ),
     },
-    { key: 'won', header: 'Спечелено', align: 'money', cell: (c) => money(c.wonEur) },
+    { key: 'won', header: 'Спечелено (€)', align: 'money', cell: (c) => moneyBare(c.wonEur) },
     { key: 'contracts', header: 'Договори', align: 'money', cell: (c) => count(c.contracts) },
     { key: 'authorities', header: 'Институции', align: 'money', cell: (c) => count(c.authorities) },
   ];

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { count, isNaturalPersonProfileName, money, pct, periodRange, plural } from '@sigma/shared';
+import { count, isNaturalPersonProfileName, money, moneyBare, pct, periodRange, plural } from '@sigma/shared';
 import { bidderIdFromSlug, getCompany } from '@sigma/db';
 import type { Route } from './+types/company';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -197,7 +197,7 @@ export default function Company({ loaderData }: Route.ComponentProps) {
                   <th scope="col">#</th>
                   <th scope="col">Институция</th>
                   <th scope="col" className="num">
-                    Платено на компанията
+                    Платено на компанията (€)
                   </th>
                   <th scope="col" className="num">
                     Договори
@@ -214,8 +214,8 @@ export default function Company({ loaderData }: Route.ComponentProps) {
                     <td className="cell-title" data-label="Институция">
                       <Link to={`/authorities/${a.slug}`}>{a.name}</Link>
                     </td>
-                    <td className="money" data-label="Платено">
-                      {money(a.paidEur)}
+                    <td className="money" data-label="Платено (€)">
+                      {moneyBare(a.paidEur)}
                     </td>
                     <td className="money" data-label="Договори">
                       {count(a.contracts)}

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { count, longDate, money, plural, signedPct } from '@sigma/shared';
+import { count, longDate, money, moneyBare, plural, signedPct } from '@sigma/shared';
 import { contractIdFromSlug, getContract } from '@sigma/db';
 import type { ContractDetail } from '@sigma/api-contract';
 import type { Route } from './+types/contract';
@@ -392,10 +392,10 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                     <th scope="col">Участък</th>
                     <th scope="col">Изпълнител</th>
                     <th scope="col" className="num">
-                      Прогнозна
+                      Прогнозна (€)
                     </th>
                     <th scope="col" className="num">
-                      При сключване
+                      При сключване (€)
                     </th>
                   </tr>
                 </thead>
@@ -424,9 +424,11 @@ export default function Contract({ loaderData }: Route.ComponentProps) {
                         )}
                       </td>
                       <td className="money">
-                        {l.estimatedEur != null ? money(l.estimatedEur) : '—'}
+                        {l.estimatedEur != null ? moneyBare(l.estimatedEur) : '—'}
                       </td>
-                      <td className="money">{l.signingEur != null ? money(l.signingEur) : '—'}</td>
+                      <td className="money">
+                        {l.signingEur != null ? moneyBare(l.signingEur) : '—'}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
-import { count, date, money } from '@sigma/shared';
+import { count, date, money, moneyBare } from '@sigma/shared';
 import {
   contractsSummary,
   getContractFacets,
@@ -226,7 +226,7 @@ export default function Contracts({ loaderData }: Route.ComponentProps) {
                         Процедура · Дата
                       </th>
                       <th scope="col" className="num">
-                        Стойност
+                        Стойност (€)
                       </th>
                     </tr>
                   </thead>
@@ -261,9 +261,9 @@ export default function Contracts({ loaderData }: Route.ComponentProps) {
                           <br />
                           {date(c.signedAt)}
                         </td>
-                        <td className="money" data-label="Стойност">
+                        <td className="money" data-label="Стойност (€)">
                           {c.valueEur != null ? (
-                            money(c.valueEur)
+                            moneyBare(c.valueEur)
                           ) : (
                             <span className="suspect">данните се проверяват</span>
                           )}

--- a/apps/web/app/routes/flows.tsx
+++ b/apps/web/app/routes/flows.tsx
@@ -1,5 +1,5 @@
 import { Form, Link, useNavigation, useSearchParams, useSubmit } from 'react-router';
-import { count, money } from '@sigma/shared';
+import { count, moneyBare } from '@sigma/shared';
 import { CPV_SECTORS } from '@sigma/config';
 import { getFlows } from '@sigma/db';
 import type { Route } from './+types/flows';
@@ -193,7 +193,7 @@ export default function Flows({ loaderData }: Route.ComponentProps) {
                     <th scope="col">Институция</th>
                     <th scope="col">Компания</th>
                     <th scope="col" className="num">
-                      Сума
+                      Сума (€)
                     </th>
                     <th scope="col" className="num">
                       Договори
@@ -212,8 +212,8 @@ export default function Flows({ loaderData }: Route.ComponentProps) {
                       <td data-label="Компания">
                         <Link to={`/companies/${p.bidderSlug}`}>{p.bidderDisplayName}</Link>
                       </td>
-                      <td className="money" data-label="Сума">
-                        {money(p.wonEur)}
+                      <td className="money" data-label="Сума (€)">
+                        {moneyBare(p.wonEur)}
                       </td>
                       <td className="money" data-label="Договори">
                         {count(p.contracts)}

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { count, date, money, pct } from '@sigma/shared';
+import { count, date, money, moneyBare, pct } from '@sigma/shared';
 import { getHomeData } from '@sigma/db';
 import type { ContractListItem } from '@sigma/api-contract';
 import type { Route } from './+types/home';
@@ -43,7 +43,7 @@ function SingleOfferTable({ items, allHref }: { items: ContractListItem[]; allHr
               <th scope="col">Договор</th>
               <th scope="col">Възложител · Изпълнител</th>
               <th scope="col" className="num">
-                Стойност
+                Стойност (€)
               </th>
             </tr>
           </thead>
@@ -61,8 +61,8 @@ function SingleOfferTable({ items, allHref }: { items: ContractListItem[]; allHr
                   {' · '}
                   <Link to={`/companies/${c.bidderSlug}`}>{c.bidderDisplayName}</Link>
                 </td>
-                <td className="money" data-label="Стойност">
-                  {c.valueEur != null ? money(c.valueEur) : '—'}
+                <td className="money" data-label="Стойност (€)">
+                  {c.valueEur != null ? moneyBare(c.valueEur) : '—'}
                 </td>
               </tr>
             ))}
@@ -204,7 +204,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                 <th scope="col">#</th>
                 <th scope="col">Компания</th>
                 <th scope="col" className="num">
-                  Спечелено
+                  Спечелено (€)
                 </th>
                 <th scope="col" className="num">
                   Договори
@@ -238,7 +238,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                       )}
                     </span>
                   </td>
-                  <td className="money">{money(c.wonEur)}</td>
+                  <td className="money">{moneyBare(c.wonEur)}</td>
                   <td className="money">{count(c.contracts)}</td>
                   <td className="money">{count(c.authorities)}</td>
                 </tr>

--- a/packages/shared/src/format.test.ts
+++ b/packages/shared/src/format.test.ts
@@ -7,6 +7,7 @@ import {
   isNaturalPersonProfileName,
   longDate,
   money,
+  moneyBare,
   monthYear,
   pct,
   periodRange,
@@ -47,6 +48,23 @@ describe('money', () => {
   });
   it('keeps a sign for negative deltas', () => {
     expect(money(-1500)).toBe(`−2${NBSP}хил.${NBSP}€`);
+  });
+});
+
+describe('moneyBare', () => {
+  it('formats like money() but without the trailing € unit', () => {
+    expect(moneyBare(640)).toBe('640');
+    expect(moneyBare(412_000)).toBe(`412${NBSP}хил.`);
+    expect(moneyBare(187_000_000)).toBe(`187${NBSP}млн.`);
+    expect(moneyBare(4.58e9)).toBe(`4,58${NBSP}млрд.`);
+  });
+  it('returns a dash for absent values', () => {
+    expect(moneyBare(null)).toBe('—');
+    expect(moneyBare(undefined)).toBe('—');
+    expect(moneyBare(NaN)).toBe('—');
+  });
+  it('keeps a sign for negative values', () => {
+    expect(moneyBare(-1500)).toBe(`−2${NBSP}хил.`);
   });
 });
 

--- a/packages/shared/src/format.ts
+++ b/packages/shared/src/format.ts
@@ -33,6 +33,22 @@ function rounded(n: number, dp: number): number {
   return Number(n.toFixed(dp));
 }
 
+function moneyBody(eur: number, withUnit: boolean): string {
+  const v = Math.abs(eur);
+  const roundedEur = Math.round(v);
+  const u = withUnit ? `${NBSP}€` : '';
+  let body: string;
+  if (roundedEur < 1000) body = `${roundedEur}${u}`;
+  else if (Math.round(v / 1e3) < 1000) body = `${Math.round(v / 1e3)}${NBSP}хил.${u}`;
+  else if (rounded(v / 1e6, 1) < 1000) body = `${dec(v / 1e6, 1, true)}${NBSP}млн.${u}`;
+  else {
+    const b = v / 1e9;
+    const useTwoDecimals = rounded(b, 2) < 10;
+    body = `${useTwoDecimals ? dec(b, 2, false) : dec(b, 1, true)}${NBSP}млрд.${u}`;
+  }
+  return body;
+}
+
 /**
  * EUR money in Bulgarian magnitude tiers, e.g. `640 €` · `412 хил. €` · `187 млн. €` · `4,58 млрд. €`.
  * млн. → one decimal (trailing „,0" dropped); млрд. → two decimals under 10, one at/above (so „50,8
@@ -41,17 +57,19 @@ function rounded(n: number, dp: number): number {
  */
 export function money(eur: number | null | undefined): string {
   if (eur == null || !Number.isFinite(eur)) return EM_DASH;
-  const v = Math.abs(eur);
-  const roundedEur = Math.round(v);
-  let body: string;
-  if (roundedEur < 1000) body = `${roundedEur}${NBSP}€`;
-  else if (Math.round(v / 1e3) < 1000) body = `${Math.round(v / 1e3)}${NBSP}хил.${NBSP}€`;
-  else if (rounded(v / 1e6, 1) < 1000) body = `${dec(v / 1e6, 1, true)}${NBSP}млн.${NBSP}€`;
-  else {
-    const b = v / 1e9;
-    const useTwoDecimals = rounded(b, 2) < 10;
-    body = `${useTwoDecimals ? dec(b, 2, false) : dec(b, 1, true)}${NBSP}млрд.${NBSP}€`;
-  }
+  const roundedEur = Math.round(Math.abs(eur));
+  const body = moneyBody(eur, true);
+  return eur < 0 && roundedEur !== 0 ? `${MINUS}${body}` : body;
+}
+
+/**
+ * Like `money()` but without the trailing `€` — for table cells where the column header already
+ * carries `(€)`. E.g. `412 хил.` instead of `412 хил. €`.
+ */
+export function moneyBare(eur: number | null | undefined): string {
+  if (eur == null || !Number.isFinite(eur)) return EM_DASH;
+  const roundedEur = Math.round(Math.abs(eur));
+  const body = moneyBody(eur, false);
   return eur < 0 && roundedEur !== 0 ? `${MINUS}${body}` : body;
 }
 


### PR DESCRIPTION
Closes #30.

## Какво

Символът „€" се изнася от клетките в заглавието на колоната — напр. „Стойност (€)" — а в клетките остава само числото с мащабния суфикс (напр. „412 хил."). Нова функция `moneyBare()` в `@sigma/shared`, която споделя същата логика за мащабиране с `money()`, но пропуска единицата.

## Засегнати таблици

- `/authorities` — колони „Похарчено (€)" и „Средна стойност (€)"
- `/companies` — колона „Спечелено (€)"
- `/contracts` — колона „Стойност (€)"
- Начална страница — таблица „единична оферта" (Стойност €) и класация на компании (Спечелено €)
- `/authorities/:eik` — таблица „Топ изпълнители" (Спечелено €)
- `/companies/:eik` — таблица „Откъде печели" (Платено на компанията €)
- `ContractMiniTable` — колона „Стойност (€)" (използвана на профилните страници)

Останалите употреби на `money()` (речникова методология, отделни числови полета, Sankey потоци, inline prose) остават непроменени — там „€" е нужно за контекст.

## Тестове

- Добавен `describe('moneyBare')` в `packages/shared/src/format.test.ts` — 27 теста, всички зелени.
- `pnpm --filter web typecheck` — чисто.