### PR TITLE
fix(web): бутонът за достъпност в цвета на бранда

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -1390,6 +1390,16 @@ a.flag:hover {
   }
 }
 
+/* The same launcher hard-codes its fill and 5px ring as pure CSS `red`, which clashes with
+   Sigma's brick-red brand accent — two different reds on screen at once (issue #82). Repaint it
+   with the brand accent so the chrome reads as one palette; the darker accent also lifts the
+   white glyph's contrast a touch. The `html` prefix outranks the vendored rule by specificity,
+   so the pinned stylesheet stays untouched and no load-order `!important` is needed. */
+html .a11y-tools__button {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
 /* Stacked horizontal bar */
 .hbar {
   display: flex;


### PR DESCRIPTION
## Какво

Вградената приставка за достъпност (ИО АД) задава плаващия си бутон (долу вдясно) с чисто CSS `red`, който се бие с тухлено-червения бранд акцент на Sigma — два различни червени на един екран. Това е една от точките в #82 (раздел „Цветове“).

Препокривам само цвета: `.a11y-tools__button` минава на `var(--accent)` (фон + ринг), в `app.css` непосредствено до вече съществуващия override за позицията на бутона. По-високата специфичност (`html` префикс) бие вендорното правило независимо от реда на зареждане, така че пинатият вендорен стайлшийт остава недокоснат. По-тъмният акцент леко вдига и контраста на бялата иконка.

## Обхват (умишлено малък)

Прегледах отворените PR-и и текущия `main`, за да съм сигурна, че не дублирам вече свършена или текуща работа:

- **Позиционното припокриване** („4,58 млрд.“ минава под бутона) **вече е решено** на `main` — съседният `@media (max-width: 760px)` override закача бутона долу вдясно, за да не покрива съдържанието. Затова тук не го пипам.
- **Контрастът (WCAG AA)** на сивите микро-етикети е затворен в `ce69f0b`.
- **По-голямата мобилна преработка** от issue-то (drill-down вместо Sankey, филтри в bottom sheet, карти вместо таблици) се застъпва с текущите PR-и за визуализациите и навигацията (#45 / #48 / #49 / #50 / #59 / #52). Както отбелязах в коментара към issue-то, по-добре е да изчакаме те да се мържнат, преди да отваряме поправки по тях.
- Никой отворен PR не пипа цвета на този бутон. **#84** (split на `app.css`) разбутва същия регион, така че там ще има тривиален merge конфликт — различно намерение (само разместване на файла), лесен за разрешаване.

## Тествано

`pnpm exec prettier --check` е зелено. Промяната е чисто CSS — един селектор, без логика, без промяна по разметката.

---

Closes #82
