### PR TITLE
build(deps): pin undici >=7.28.0 to clear high-severity advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ws: ^8.21.0
   vite@7: ^7.3.5
   vite@8: ^8.0.16
+  undici: ^7.28.0
   '@babel/core': ^7.29.6
 
 importers:
@@ -1604,8 +1605,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2868,7 +2869,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260520.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -3070,7 +3071,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,9 +13,14 @@ overrides:
   #   vite        — server.fs.deny bypass (GHSA-fx2h-pf6j-xcff): v7 via @react-router/dev→
   #                 vite-node, v8 via apps/web + vitest. Patched per-major to avoid forcing
   #                 vite-node (which needs v7) onto v8.
+  #   undici <7.28.0 — three HIGH advisories via wrangler→miniflare: SOCKS5 TLS-cert bypass
+  #                 (GHSA-vmh5-mc38-953g), WebSocket DoS via fragment-count bypass
+  #                 (GHSA-vxpw-j846-p89q), cross-origin routing via SOCKS5 pool reuse
+  #                 (GHSA-hm92-r4w5-c3mj). miniflare's local fetch only; never ships to the Worker.
   ws: "^8.21.0"
   vite@7: "^7.3.5"
   vite@8: "^8.0.16"
+  undici: "^7.28.0"
   #   @babel/core <7.29.6 — arbitrary file read via sourceMappingURL (GHSA-4x5r-pxfx-6jf8);
   #                 dev/build-time only (via @react-router/dev), never ships to the Worker.
   "@babel/core": "^7.29.6"


### PR DESCRIPTION
## Какво

CI gate-ът `pnpm audit --audit-level=high` пада на `main` (и на всеки отворен PR, понеже audit-ът върви по branch) заради **три HIGH** advisory-та в `undici`, достижими през `wrangler → miniflare → undici@7.24.8`:

| Advisory | Проблем |
|----------|---------|
| [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) | TLS cert validation bypass през изпуснат `requestTls` в SOCKS5 `ProxyAgent` |
| [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q) | WebSocket client DoS през fragment-count bypass |
| [GHSA-hm92-r4w5-c3mj](https://github.com/advisories/GHSA-hm92-r4w5-c3mj) | cross-origin request routing през SOCKS5 proxy pool reuse |

И трите са поправени в `undici >=7.28.0`.

## Поправката

Добавям `undici: "^7.28.0"` override в `pnpm-workspace.yaml`, до съществуващите `ws`/`vite` security pins. Това принуждава транзитивния `undici` на miniflare към `7.28.0`. Това е **само** локалният fetch на miniflare (dev/test симулаторът) — **не стига до Worker runtime-а**, същата категория като другите pins.

## Защо отделен PR

Това е независимо от #86 (bump на GitHub Actions). #86 не пада заради собствените си промени — пада, защото audit gate-ът е счупен на всеки branch в момента. След merge на този PR в `main`, #86 минава след rebase.

## Проверка

- `pnpm audit --audit-level=high` → **No known vulnerabilities found** (exit 0)
- `undici` резолва на `7.28.0` (от `7.24.8`)
- `pnpm --filter web typecheck` → 0
- web тестове → 63/63