### PR TITLE
feat(web): add /health endpoint and post-deploy smoke check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,31 @@ jobs:
         if: steps.guard.outputs.ok == 'true'
         run: pnpm --filter @sigma/web run deploy
 
+      # Cheap readiness probe: confirms the worker is live and the D1 binding answers after deploy.
+      # When Cloudflare Access gates the target URL, set CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET
+      # as Environment secrets (service token) — see docs/deploy.md.
+      - name: Smoke — verify /health after web deploy
+        if: steps.guard.outputs.ok == 'true'
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          if [ "${{ needs.detect.outputs.env }}" = "production" ]; then
+            base="https://sigma.midt.bg"
+          else
+            base="https://${SIGMA_WEB_NAME}.cf-midt.workers.dev"
+          fi
+          url="${base}/health"
+          curl_opts=(--fail --silent --show-error --retry 5 --retry-delay 3 --retry-connrefused)
+          if [ -n "${CF_ACCESS_CLIENT_ID}" ] && [ -n "${CF_ACCESS_CLIENT_SECRET}" ]; then
+            curl_opts+=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}")
+            curl_opts+=(-H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+          fi
+          echo "Probing ${url}"
+          body="$(curl "${curl_opts[@]}" "$url")"
+          echo "$body"
+          printf '%s' "$body" | jq -e '.ok == true and .db == "ok"'
+
       - name: Initialize LOG_IP_KEY secret if absent
         if: steps.guard.outputs.ok == 'true'
         run: |

--- a/apps/web/app/lib/health.test.ts
+++ b/apps/web/app/lib/health.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildHealthResponse, pingDb } from './health';
+
+function mockDb(firstResult: unknown, shouldThrow = false): D1Database {
+  const first = vi.fn().mockImplementation(async () => {
+    if (shouldThrow) throw new Error('D1 unavailable');
+    return firstResult;
+  });
+  const prepare = vi.fn().mockReturnValue({ first });
+  return { prepare } as unknown as D1Database;
+}
+
+describe('pingDb', () => {
+  it('returns ok when SELECT 1 succeeds', async () => {
+    expect(await pingDb(mockDb({ ok: 1 }))).toBe('ok');
+  });
+
+  it('returns error when D1 throws', async () => {
+    expect(await pingDb(mockDb(null, true))).toBe('error');
+  });
+});
+
+describe('buildHealthResponse', () => {
+  it('returns 200 JSON when db is ok', async () => {
+    const response = buildHealthResponse('ok', new Date('2026-06-23T12:00:00.000Z'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      ts: '2026-06-23T12:00:00.000Z',
+      db: 'ok',
+    });
+  });
+
+  it('returns 503 JSON when db is error', async () => {
+    const response = buildHealthResponse('error', new Date('2026-06-23T12:00:00.000Z'));
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      ts: '2026-06-23T12:00:00.000Z',
+      db: 'error',
+    });
+  });
+});

--- a/apps/web/app/lib/health.test.ts
+++ b/apps/web/app/lib/health.test.ts
@@ -16,7 +16,11 @@ describe('pingDb', () => {
   });
 
   it('returns error when D1 throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(await pingDb(mockDb(null, true))).toBe('error');
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('health_db_ping_failed');
+    errorSpy.mockRestore();
   });
 });
 

--- a/apps/web/app/lib/health.ts
+++ b/apps/web/app/lib/health.ts
@@ -1,0 +1,32 @@
+export type HealthDbStatus = 'ok' | 'error';
+
+export interface HealthPayload {
+  ok: boolean;
+  ts: string;
+  db: HealthDbStatus;
+}
+
+export async function pingDb(db: D1Database): Promise<HealthDbStatus> {
+  try {
+    await db.prepare('SELECT 1 AS ok').first();
+    return 'ok';
+  } catch {
+    return 'error';
+  }
+}
+
+export function buildHealthResponse(db: HealthDbStatus, now = new Date()): Response {
+  const ok = db === 'ok';
+  const body: HealthPayload = {
+    ok,
+    ts: now.toISOString(),
+    db,
+  };
+  return new Response(JSON.stringify(body), {
+    status: ok ? 200 : 503,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/apps/web/app/lib/health.ts
+++ b/apps/web/app/lib/health.ts
@@ -8,9 +8,17 @@ export interface HealthPayload {
 
 export async function pingDb(db: D1Database): Promise<HealthDbStatus> {
   try {
-    await db.prepare('SELECT 1 AS ok').first();
+    await db.prepare('SELECT 1').first();
     return 'ok';
-  } catch {
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        event: 'health_db_ping_failed',
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
     return 'error';
   }
 }

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -15,6 +15,7 @@ export default [
   route('contracts/:id.json', 'routes/contract.json.tsx'),
   route('contracts/:id', 'routes/contract.tsx'),
   route('methodology', 'routes/methodology.tsx'),
+  route('health', 'routes/health.tsx'),
   route('accessibility', 'routes/accessibility.tsx'),
   route('privacy', 'routes/privacy.tsx'),
   route('impressum', 'routes/impressum.tsx'),

--- a/apps/web/app/routes/health.tsx
+++ b/apps/web/app/routes/health.tsx
@@ -1,0 +1,7 @@
+import type { Route } from './+types/health';
+import { buildHealthResponse, pingDb } from '../lib/health';
+
+export async function loader({ context }: Route.LoaderArgs) {
+  const db = await pingDb(context.cloudflare.env.DB);
+  return buildHealthResponse(db);
+}

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -4,6 +4,7 @@ import { rateLimitAggregationRoute } from './aggregation-rate-limit';
 import { cacheKey } from './cache-key';
 import { cspNonce, hashTrustedInlineScripts } from './csp';
 import { rateLimitCsvExport } from './csv-rate-limit';
+import { rateLimitHealthRoute } from './health-rate-limit';
 import { optionsResponse, redirectCleartextHttp, setAllowHeader } from './http';
 import { rateLimitSearchRoute } from './search-rate-limit';
 import { withRequestLog } from './request-log';
@@ -123,6 +124,9 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
 
   const searchRateLimitResponse = await rateLimitSearchRoute(request, env, import.meta.env.PROD);
   if (searchRateLimitResponse) return searchRateLimitResponse;
+
+  const healthRateLimitResponse = await rateLimitHealthRoute(request, env, import.meta.env.PROD);
+  if (healthRateLimitResponse) return healthRateLimitResponse;
 
   const response = await requestHandler(request, { cloudflare: { env, ctx } });
   const cacheable =

--- a/apps/web/workers/health-rate-limit.test.ts
+++ b/apps/web/workers/health-rate-limit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { rateLimitHealthRoute } from './health-rate-limit';
+
+function rateLimiter(success: boolean): { limiter: RateLimit; limit: ReturnType<typeof vi.fn> } {
+  const limit = vi.fn(async () => ({ success }));
+  return { limiter: { limit } as RateLimit, limit };
+}
+
+describe('rateLimitHealthRoute', () => {
+  it('limits /health requests keyed on client IP', async () => {
+    const { limiter, limit } = rateLimiter(false);
+
+    const response = await rateLimitHealthRoute(
+      new Request('http://local/health', {
+        headers: { 'CF-Connecting-IP': '203.0.113.50' },
+      }),
+      { HEALTH_RATE_LIMITER: limiter },
+      false,
+    );
+
+    expect(limit).toHaveBeenCalledWith({ key: '203.0.113.50' });
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get('Retry-After')).toBe('60');
+  });
+
+  it('limits /health with a trailing slash', async () => {
+    const { limiter, limit } = rateLimiter(false);
+
+    const response = await rateLimitHealthRoute(
+      new Request('http://local/health/', {
+        headers: { 'CF-Connecting-IP': '203.0.113.51' },
+      }),
+      { HEALTH_RATE_LIMITER: limiter },
+      false,
+    );
+
+    expect(limit).toHaveBeenCalledWith({ key: '203.0.113.51' });
+    expect(response?.status).toBe(429);
+  });
+
+  it('does not limit unrelated paths', async () => {
+    const { limiter, limit } = rateLimiter(false);
+
+    await expect(
+      rateLimitHealthRoute(
+        new Request('http://local/contracts'),
+        { HEALTH_RATE_LIMITER: limiter },
+        false,
+      ),
+    ).resolves.toBeNull();
+    expect(limit).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the binding is missing or throws', async () => {
+    await expect(
+      rateLimitHealthRoute(new Request('http://local/health'), {}, false),
+    ).resolves.toBeNull();
+
+    const limit = vi.fn(async () => {
+      throw new Error('rate limit unavailable');
+    });
+    await expect(
+      rateLimitHealthRoute(
+        new Request('http://local/health'),
+        { HEALTH_RATE_LIMITER: { limit } as RateLimit },
+        false,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/workers/health-rate-limit.ts
+++ b/apps/web/workers/health-rate-limit.ts
@@ -1,0 +1,28 @@
+import { normalizedPathname, rateLimitRequest } from './rate-limit';
+
+interface HealthRateLimitEnv {
+  HEALTH_RATE_LIMITER?: RateLimit;
+}
+
+export async function rateLimitHealthRoute(
+  request: Request,
+  env: HealthRateLimitEnv,
+  isProd: boolean,
+): Promise<Response | null> {
+  if (!isHealthRequest(request)) return null;
+
+  return rateLimitRequest(
+    request,
+    env.HEALTH_RATE_LIMITER,
+    isProd,
+    'Too many health check requests',
+    'HEALTH_RATE_LIMITER',
+  );
+}
+
+function isHealthRequest(request: Request): boolean {
+  return (
+    (request.method === 'GET' || request.method === 'HEAD') &&
+    normalizedPathname(request) === '/health'
+  );
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -43,6 +43,13 @@
         "namespace_id": "1003",
         "simple": { "limit": 20, "period": 60 },
       },
+      {
+        "name": "HEALTH_RATE_LIMITER",
+        "type": "ratelimit",
+        // /health does a D1 read on every request; cap abuse without blocking normal uptime probes.
+        "namespace_id": "1004",
+        "simple": { "limit": 60, "period": 60 },
+      },
     ],
   },
   "observability": {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -286,6 +286,12 @@ gate-а. Това е стъпката, която хората забравят.
 > добавете **Service Token** policy или IP bypass. Access приложението + policy може да се управлява и
 > като код (Terraform `cloudflare_zero_trust_access_application` / `_policy`) вместо click-ops. ETL-ът
 > не се нуждае от нищо тук — `sigma-etl` е cron-only без публична повърхност.
+>
+> **Readiness probe.** `GET /health` връща `{ ok, ts, db }` — лек D1 ping (`SELECT 1`), без кеш.
+> Deploy workflow-ът (`.github/workflows/deploy.yml`) прави smoke check след web deploy. За
+> Access-заключени URL-и задайте `CF_ACCESS_CLIENT_ID` и `CF_ACCESS_CLIENT_SECRET` като Environment
+> secrets (service token с достъп до staging/production). Външни uptime монитори могат да ползват
+> същия endpoint и headers.
 
 ## Гаранции за изолация — защо staging не може да докосне production
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -288,6 +288,7 @@ gate-а. Това е стъпката, която хората забравят.
 > не се нуждае от нищо тук — `sigma-etl` е cron-only без публична повърхност.
 >
 > **Readiness probe.** `GET /health` връща `{ ok, ts, db }` — лек D1 ping (`SELECT 1`), без кеш.
+> Защитен от `HEALTH_RATE_LIMITER` (60/60s на IP); D1 грешки се логват в Workers logs.
 > Deploy workflow-ът (`.github/workflows/deploy.yml`) прави smoke check след web deploy. За
 > Access-заключени URL-и задайте `CF_ACCESS_CLIENT_ID` и `CF_ACCESS_CLIENT_SECRET` като Environment
 > secrets (service token с достъп до staging/production). Външни uptime монитори могат да ползват

--- a/scripts/wrangler-render.mjs
+++ b/scripts/wrangler-render.mjs
@@ -21,7 +21,12 @@ const SENTINELS = {
 
 // Required at deploy: every rate limiter the worker relies on must be bound, and Cloudflare requires
 // rate-limit namespace_ids to be account-unique — a duplicate silently merges two buckets.
-const REQUIRED_RATE_LIMITERS = ['CSV_RATE_LIMITER', 'AGG_RATE_LIMITER', 'SEARCH_RATE_LIMITER'];
+const REQUIRED_RATE_LIMITERS = [
+  'CSV_RATE_LIMITER',
+  'AGG_RATE_LIMITER',
+  'SEARCH_RATE_LIMITER',
+  'HEALTH_RATE_LIMITER',
+];
 
 const input = process.argv[2];
 if (!input) {


### PR DESCRIPTION
## Summary

Adds a production readiness probe and automated post-deploy verification — standard deployment-patterns practice for a Cloudflare Worker + D1 app.

- **`GET /health`** — JSON `{ ok, ts, db }` with a cheap D1 `SELECT 1` ping; returns `503` when DB is unreachable; `Cache-Control: no-store`
- **Deploy smoke check** — curls `/health` after the web worker deploy (retries, optional Cloudflare Access service-token headers)
- **Tests** — Vitest coverage for `pingDb` and response shaping
- **Docs** — `docs/deploy.md` note on uptime probing and Access bypass for automation

Closes #117

## Test plan

- [x] `pnpm --filter @sigma/web test -- app/lib/health.test.ts`
- [x] `pnpm typecheck`
- [ ] After merge: confirm deploy workflow smoke step passes on staging (requires `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` if Access is enabled)
- [ ] `curl https://<staging-worker>/health` returns `{"ok":true,"db":"ok",...}`

## Follow-up backlog (from repo audit)

| Priority | Issue idea | Skill |
|----------|-----------|-------|
| 1 | Wire `web-vitals` attribution → GA4 in `root.tsx` + CSP `connect-src` | web-vitals-monitor |
| 2 | `eslint-plugin-jsx-a11y` + axe Vitest on key routes | a11y-architect |
| 3 | `pnpm build` in CI to catch SSR build regressions before deploy | deployment-patterns |

Made with [Cursor](https://cursor.com)