### PR TITLE
feat(web): live smart search + slide-in mobile nav

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -307,6 +307,13 @@ code,
   color: var(--ink);
   border-bottom-color: var(--ink);
 }
+/* Drawer chrome — only present once the nav collapses (≤960px). */
+.site-nav-head {
+  display: none;
+}
+.nav-backdrop {
+  display: none;
+}
 
 /* Search icon button — opens the search drawer below the masthead */
 .nav-search {
@@ -397,8 +404,9 @@ code,
   transform: rotate(-45deg);
 }
 
-/* ≤960px — collapse the inline nav into a full-width slide-down drawer.
-   Six mono nav items get tight before this; the menu toggle takes over. */
+/* ≤960px — six mono nav items get tight, so the inline bar gives way to a menu button that opens a
+   right-side drawer over a dimmed backdrop. The slide is a compositor-friendly transform (not the
+   old layout-bound max-height), and `visibility` takes the panel out of the tab order when closed. */
 @media (max-width: 960px) {
   .site-header-inner {
     padding: 18px var(--gutter) 16px;
@@ -406,29 +414,78 @@ code,
   .nav-toggle {
     display: inline-flex;
   }
+
+  .nav-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    background: oklch(20% 0 0 / 0.46);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.28s var(--ease-out, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+  .nav-backdrop.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .site-nav {
-    order: 3;
-    flex-basis: 100%;
+    position: fixed;
+    inset: 0 0 0 auto;
+    z-index: 31;
+    width: min(20rem, 84vw);
     flex-direction: column;
     align-items: stretch;
     gap: 0;
-    margin: 0 calc(-1 * var(--gutter));
-    padding: 0 var(--gutter);
-    max-height: 0;
-    overflow: hidden;
-    opacity: 0;
+    margin: 0;
+    padding: var(--s-4) var(--gutter) var(--s-6);
+    background: var(--paper);
+    border-left: 1px solid var(--rule);
+    box-shadow: -24px 0 60px -40px rgb(0 0 0 / 0.5);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    transform: translateX(100%);
+    visibility: hidden;
     transition:
-      max-height 0.28s ease,
-      opacity 0.2s ease,
-      margin-top 0.28s ease;
+      transform 0.3s var(--ease-out, cubic-bezier(0.16, 1, 0.3, 1)),
+      visibility 0.3s;
   }
   .site-nav.is-open {
-    max-height: 75vh;
-    opacity: 1;
-    margin-top: var(--s-4);
-    overflow-y: auto;
-    border-top: 1px solid var(--rule);
+    transform: translateX(0);
+    visibility: visible;
   }
+
+  .site-nav-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: var(--s-3);
+    margin-bottom: var(--s-2);
+    border-bottom: 1px solid var(--rule);
+  }
+  .site-nav-head-label {
+    font: 500 11px/1 var(--font-mono);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+  .site-nav-close {
+    background: transparent;
+    border: 0;
+    color: var(--ink-mid);
+    font: 400 30px/1 var(--font-serif);
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .site-nav-close:hover {
+    color: var(--accent);
+  }
+  .site-nav-close:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
   .site-nav a {
     display: flex;
     align-items: center;
@@ -449,6 +506,14 @@ code,
   }
 }
 
+/* Honour reduced-motion: the drawer and backdrop snap rather than slide/fade. */
+@media (prefers-reduced-motion: reduce) {
+  .site-nav,
+  .nav-backdrop {
+    transition: none;
+  }
+}
+
 /* Search drawer — drops below masthead on icon click */
 .search-drawer {
   background: var(--paper);
@@ -461,58 +526,22 @@ code,
   display: none;
 }
 .search-drawer.is-open {
-  max-height: 240px;
+  max-height: 320px;
+  /* Once open, let the suggestions listbox escape the drawer box. Overflow stays hidden only while
+     the drawer is collapsing, so the slide animation still clips cleanly. */
+  overflow: visible;
 }
-.search-drawer-form {
+.search-drawer-inner {
   max-width: var(--max);
   margin: 0 auto;
   padding: var(--s-5) var(--gutter);
-  display: grid;
-  grid-template-columns: auto 1fr auto auto;
-  column-gap: var(--s-3);
-  row-gap: var(--s-3);
-  align-items: center;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--s-3);
 }
-.search-drawer-prompt {
-  color: var(--accent);
-  font: 400 24px/1 var(--font-serif);
-  align-self: center;
-  user-select: none;
-}
-.search-drawer-form input {
-  border: 0;
-  border-bottom: 1px solid var(--ink);
-  background: transparent;
-  color: var(--ink);
-  font: 400 20px/1.2 var(--font-serif);
-  letter-spacing: -0.01em;
-  padding: 6px 0 8px;
-  outline: none;
-  width: 100%;
+.search-drawer-inner .smart-search {
+  flex: 1 1 auto;
   min-width: 0;
-}
-.search-drawer-form input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.search-drawer-form input::placeholder {
-  color: var(--ink-soft);
-  font-style: italic;
-}
-.search-drawer-form button[type='submit'] {
-  border: 1px solid var(--ink);
-  background: var(--ink);
-  color: var(--paper);
-  padding: 10px var(--s-5);
-  font: 500 11px/1 var(--font-mono);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  cursor: pointer;
-  white-space: nowrap;
-}
-.search-drawer-form button[type='submit']:hover {
-  background: var(--accent);
-  border-color: var(--accent);
 }
 .search-drawer-close {
   background: transparent;
@@ -530,31 +559,11 @@ code,
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-
 @media (max-width: 760px) {
-  .search-drawer-form {
-    grid-template-columns: auto 1fr auto;
-  }
-  /* Pin every cell so the close button can't fall to a third row: row 1 is
-     `› input ×`, the submit button takes the full second row. Without explicit
-     placement, grid's sparse auto-flow strands the × bottom-left. */
-  .search-drawer-prompt {
-    grid-column: 1;
-    grid-row: 1;
-  }
-  .search-drawer-form input {
-    grid-column: 2;
-    grid-row: 1;
-  }
-  .search-drawer-form .search-drawer-close {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
-  }
-  .search-drawer-form button[type='submit'] {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    width: 100%;
+  /* Keep the × pinned to the top of the row while the submit button wraps below the field. */
+  .search-drawer-close {
+    align-self: flex-start;
+    padding-top: 2px;
   }
 }
 
@@ -1958,49 +1967,57 @@ details.row .body .signal .why {
   }
 }
 
-.hero-search {
+/* ── Smart search combobox ──────────────────────────────────────────────────────────────────────
+   One field powers both the hero and the header drawer. It renders a real GET form to /search
+   (works with JS off), and on hydration shows a live, keyboard-navigable suggestions listbox. */
+.smart-search {
+  position: relative;
+}
+.smart-search--hero {
+  margin: var(--s-6) 0 var(--s-2);
+  max-width: 100%;
+}
+.smart-search-form {
   display: grid;
   grid-template-columns: auto 1fr auto;
   column-gap: var(--s-3);
   row-gap: var(--s-3);
   align-items: end;
-  margin: var(--s-6) 0 var(--s-2);
-  max-width: 100%;
 }
-.hero-search::before {
-  content: '›';
+.smart-search-prompt {
+  grid-column: 1;
   color: var(--accent);
   font: 400 28px/1 var(--font-serif);
   align-self: end;
   margin-bottom: 6px;
-  grid-column: 1 / 2;
+  user-select: none;
 }
-.hero-search input {
-  grid-column: 2 / 3;
+.smart-search-input {
+  grid-column: 2;
+  /* The overflow fix: a search field's intrinsic min-width would otherwise blow out the 1fr track
+     on narrow phones (the old hero field pushed the „Намери" button off-screen). min-width:0 lets
+     the track shrink to the viewport. */
+  min-width: 0;
+  width: 100%;
   border: 0;
   border-bottom: 1px solid var(--ink);
   background: transparent;
   color: var(--ink);
   font: 400 24px/1.2 var(--font-serif);
   letter-spacing: -0.01em;
-  padding: 0 0 4px 0;
+  padding: 0 0 4px;
   outline: none;
-  width: 100%;
-  /* No `margin-left` here: `width: 100%` already fills the grid column, so a left
-     margin pushes the field (and its underline) past the column's right edge —
-     ~8px beyond the full-width „Намери" button below it on mobile. The chevron→
-     field spacing is provided by the grid `column-gap`. */
 }
-.hero-search input:focus-visible {
+.smart-search-input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.hero-search input::placeholder {
+.smart-search-input::placeholder {
   color: var(--ink-soft);
   font-style: italic;
 }
-.hero-search button {
-  grid-column: 3 / 4;
+.smart-search-submit {
+  grid-column: 3;
   margin-left: var(--s-3);
   border: 1px solid var(--ink);
   background: var(--ink);
@@ -2013,26 +2030,127 @@ details.row .body .signal .why {
   white-space: nowrap;
   align-self: end;
 }
-.hero-search button:hover {
+.smart-search-submit:hover {
   background: var(--accent);
   border-color: var(--accent);
 }
+.smart-search--drawer .smart-search-input {
+  font-size: 20px;
+}
+.smart-search--drawer .smart-search-prompt {
+  font-size: 24px;
+}
+
+/* Suggestions popover — anchored below the field, escapes the drawer via z-index. */
+.smart-search-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 40;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+  box-shadow: 0 18px 40px -24px rgb(0 0 0 / 0.45);
+  max-height: min(60vh, 420px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.smart-search-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--s-2) 0;
+}
+.smart-search-group + .smart-search-group {
+  border-top: 1px solid var(--rule-soft);
+}
+.smart-search-group-label {
+  margin: 0;
+  padding: var(--s-3) var(--s-4) var(--s-1);
+  font: 500 10px/1 var(--font-mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.smart-search-group-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.smart-search-option {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 2px var(--s-3);
+  padding: 8px var(--s-4);
+  cursor: pointer;
+}
+.smart-search-option.is-active {
+  background: color-mix(in oklab, var(--accent) 9%, transparent);
+}
+.smart-search-option-kind {
+  grid-column: 1;
+  font: 500 9px/1.3 var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.smart-search-option-body {
+  grid-column: 2;
+  min-width: 0;
+}
+.smart-search-option-title {
+  display: block;
+  color: var(--ink);
+  font: 400 15px/1.3 var(--font-serif);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.smart-search-option-meta {
+  display: block;
+  color: var(--ink-mid);
+  font: 11px/1.3 var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.smart-search-option-amt {
+  grid-column: 3;
+  font: 500 11px/1 var(--font-mono);
+  color: var(--ink-mid);
+  white-space: nowrap;
+}
+.smart-search-see-all {
+  padding: 11px var(--s-4);
+  border-top: 1px solid var(--rule);
+  font: 500 11px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  cursor: pointer;
+}
+.smart-search-see-all.is-active {
+  background: color-mix(in oklab, var(--accent) 9%, transparent);
+}
+.smart-search-empty {
+  padding: var(--s-3) var(--s-4);
+  color: var(--ink-mid);
+  font: italic 14px/1.4 var(--font-serif);
+}
 
 @media (max-width: 760px) {
-  .hero-search {
+  .smart-search-form {
     grid-template-columns: auto 1fr;
   }
-  /* The 24px desktop serif placeholder cannot fit a phone-width field, so it
-     was clipped mid-phrase. Drop to 16px on mobile so the (shortened)
-     placeholder reads in full down to ~360px while keeping the serif look. */
-  .hero-search::before {
+  /* The 24px desktop serif placeholder cannot fit a phone-width field, so the field drops to 16px
+     and the submit button wraps to its own full-width row below. */
+  .smart-search-prompt {
     font-size: 20px;
   }
-  .hero-search input {
-    grid-column: 2 / 3;
+  .smart-search-input {
     font-size: 16px;
   }
-  .hero-search button {
+  .smart-search-submit {
     grid-column: 1 / -1;
     width: 100%;
     margin-left: 0;

--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { Link, NavLink, useSearchParams } from 'react-router';
+import { SmartSearch } from './SmartSearch';
 
 const NAV = [
   { to: '/', label: 'Начало', end: true },
@@ -10,12 +11,10 @@ const NAV = [
   { to: '/methodology', label: 'Методология' },
 ];
 
-const PLACEHOLDER = 'Институция, компания или договор';
-
-// Masthead: serif brand + mono nav + a search drawer that slides below. Ports mocks/v1/assets/site.js
-// (open/close, Esc, click-outside, mobile nav collapse) into React state — no external script, so the
-// strict CSP needs no script allowance beyond the framework nonce. SSR renders both closed; the
-// handlers wire up on hydration.
+// Masthead: serif brand + mono nav. The search icon opens a drawer below the mast; on mobile the
+// nav collapses into a slide-in drawer with a dimmed backdrop. All interaction is React state — no
+// external script — so the strict CSP needs no script allowance beyond the framework nonce. SSR
+// renders everything closed; the handlers wire up on hydration.
 export function SiteHeader() {
   const [searchParams] = useSearchParams();
   // Prefill from the active query so reopening search on a results page shows it.
@@ -28,13 +27,29 @@ export function SiteHeader() {
   const inputRef = useRef<HTMLInputElement>(null);
   const searchToggleRef = useRef<HTMLButtonElement>(null);
   const navToggleRef = useRef<HTMLButtonElement>(null);
+  const navCloseRef = useRef<HTMLButtonElement>(null);
 
-  // Focus the field when the drawer opens.
+  // Focus the field when the search drawer opens.
   useEffect(() => {
     if (searchOpen) inputRef.current?.focus({ preventScroll: true });
   }, [searchOpen]);
 
-  // Esc closes whichever is open (and returns focus to the search toggle).
+  // Move focus into the nav drawer when it opens (keyboard users land on the close control).
+  useEffect(() => {
+    if (navOpen) navCloseRef.current?.focus({ preventScroll: true });
+  }, [navOpen]);
+
+  // Lock body scroll behind the open nav drawer so the dimmed page doesn't scroll under it.
+  useEffect(() => {
+    if (!navOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [navOpen]);
+
+  // Esc closes whichever surface is open (and returns focus to the control that opened it).
   useEffect(() => {
     if (!searchOpen && !navOpen) return;
     const onKey = (e: KeyboardEvent) => {
@@ -72,6 +87,11 @@ export function SiteHeader() {
     return () => mq.removeEventListener('change', onChange);
   }, []);
 
+  const closeNav = () => {
+    setNavOpen(false);
+    navToggleRef.current?.focus();
+  };
+
   return (
     <>
       <header className="site-header" role="banner">
@@ -90,6 +110,18 @@ export function SiteHeader() {
             id={navId}
             aria-label="Главна навигация"
           >
+            <div className="site-nav-head">
+              <span className="site-nav-head-label">Навигация</span>
+              <button
+                ref={navCloseRef}
+                type="button"
+                className="site-nav-close"
+                aria-label="Затвори менюто"
+                onClick={closeNav}
+              >
+                ×
+              </button>
+            </div>
             {NAV.map((item) => (
               <NavLink key={item.to} to={item.to} end={item.end} onClick={() => setNavOpen(false)}>
                 {item.label}
@@ -146,40 +178,26 @@ export function SiteHeader() {
         </div>
       </header>
 
+      {/* Dimmed backdrop behind the mobile nav drawer — pointer convenience; Esc and the × also close. */}
+      <div
+        className={`nav-backdrop${navOpen ? ' is-open' : ''}`}
+        aria-hidden="true"
+        onClick={closeNav}
+      />
+
       <div
         ref={drawerRef}
         className={`search-drawer${searchOpen ? ' is-open' : ''}`}
         id={drawerId}
         inert={!searchOpen}
       >
-        <form
-          className="search-drawer-form"
-          role="search"
-          aria-label="Търсене в сайта"
-          action="/search"
-          method="get"
-          onSubmit={(e) => {
-            // An empty/whitespace query shouldn't navigate to /search?q= (which then claims matches).
-            if (!inputRef.current?.value.trim()) {
-              e.preventDefault();
-              inputRef.current?.focus();
-            }
-          }}
-        >
-          <span className="search-drawer-prompt" aria-hidden="true">
-            ›
-          </span>
-          <input
-            key={activeQuery}
-            ref={inputRef}
-            type="search"
-            name="q"
+        <div className="search-drawer-inner">
+          <SmartSearch
+            variant="drawer"
             defaultValue={activeQuery}
-            placeholder={PLACEHOLDER}
-            aria-label="Търсене"
-            autoComplete="off"
+            inputRef={inputRef}
+            onNavigate={() => setSearchOpen(false)}
           />
-          <button type="submit">Намери</button>
           <button
             type="button"
             className="search-drawer-close"
@@ -191,7 +209,7 @@ export function SiteHeader() {
           >
             ×
           </button>
-        </form>
+        </div>
       </div>
     </>
   );

--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -101,6 +101,7 @@ export function SiteHeader() {
             to="/"
             aria-label="СИГМА — начална страница"
             title="Система за интегриран граждански мониторинг и анализ на обществените поръчки"
+            inert={navOpen}
           >
             <img className="brand-logo" src="/logo.svg" width={523} height={115} alt="СИГМА" />
             <span className="brand-sub">Платформа за прозрачност на обществените поръчки</span>
@@ -128,7 +129,7 @@ export function SiteHeader() {
               </NavLink>
             ))}
           </nav>
-          <div className="site-actions">
+          <div className="site-actions" inert={navOpen}>
             <button
               ref={searchToggleRef}
               className="nav-search"
@@ -189,7 +190,7 @@ export function SiteHeader() {
         ref={drawerRef}
         className={`search-drawer${searchOpen ? ' is-open' : ''}`}
         id={drawerId}
-        inert={!searchOpen}
+        inert={!searchOpen || navOpen}
       >
         <div className="search-drawer-inner">
           <SmartSearch

--- a/apps/web/app/components/SmartSearch.tsx
+++ b/apps/web/app/components/SmartSearch.tsx
@@ -49,6 +49,11 @@ export function SmartSearch({
   const inputRef = externalInputRef ?? localInputRef;
   const rootRef = useRef<HTMLDivElement>(null);
 
+  // Keep the field in sync when the caller navigates between results pages and reopens the drawer.
+  useEffect(() => {
+    setQuery(defaultValue);
+  }, [defaultValue]);
+
   const listboxId = useId();
   const optionId = (i: number) => `${listboxId}-opt-${i}`;
 

--- a/apps/web/app/components/SmartSearch.tsx
+++ b/apps/web/app/components/SmartSearch.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import { useFetcher, useNavigate } from 'react-router';
+import { money } from '@sigma/shared';
+import type { SearchHit } from '@sigma/api-contract';
+import type { loader as suggestLoader } from '../routes/search.suggest';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+
+const KIND_LABEL: Record<SearchHit['kind'], string> = {
+  authority: 'институция',
+  company: 'компания',
+  contract: 'договор',
+};
+
+// Below this length we don't query — single letters match almost everything and just add noise.
+const MIN_QUERY = 2;
+const DEBOUNCE_MS = 150;
+
+interface SmartSearchProps {
+  variant: 'hero' | 'drawer';
+  defaultValue?: string;
+  placeholder?: string;
+  inputLabel?: string;
+  submitLabel?: string;
+  // Drawer wants to close itself once a suggestion navigates away.
+  onNavigate?: () => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+}
+
+// Accessible search combobox (WAI-ARIA combobox + listbox). Progressive enhancement: it renders a
+// real GET form to /search, so with JS off (or before hydration) it submits exactly like the old
+// static field. With JS, typing fetches ranked suggestions from /search/suggest and lets the user
+// jump straight to an institution, company or contract — keyboard or pointer.
+export function SmartSearch({
+  variant,
+  defaultValue = '',
+  placeholder = 'Институция, компания или договор',
+  inputLabel = 'Търсене',
+  submitLabel = 'Намери',
+  onNavigate,
+  inputRef: externalInputRef,
+}: SmartSearchProps) {
+  const navigate = useNavigate();
+  const fetcher = useFetcher<typeof suggestLoader>();
+  const [query, setQuery] = useState(defaultValue);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const localInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef ?? localInputRef;
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const listboxId = useId();
+  const optionId = (i: number) => `${listboxId}-opt-${i}`;
+
+  const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+
+  // Fetch suggestions when the settled query is long enough; clear out below the threshold.
+  useEffect(() => {
+    if (debounced.length < MIN_QUERY) return;
+    fetcher.load(`/search/suggest?q=${encodeURIComponent(debounced)}`);
+    // fetcher identity is stable across renders; depending on it would re-fire needlessly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debounced]);
+
+  const results = debounced.length >= MIN_QUERY ? fetcher.data : undefined;
+  const groups = results?.groups.filter((g) => g.hits.length > 0) ?? [];
+  const flatHits = groups.flatMap((g) => g.hits);
+  const hasResults = flatHits.length > 0;
+  // Trailing "see all" row is index === flatHits.length.
+  const seeAllIndex = hasResults ? flatHits.length : -1;
+  const optionCount = flatHits.length + (hasResults ? 1 : 0);
+
+  const showList = open && debounced.length >= MIN_QUERY;
+  const loading = fetcher.state === 'loading';
+
+  // Any change to the option set invalidates the highlighted row.
+  useEffect(() => setActiveIndex(-1), [debounced, fetcher.data]);
+
+  // Pointer-dismiss: closing on outside mousedown keeps it from fighting option clicks.
+  useEffect(() => {
+    if (!showList) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [showList]);
+
+  function goTo(href: string) {
+    setOpen(false);
+    onNavigate?.();
+    navigate(href);
+  }
+
+  function selectIndex(i: number) {
+    if (i === seeAllIndex) {
+      goTo(`/search?q=${encodeURIComponent(query.trim())}`);
+    } else if (i >= 0 && i < flatHits.length) {
+      goTo(flatHits[i].href);
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      if (showList) {
+        e.preventDefault();
+        // Swallow it so a surrounding drawer's Esc handler doesn't also fire: first Esc closes the
+        // suggestions, a second Esc closes the drawer.
+        e.stopPropagation();
+        setOpen(false);
+      }
+      return;
+    }
+    if (!showList || optionCount === 0) return;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % optionCount);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i <= 0 ? optionCount - 1 : i - 1));
+        break;
+      case 'Enter':
+        // Only intercept when a row is highlighted; otherwise let the form submit to /search.
+        if (activeIndex >= 0) {
+          e.preventDefault();
+          selectIndex(activeIndex);
+        }
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(optionCount - 1);
+        break;
+    }
+  }
+
+  // Flat option index as we walk groups in render order, so keyboard and DOM agree.
+  let runningIndex = -1;
+
+  return (
+    <div className={`smart-search smart-search--${variant}`} ref={rootRef}>
+      <form
+        className="smart-search-form"
+        role="search"
+        action="/search"
+        method="get"
+        onSubmit={(e) => {
+          if (!query.trim()) {
+            e.preventDefault();
+            inputRef.current?.focus();
+          }
+        }}
+      >
+        <span className="smart-search-prompt" aria-hidden="true">
+          ›
+        </span>
+        <input
+          ref={inputRef}
+          type="search"
+          name="q"
+          className="smart-search-input"
+          value={query}
+          placeholder={placeholder}
+          aria-label={inputLabel}
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={showList}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeIndex >= 0 ? optionId(activeIndex) : undefined}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+        />
+        <button type="submit" className="smart-search-submit">
+          {submitLabel}
+        </button>
+      </form>
+
+      <div
+        className={`smart-search-pop${showList ? ' is-open' : ''}`}
+        // Hidden from AT until there's something to announce; inert when closed.
+        hidden={!showList}
+      >
+        <ul className="smart-search-list" id={listboxId} role="listbox" aria-label="Предложения">
+          {groups.map((g) => (
+            <li key={g.kind} role="group" aria-label={g.label} className="smart-search-group">
+              <p className="smart-search-group-label" aria-hidden="true">
+                {g.label}
+              </p>
+              <ul className="smart-search-group-list" role="presentation">
+                {g.hits.map((hit) => {
+                  runningIndex += 1;
+                  const i = runningIndex;
+                  const meta = hit.ident || hit.subtitle;
+                  return (
+                    <li
+                      key={hit.slug + hit.title}
+                      id={optionId(i)}
+                      role="option"
+                      aria-selected={activeIndex === i}
+                      className={`smart-search-option${activeIndex === i ? ' is-active' : ''}`}
+                      onMouseEnter={() => setActiveIndex(i)}
+                      // Keep input focused so the click lands before blur closes the list.
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => selectIndex(i)}
+                    >
+                      <span className="smart-search-option-kind">{KIND_LABEL[hit.kind]}</span>
+                      <span className="smart-search-option-body">
+                        <span className="smart-search-option-title">{hit.title}</span>
+                        {meta && <span className="smart-search-option-meta">{meta}</span>}
+                      </span>
+                      {hit.amountEur != null && (
+                        <span className="smart-search-option-amt">{money(hit.amountEur)}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          ))}
+
+          {hasResults && (
+            <li
+              id={optionId(seeAllIndex)}
+              role="option"
+              aria-selected={activeIndex === seeAllIndex}
+              className={`smart-search-see-all${activeIndex === seeAllIndex ? ' is-active' : ''}`}
+              onMouseEnter={() => setActiveIndex(seeAllIndex)}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => selectIndex(seeAllIndex)}
+            >
+              Всички резултати за „{query.trim()}" →
+            </li>
+          )}
+
+          {!hasResults && !loading && (
+            <li className="smart-search-empty" role="presentation">
+              Няма съвпадения. Пробвай с име, ЕИК или УНП.
+            </li>
+          )}
+          {!hasResults && loading && (
+            <li className="smart-search-empty" role="presentation" aria-live="polite">
+              Търсене…
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hooks/useDebouncedValue.ts
+++ b/apps/web/app/hooks/useDebouncedValue.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+// Returns a copy of `value` that only updates after it has stayed unchanged for `delay` ms. Used to
+// throttle live-search requests: the input updates synchronously for the user, but the fetch keyed
+// off the debounced value only fires once typing settles.
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -3,6 +3,7 @@ import { type RouteConfig, index, route } from '@react-router/dev/routes';
 export default [
   index('routes/home.tsx'),
   route('search', 'routes/search.tsx'),
+  route('search/suggest', 'routes/search.suggest.tsx'),
   route('flows', 'routes/flows.tsx'),
   route('companies', 'routes/companies.tsx'),
   route('companies.csv', 'routes/companies.csv.tsx'),

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -4,6 +4,7 @@ import { getHomeData } from '@sigma/db';
 import type { ContractListItem } from '@sigma/api-contract';
 import type { Route } from './+types/home';
 import { PageHeader } from '../components/PageHeader';
+import { SmartSearch } from '../components/SmartSearch';
 import { TotalsStrip } from '../components/TotalsStrip';
 import { RankedBars } from '../components/RankedBars';
 import { OwnershipChip } from '../components/ui';
@@ -90,7 +91,9 @@ function SingleOfferPortion({ valueEur, totalEur }: { valueEur: number; totalEur
       </p>
       <div className="hbar" aria-hidden="true">
         <span style={{ width: `${(ratio * 100).toFixed(1)}%`, background: 'var(--accent)' }} />
-        <span style={{ width: `${((1 - ratio) * 100).toFixed(1)}%`, background: 'var(--ink-soft)' }} />
+        <span
+          style={{ width: `${((1 - ratio) * 100).toFixed(1)}%`, background: 'var(--ink-soft)' }}
+        />
       </div>
       <p className="small muted so-portion-cap">
         {money(valueEur)} от {money(totalEur)}
@@ -123,20 +126,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           }
           lede="СИГМА показва как държавните институции и общините харчат парите на данъкоплатците чрез обществени поръчки във всички сектори. Без регистрация, без тълкуване. Зад всяко число стои конкретен договор — можеш да го отвориш."
         >
-          <form
-            className="hero-search"
-            role="search"
-            aria-label="Търсене на началната страница"
-            action="/search"
-          >
-            <input
-              type="search"
-              name="q"
-              placeholder="Институция, компания или договор"
-              aria-label="Търсене"
-            />
-            <button type="submit">Намери</button>
-          </form>
+          <SmartSearch variant="hero" />
         </PageHeader>
         <img
           className="hero-mark"

--- a/apps/web/app/routes/search.suggest.test.ts
+++ b/apps/web/app/routes/search.suggest.test.ts
@@ -6,6 +6,8 @@ function makeGroup(count: number): SearchGroup {
   return {
     kind: 'authority',
     label: 'Институции',
+    total: count,
+    moreHref: null,
     hits: Array.from({ length: count }, (_, i) => ({
       kind: 'authority' as const,
       slug: `slug-${i}`,
@@ -14,6 +16,7 @@ function makeGroup(count: number): SearchGroup {
       subtitle: null,
       ident: null,
       amountEur: null,
+      amountLabel: '',
     })),
   };
 }

--- a/apps/web/app/routes/search.suggest.test.ts
+++ b/apps/web/app/routes/search.suggest.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { trimGroup } from './search.suggest';
+import type { SearchGroup } from '@sigma/api-contract';
+
+function makeGroup(count: number): SearchGroup {
+  return {
+    kind: 'authority',
+    label: 'Институции',
+    hits: Array.from({ length: count }, (_, i) => ({
+      kind: 'authority' as const,
+      slug: `slug-${i}`,
+      title: `Institution ${i}`,
+      href: `/authorities/slug-${i}`,
+      subtitle: null,
+      ident: null,
+      amountEur: null,
+    })),
+  };
+}
+
+describe('trimGroup', () => {
+  it('returns the group unchanged when hits are within the limit', () => {
+    const group = makeGroup(3);
+    expect(trimGroup(group)).toBe(group);
+  });
+
+  it('returns the group unchanged when hits are exactly at the limit', () => {
+    const group = makeGroup(4);
+    expect(trimGroup(group)).toBe(group);
+  });
+
+  it('trims hits to 4 when the group exceeds the limit', () => {
+    const group = makeGroup(7);
+    const trimmed = trimGroup(group);
+    expect(trimmed.hits).toHaveLength(4);
+  });
+
+  it('returns a new object instead of mutating the original', () => {
+    const group = makeGroup(6);
+    const trimmed = trimGroup(group);
+    expect(trimmed).not.toBe(group);
+    expect(group.hits).toHaveLength(6);
+  });
+
+  it('preserves the first hits in order', () => {
+    const group = makeGroup(6);
+    const trimmed = trimGroup(group);
+    expect(trimmed.hits[0].slug).toBe('slug-0');
+    expect(trimmed.hits[3].slug).toBe('slug-3');
+  });
+});

--- a/apps/web/app/routes/search.suggest.tsx
+++ b/apps/web/app/routes/search.suggest.tsx
@@ -1,0 +1,27 @@
+import { search } from '@sigma/db';
+import type { SearchGroup, SearchResults } from '@sigma/api-contract';
+import type { Route } from './+types/search.suggest';
+import { publicCache } from '../lib/cache';
+
+// How many hits per kind a suggestion dropdown shows. The full `/search` page keeps the wider set;
+// the typeahead stays compact so the listbox never dwarfs the field that opened it.
+const SUGGEST_PER_GROUP = 4;
+
+function trimGroup(group: SearchGroup): SearchGroup {
+  if (group.hits.length <= SUGGEST_PER_GROUP) return group;
+  return { ...group, hits: group.hits.slice(0, SUGGEST_PER_GROUP) };
+}
+
+// Resource route powering the live search combobox (/search/suggest?q=…). Reuses the same ranked
+// FTS query as the full results page, so suggestions and the eventual page agree. JSON only — the
+// listbox is rendered client-side from this payload; with JS off the form still posts to /search.
+export async function loader({ request, context }: Route.LoaderArgs): Promise<SearchResults> {
+  const q = new URL(request.url).searchParams.get('q') ?? '';
+  const results = await search(context.cloudflare.env.DB, q);
+  return { ...results, groups: results.groups.map(trimGroup) };
+}
+
+export function headers() {
+  // Short edge cache: queries repeat heavily as people type the same prefixes.
+  return { 'Cache-Control': publicCache(120) };
+}

--- a/apps/web/app/routes/search.suggest.tsx
+++ b/apps/web/app/routes/search.suggest.tsx
@@ -1,3 +1,4 @@
+import { data } from 'react-router';
 import { search } from '@sigma/db';
 import type { SearchGroup, SearchResults } from '@sigma/api-contract';
 import type { Route } from './+types/search.suggest';
@@ -7,7 +8,7 @@ import { publicCache } from '../lib/cache';
 // the typeahead stays compact so the listbox never dwarfs the field that opened it.
 const SUGGEST_PER_GROUP = 4;
 
-function trimGroup(group: SearchGroup): SearchGroup {
+export function trimGroup(group: SearchGroup): SearchGroup {
   if (group.hits.length <= SUGGEST_PER_GROUP) return group;
   return { ...group, hits: group.hits.slice(0, SUGGEST_PER_GROUP) };
 }
@@ -15,13 +16,15 @@ function trimGroup(group: SearchGroup): SearchGroup {
 // Resource route powering the live search combobox (/search/suggest?q=…). Reuses the same ranked
 // FTS query as the full results page, so suggestions and the eventual page agree. JSON only — the
 // listbox is rendered client-side from this payload; with JS off the form still posts to /search.
-export async function loader({ request, context }: Route.LoaderArgs): Promise<SearchResults> {
+export async function loader({ request, context }: Route.LoaderArgs) {
   const q = new URL(request.url).searchParams.get('q') ?? '';
   const results = await search(context.cloudflare.env.DB, q);
-  return { ...results, groups: results.groups.map(trimGroup) };
-}
-
-export function headers() {
-  // Short edge cache: queries repeat heavily as people type the same prefixes.
-  return { 'Cache-Control': publicCache(120) };
+  const payload: SearchResults = { ...results, groups: results.groups.map(trimGroup) };
+  return data(payload, {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      // Short edge cache: queries repeat heavily as people type the same prefixes.
+      'Cache-Control': publicCache(120),
+    },
+  });
 }


### PR DESCRIPTION
## What's in this PR

Three interlocking improvements to the landing page and header that together make the site feel significantly more polished on mobile and more useful on every screen size.

### 🔎 Smart search (live suggestions as you type)
- New `/search/suggest` resource route reusing the existing ranked FTS5 query — no new infrastructure, fully CSP-safe (`connect-src 'self'` unchanged)
- Shared `SmartSearch` combobox component used in both the hero and the header search drawer — single source of truth for the ARIA pattern
- Full WAI-ARIA combobox + listbox (keyboard nav: ↑↓ cycle, Enter navigate, Escape close suggestions, second Escape closes drawer)
- Grouped results: institutions · companies · contracts, each capped at 4 hits, with a "see all" trailing row
- 150 ms debounce via a small `useDebouncedValue` hook — no extra library
- Progressive enhancement: renders a real `<form method="get" action="/search">` so it works before hydration
- `publicCache(120)` edge cache on the suggest route

### 📱 Overflow fix — hero "Намери" button
- Root cause: grid item without `min-width: 0` prevented the `1fr` column from shrinking, so the button pushed past the viewport
- Fix: `min-width: 0` on `.smart-search-input` — one line, no layout regressions

### 🍔 Mobile nav — slide-in drawer
- Replaced the cramped `max-height` slide-down with a `translateX` slide-in panel + dimmed backdrop
- Body scroll locked behind the open drawer
- Focus management: opens → focus lands on the × close button; closes → focus returns to the hamburger toggle
- `prefers-reduced-motion` respected: transitions disabled when the user opts out
- Esc closes whichever surface is open; first Esc on the search suggestions closes the dropdown, second Esc closes the drawer (via `stopPropagation`)

### ♿ Search icon semantics audit
Already compliant — `aria-label="Търсене"`, `aria-expanded`, `aria-controls`, SVG with `aria-hidden="true" focusable="false"`. No changes needed.

---

## Files changed
| File | Change |
|------|--------|
| `apps/web/app/routes/search.suggest.tsx` | **new** — suggest resource route |
| `apps/web/app/hooks/useDebouncedValue.ts` | **new** — 150 ms debounce hook |
| `apps/web/app/components/SmartSearch.tsx` | **new** — accessible combobox |
| `apps/web/app/routes.ts` | registered `/search/suggest` |
| `apps/web/app/routes/home.tsx` | replaced static hero form with `<SmartSearch variant="hero" />` |
| `apps/web/app/components/SiteHeader.tsx` | new nav drawer, `SmartSearch` in search drawer |
| `apps/web/app/app.css` | overflow fix, smart search styles, slide-in nav styles |

## Test plan
- [ ] Type `мин` in the hero search → grouped suggestions appear within ~200 ms
- [ ] Arrow keys cycle through options; Enter navigates to the selected result
- [ ] Escape closes suggestions; second Escape closes the search drawer
- [ ] On 375 px viewport: "Намери" button no longer overflows; no horizontal scroll
- [ ] Mobile menu (≤ 960 px): tap hamburger → drawer slides in from right with backdrop; × and Esc close it; focus returns to hamburger
- [ ] With `prefers-reduced-motion: reduce`: nav opens/closes instantly (no transition)
- [ ] JS disabled: hero form submits to `/search?q=…` as a plain GET
- [ ] `pnpm typecheck` exits 0; `pnpm build` green; 58 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)