### PR TITLE
fix(web): без FOUC при пълно презареждане в dev (линк на стила през links())

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -22,11 +22,15 @@ import { AccessibilityWidget } from './components/AccessibilityWidget';
 import { PageHeader } from './components/PageHeader';
 import { getCoverageMeta } from './lib/coverage';
 import { withDbRetry } from './lib/retry';
-import './app.css';
+import stylesheet from './app.css?url';
 
 // The editorial design uses a system serif/mono/sans stack (see app.css @theme) — no webfont request.
 // Brand favicons (white „С“ on the deep-red tile) live in /public; declare them so the head is explicit.
 export const links: Route.LinksFunction = () => [
+  // Link the global stylesheet explicitly (instead of a side-effect import) so it is a real
+  // <link> in the document head in dev too, not injected by JS after first paint - which avoids
+  // a flash of unstyled content on a full reload. In production both paths emit the same <link>.
+  { rel: 'stylesheet', href: stylesheet },
   { rel: 'icon', href: '/favicon.ico', sizes: '48x48' },
   { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32.png' },
   { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16.png' },


### PR DESCRIPTION
## Какво
В dev режим при пълно презареждане има кратко „мигване" без стилове (FOUC): `app.css` се внася като side-effect import, затова Vite го инжектира късно през JS, след първия paint. Тази промяна го внася с `?url` и го emit-ва през `links()` → реален `<link rel="stylesheet">` в `<head>` и в dev, който блокира първия paint до зареждане на стила.

## Защо отделен PR
Открих го докато правех визуализационните страници (#45/#48/#49/#50) и първоначално беше включен там, но е промяна по app shell-а, несвързана с тях. Изнесох го самостоятелно, за да са онези PR-и фокусирани върху своите функции.

## Ефект
- **Прод:** няма промяна — стилът и сега се линква в `<head>` (Vite извлича `app.css` като хеширан asset, който `<Links/>` emit-ва).
- **Dev:** край на примигването/подскачането при пълно презареждане.

## Тествано
`pnpm typecheck` и `pnpm exec prettier --check` са зелени. Производственият build потвърждава, че `app.css` става реален `<link>` в `<head>` (без FOUC).
