### PR TITLE
fix(web): mobile nav drawer stacking + search submit width

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2030,6 +2030,7 @@ details.row .body .signal .why {
   background: var(--ink);
   color: var(--paper);
   padding: 10px var(--s-5);
+  box-sizing: border-box;
   font: 500 11px/1 var(--font-mono);
   letter-spacing: 0.18em;
   text-transform: uppercase;

--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -415,6 +415,13 @@ code,
     display: inline-flex;
   }
 
+  /* The drawer (z-31) and backdrop (z-30) are positioned siblings in the root context only if the
+     header doesn't trap the drawer: drop the header's stacking context on mobile so the open menu
+     sits above the scrim (otherwise .site-header{z-index:20} keeps the drawer under the backdrop). */
+  .site-header {
+    z-index: auto;
+  }
+
   .nav-backdrop {
     display: block;
     position: fixed;


### PR DESCRIPTION
Две мобилни регресии от наскоро мърджнатото #59 (slide-in меню + smart search), потвърдени и поправени на ширини 390px / 360px спрямо staging. Само CSS, два фокусирани комита.

## Меню: чекмеджето стои под собствения си фон
`.site-header { position: relative; z-index: 20 }` създава stacking context, който затваря slide-in чекмеджето `.site-nav` (`z-index: 31`) **под** `.nav-backdrop` (`z-index: 30`, рендиран в корена). Затъмняващият слой се рисува върху отвореното меню — панелът изглежда затъмнен, а връзките и × не се натискат (тапът попада във фона и затваря).

**Поправка:** на мобилно (`@media max-width: 960px`) махаме stacking context-а на хедъра (`z-index: auto`), за да може фиксираното чекмедже (31) да изплува над фиксирания фон (30) в кореновия контекст. Затъмнен остава само фонът зад менюто.

## „Намери": бутонът прелива ширината
Няма глобален `border-box` reset, така че `.smart-search-submit` се смята като `content-box`. На `@media max-width: 760px` бутонът е `grid-column: 1 / -1; width: 100%`, но `padding` + `border` се добавят **върху** тези 100% → рендира се ~50px по-широк от полето над него и стърчи вдясно.

**Поправка:** `box-sizing: border-box` на бутона — пак цяла ширина, но подравнен с полето и текста.
