### PR TITLE
build(deps): pin undici ^7.28.0 to clear the audit advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ws: ^8.21.0
   vite@7: ^7.3.5
   vite@8: ^8.0.16
+  undici: ^7.28.0
 
 importers:
 
@@ -1552,8 +1553,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2751,7 +2752,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260520.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -2953,7 +2954,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,9 @@ overrides:
   #   vite        — server.fs.deny bypass (GHSA-fx2h-pf6j-xcff): v7 via @react-router/dev→
   #                 vite-node, v8 via apps/web + vitest. Patched per-major to avoid forcing
   #                 vite-node (which needs v7) onto v8.
-  #   undici <7.28.0 — DoS via WebSocket fragment-count bypass + SOCKS5 proxy pool reuse
-  #                 (GHSA-vmh5-mc38-953g / -vxpw-j846-p89q / -hm92-r4w5-c3mj), via wrangler→miniflare.
+  #   undici <7.28.0 — TLS cert-validation bypass via SOCKS5 (GHSA-vmh5-mc38-953g), WebSocket DoS via
+  #                 fragment-count bypass (GHSA-vxpw-j846-p89q), and cross-origin request routing via
+  #                 SOCKS5 pool reuse (GHSA-hm92-r4w5-c3mj), via wrangler→miniflare.
   ws: "^8.21.0"
   vite@7: "^7.3.5"
   vite@8: "^8.0.16"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,12 @@ overrides:
   #   vite        — server.fs.deny bypass (GHSA-fx2h-pf6j-xcff): v7 via @react-router/dev→
   #                 vite-node, v8 via apps/web + vitest. Patched per-major to avoid forcing
   #                 vite-node (which needs v7) onto v8.
+  #   undici <7.28.0 — DoS via WebSocket fragment-count bypass + SOCKS5 proxy pool reuse
+  #                 (GHSA-vmh5-mc38-953g / -vxpw-j846-p89q / -hm92-r4w5-c3mj), via wrangler→miniflare.
   ws: "^8.21.0"
   vite@7: "^7.3.5"
   vite@8: "^8.0.16"
+  undici: "^7.28.0"
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Проблем

CI стъпката **„Dependency audit"** (`pnpm audit --audit-level=high`) започна да пада **в цялото репо** — на всеки отворен PR и на `main` — заради новопубликувана уязвимост в **`undici`** (по веригата `wrangler → miniflare → undici`, версия 7.24.8 в lock-а):

- GHSA-vmh5-mc38-953g — заобикаляне на TLS валидацията на сертификати през SOCKS5;
- GHSA-vxpw-j846-p89q — DoS на WebSocket клиента през fragment-count bypass;
- GHSA-hm92-r4w5-c3mj — cross-origin маршрутизиране на заявки през преизползване на SOCKS5 proxy pool.

Това е dev/build-time транзитивна зависимост — **не стига до Worker runtime-а**. Не е въведено от конкретен PR; адвайзърито е по-ново от последния pin на сигурностни съвети (`89c5d34`).

## Поправка

Добавя `undici: "^7.28.0"` override в `pnpm-workspace.yaml`, до съществуващите `ws`/`vite` pin-ове (същият установен модел). Lock-ът минава на `undici@7.28.0`.

## Проверка

```
$ pnpm audit --audit-level=high
1 vulnerabilities found
Severity: 1 low
# exit 0  (трите high + moderate-ите от undici са изчистени; остава 1 low под прага)
```

Diff е само `pnpm-workspace.yaml` (+override) и `pnpm-lock.yaml` (само undici 7.24.8 → 7.28.0).

Понеже е workspace-level pin, **отблокира CI на всички отворени PR-и** след merge — без нужда от rebase.

