### PR TITLE
fix(web): fix list-page scroll behaviour at the root (filters, sort, pagination)

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -45,6 +45,16 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   return { ...coverage, origin: url.origin };
 }
 
+// Scroll-restoration key for list pages. Filters and sort live in the query string under a stable
+// pathname, so keying on pathname alone preserves the visitor's scroll position when they change a
+// filter or sort instead of jumping to the top (issue #13). Pagination is the deliberate exception:
+// Prev/Next carry a keyset `cursor` (which a filter or sort change resets), so a URL with a cursor
+// gets its own key and lands at the top — the conventional paging behaviour.
+function scrollKey(location: { pathname: string; search: string }): string {
+  const cursor = new URLSearchParams(location.search).get('cursor');
+  return cursor ? `${location.pathname}?cursor=${cursor}` : location.pathname;
+}
+
 export function Layout({ children }: { children: React.ReactNode }) {
   const nonce = useNonce();
   const rootData = useRouteLoaderData('root') as { origin?: string } | undefined;
@@ -73,7 +83,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         {children}
-        <ScrollRestoration nonce={nonce} getKey={(loc) => loc.pathname} />
+        <ScrollRestoration nonce={nonce} getKey={scrollKey} />
         <Scripts nonce={nonce} />
       </body>
     </html>

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -73,7 +73,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         {children}
-        <ScrollRestoration nonce={nonce} />
+        <ScrollRestoration nonce={nonce} getKey={(loc) => loc.pathname} />
         <Scripts nonce={nonce} />
       </body>
     </html>
@@ -111,14 +111,19 @@ export default function App({ loaderData }: Route.ComponentProps) {
   // After a client-side navigation, move focus to the main region so keyboard and
   // screen-reader users aren't stranded on <body> mid-page (and the skip link stays
   // reachable). Skip the first run so SSR/hydration and the initial load are untouched.
+  // Also skip when only search params changed (filter or sort update within the same
+  // page) — clicking a filter checkbox should not yank the user back to the top.
   const location = useLocation();
   const navigationType = useNavigationType();
   const firstRender = useRef(true);
+  const prevPathname = useRef(location.pathname);
   useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
-      return;
-    }
+    const isFirst = firstRender.current;
+    firstRender.current = false;
+    const prevPath = prevPathname.current;
+    prevPathname.current = location.pathname;
+    if (isFirst) return;
+    if (location.pathname === prevPath) return;
     const frame = window.requestAnimationFrame(() => {
       const el = document.querySelector<HTMLElement>('main h1') ?? document.getElementById('main');
       if (el) {


### PR DESCRIPTION
## Проблем

На списъчните страници (`/contracts`, `/authorities`, `/companies`) скролът се държеше грешно при работа с филтри, подреждане и странициране. Това PR поправя цялото поведение **на едно място** в `root.tsx` и заменя по-точковите #15 и #16.

## Причини и поправки

**1. `ScrollRestoration`, ключуван по целия URL**

По подразбиране позицията се пази по pathname + search, така че промяна само на query параметрите (филтър/подреждане) минтва нов ключ и нулира скрола до `0`.

Поправка: `getKey` ключува по **pathname** — промяна на филтър или подреждане ползва запазената позиция вместо да скача горе.

**2. Странициране (запазено като изключение)**

Чист pathname-ключ би запазвал скрола и при странициране, докато конвенцията е „нова страница → горе" (както нарочно беше оставено в #16). Prev/Next носят keyset `cursor`, който филтър/подреждане нулират — затова вграждаме `cursor` в ключа: URL с курсор получава собствен ключ и каца най-горе, а филтър/подреждане се свеждат до голия pathname-ключ и пазят позицията.

**3. Focus-management ефект при промяна само на query параметрите**

Ефектът в `App` се задействаше при всяка смяна на `location.key` и викаше `el.focus()` върху `<main h1>`, което скролваше заглавието в изгледа. Сега следим предишния `pathname` в ref и излизаме, ако той не се е сменил — фокус-преместването (важно за достъпност) остава при реална смяна на страница, но не и при филтриране/подреждане.

## Промени

- `apps/web/app/root.tsx` — `getKey` за `ScrollRestoration` + guard в focus ефекта.

## Обхват и замяна

Това PR покрива в корена и трите случая — **филтри, подреждане и странициране** — плюс focus-ефекта, който #15 и #16 не достигат. Затова **замества** и затваря:

- #15 (scroll при филтри — на ниво `FilterRail`)
- #16 (scroll при подреждане — на ниво `ListControls`)

Затваря #13.
