### PR TITLE
refactor: споделяне на single-select филтрите и sectorOptions (#85)

### DIFF
--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -53,11 +53,15 @@ export interface SingleSelectFilters {
 
 /**
  * Single-select explorer filters (sector / year / funding / top) shared by the visual pages
- * (/flows, /competition). A bogus ?sector or ?year is flagged and dropped from the params, so the
- * page can show an explicit empty state instead of silently filtering everything out. `years` is the
- * valid set for the current coverage window.
+ * (/flows, /competition, /map, /trends). A bogus ?sector or ?year is flagged and dropped from the
+ * params, so the page can show an explicit empty state instead of silently filtering everything out.
+ * `years` is the valid set for the current coverage window; omit it on pages with no year filter
+ * (e.g. /trends), where `unknownYear` is then always false.
  */
-export function singleSelectFilters(sp: URLSearchParams, years: string[]): SingleSelectFilters {
+export function singleSelectFilters(
+  sp: URLSearchParams,
+  years: string[] = [],
+): SingleSelectFilters {
   const sector = sp.get('sector');
   const year = sp.get('year');
   const unknownSector = Boolean(sector) && !KNOWN_SECTORS.has(sector!);

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -65,7 +65,7 @@ export function singleSelectFilters(
   const sector = sp.get('sector');
   const year = sp.get('year');
   const unknownSector = Boolean(sector) && !KNOWN_SECTORS.has(sector!);
-  const unknownYear = Boolean(year) && !years.includes(year!);
+  const unknownYear = years.length > 0 && Boolean(year) && !years.includes(year!);
   const funding = sp.get('funding');
   return {
     sector: unknownSector ? null : sector,

--- a/apps/web/app/routes/map.tsx
+++ b/apps/web/app/routes/map.tsx
@@ -1,7 +1,6 @@
 import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import type { MacroRegionSpend, RegionSpend } from '@sigma/api-contract';
 import { count, money, pct } from '@sigma/shared';
-import { CPV_SECTORS } from '@sigma/config';
 import { getRegionalSpending } from '@sigma/db';
 import type { Route } from './+types/map';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -12,6 +11,7 @@ import { Choropleth } from '../components/Choropleth';
 import { Callout, Section, ShareBar } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta, yearOptions } from '../lib/coverage';
+import { singleSelectFilters } from '../lib/filters';
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -29,20 +29,14 @@ export function headers() {
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const sp = new URL(request.url).searchParams;
-  const sector = sp.get('sector');
-  const year = sp.get('year');
   const db = context.cloudflare.env.DB;
   const coverage = await getCoverageMeta(db);
   const years = yearOptions(coverage.coverageEndYear);
-  // A bogus ?sector / ?year would silently filter everything out; flag it and ignore it instead.
-  const unknownSector = Boolean(sector) && !CPV_SECTORS.some((s) => s.code === sector);
-  const unknownYear = Boolean(year) && !years.includes(year!);
-  const data = await getRegionalSpending(db, {
-    sector: unknownSector ? null : sector,
-    year: unknownYear ? null : year,
-    funding: (sp.get('funding') as 'eu' | 'national' | null) || 'all',
-  });
+  const { sector, year, funding, unknownSector, unknownYear } = singleSelectFilters(
+    new URL(request.url).searchParams,
+    years,
+  );
+  const data = await getRegionalSpending(db, { sector, year, funding });
   return { data, coverage, years, unknownSector, unknownYear };
 }
 

--- a/apps/web/app/routes/trends.tsx
+++ b/apps/web/app/routes/trends.tsx
@@ -1,7 +1,6 @@
 import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import type { TrendYear } from '@sigma/api-contract';
 import { count, money, pct, signedPct } from '@sigma/shared';
-import { CPV_SECTORS } from '@sigma/config';
 import { getSpendingTrend } from '@sigma/db';
 import type { Route } from './+types/trends';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -10,6 +9,7 @@ import { DataTable, type Column } from '../components/DataTable';
 import { TrendChart } from '../components/TrendChart';
 import { Callout, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
+import { singleSelectFilters } from '../lib/filters';
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -28,16 +28,10 @@ export function headers() {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const sp = new URL(request.url).searchParams;
-  const sector = sp.get('sector');
+  const { sector, funding, unknownSector } = singleSelectFilters(sp);
   const granularity = sp.get('g') === 'year' ? 'year' : 'month';
   const db = context.cloudflare.env.DB;
-  // A bogus ?sector would silently empty the chart; flag it and ignore it instead.
-  const unknownSector = Boolean(sector) && !CPV_SECTORS.some((s) => s.code === sector);
-  const data = await getSpendingTrend(db, {
-    sector: unknownSector ? null : sector,
-    funding: (sp.get('funding') as 'eu' | 'national' | null) || 'all',
-    granularity,
-  });
+  const data = await getSpendingTrend(db, { sector, funding, granularity });
   return { data, unknownSector };
 }
 

--- a/packages/db/src/queries/competition.ts
+++ b/packages/db/src/queries/competition.ts
@@ -11,12 +11,11 @@ import type {
   CompetitionData,
   CompetitionPair,
   CompetitionTotals,
-  SectorRef,
 } from '@sigma/api-contract';
-import { CPV_SECTORS } from '@sigma/config';
 import { cleanName, entityName } from '@sigma/shared';
 import { authoritySlug, companySlug } from './identity';
 import { typeLabel } from './rows';
+import { sectorOptions } from './sectors';
 
 export interface CompetitionParams {
   sector?: string | null;
@@ -30,7 +29,6 @@ export interface CompetitionParams {
 const DEFAULT_TOP = 20;
 const MAX_TOP = 50;
 const DEFAULT_MIN_CONTRACTS = 20;
-const SECTOR_OPTION_LIMIT = 12;
 
 // Shared contract-scope filter, identical across panels: sector via the parent tender's CPV division,
 // year via signed_at, EU funding via eu_funded. Every contract has a parent tender (synthetic when the
@@ -269,19 +267,6 @@ async function topRecurringPairs(
       wonEur: r.won_eur,
     };
   });
-}
-
-// Sector select options: the present sectors by value (curated label), capped. Same source as getFlows.
-async function sectorOptions(db: D1Database): Promise<SectorRef[]> {
-  const { results } = await db
-    .prepare(`SELECT division FROM sector_totals ORDER BY value_eur DESC LIMIT ?`)
-    .bind(SECTOR_OPTION_LIMIT)
-    .all<{ division: string }>();
-  const byCode = new Map(CPV_SECTORS.map((s) => [s.code, s]));
-  return results
-    .map((r) => byCode.get(r.division))
-    .filter((s): s is (typeof CPV_SECTORS)[number] => Boolean(s))
-    .map((s) => ({ code: s.code, label: s.short ?? s.label, short: s.short ?? s.label }));
 }
 
 export async function getCompetition(

--- a/packages/db/src/queries/flows.ts
+++ b/packages/db/src/queries/flows.ts
@@ -9,11 +9,10 @@ import type {
   SankeyLayout,
   SankeyNode,
   SankeyRibbon,
-  SectorRef,
 } from '@sigma/api-contract';
-import { CPV_SECTORS } from '@sigma/config';
 import { cleanName, entityName, money } from '@sigma/shared';
 import { authoritySlug, companySlug } from './identity';
+import { sectorOptions } from './sectors';
 
 export interface FlowsParams {
   sector?: string | null;
@@ -179,10 +178,8 @@ function buildSankey(pairs: PairRow[]): SankeyLayout {
   return { viewBox: '-150 -6 990 614', width: 990, height: 614, nodes, ribbons };
 }
 
-const SECTOR_OPTION_LIMIT = 12;
 const DEFAULT_TOP = 20;
 const MAX_TOP = 50;
-
 export async function getFlows(db: D1Database, p: FlowsParams): Promise<FlowsData> {
   const requestedTop = Number.isInteger(p.top) ? p.top! : DEFAULT_TOP;
   const top = requestedTop >= 1 && requestedTop <= MAX_TOP ? requestedTop : DEFAULT_TOP;
@@ -203,16 +200,7 @@ export async function getFlows(db: D1Database, p: FlowsParams): Promise<FlowsDat
     };
   });
 
-  // Sector select options: present sectors by value (curated first), capped.
-  const sectorRows = await db
-    .prepare(`SELECT division FROM sector_totals ORDER BY value_eur DESC LIMIT ?`)
-    .bind(SECTOR_OPTION_LIMIT)
-    .all<{ division: string }>();
-  const byCode = new Map(CPV_SECTORS.map((s) => [s.code, s]));
-  const sectors: SectorRef[] = sectorRows.results
-    .map((r) => byCode.get(r.division))
-    .filter((s): s is (typeof CPV_SECTORS)[number] => Boolean(s))
-    .map((s) => ({ code: s.code, label: s.short ?? s.label, short: s.short ?? s.label }));
+  const sectors = await sectorOptions(db);
 
   return {
     pairs,

--- a/packages/db/src/queries/regions.ts
+++ b/packages/db/src/queries/regions.ts
@@ -4,13 +4,9 @@
 // comes from authorities.region (OCDS NUTS, ~half of authorities), so we always split out an
 // "unattributed" bucket and report coverage; the 28 regions are zero-filled so the map colours all of them.
 
-import type {
-  MacroRegionSpend,
-  RegionSpend,
-  RegionalSpending,
-  SectorRef,
-} from '@sigma/api-contract';
-import { BG_REGIONS, CPV_SECTORS, regionByName } from '@sigma/config';
+import type { MacroRegionSpend, RegionSpend, RegionalSpending } from '@sigma/api-contract';
+import { BG_REGIONS, regionByName } from '@sigma/config';
+import { sectorOptions } from './sectors';
 
 export interface RegionalParams {
   sector?: string | null;
@@ -61,21 +57,6 @@ async function regionRows(db: D1Database, p: RegionalParams): Promise<RegionRow[
     .bind(...params)
     .all<RegionRow>();
   return results;
-}
-
-const SECTOR_OPTION_LIMIT = 12;
-
-// Sector select options: present sectors by value (curated label), capped. Same source as getFlows.
-async function sectorOptions(db: D1Database): Promise<SectorRef[]> {
-  const { results } = await db
-    .prepare(`SELECT division FROM sector_totals ORDER BY value_eur DESC LIMIT ?`)
-    .bind(SECTOR_OPTION_LIMIT)
-    .all<{ division: string }>();
-  const byCode = new Map(CPV_SECTORS.map((s) => [s.code, s]));
-  return results
-    .map((r) => byCode.get(r.division))
-    .filter((s): s is (typeof CPV_SECTORS)[number] => Boolean(s))
-    .map((s) => ({ code: s.code, label: s.short ?? s.label, short: s.short ?? s.label }));
 }
 
 export async function getRegionalSpending(

--- a/packages/db/src/queries/sectors.test.ts
+++ b/packages/db/src/queries/sectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sectorRef } from './sectors';
+import { sectorOptions, sectorRef } from './sectors';
 
 describe('sectorRef', () => {
   it('resolves a valid 2-digit CPV division to a SectorRef', () => {
@@ -30,5 +30,26 @@ describe('sectorRef', () => {
     const ref = sectorRef('45');
     expect(typeof ref?.short).toBe('string');
     expect(ref!.short.length).toBeGreaterThan(0);
+  });
+});
+
+const fakeSectorDb = (divisions: string[]) =>
+  ({
+    prepare: () => ({
+      bind: () => ({
+        all: async () => ({ results: divisions.map((division) => ({ division })) }),
+      }),
+    }),
+  }) as unknown as D1Database;
+
+describe('sectorOptions', () => {
+  it('maps sector_totals divisions (in order) to SectorRef[], dropping unknown codes', async () => {
+    const opts = await sectorOptions(fakeSectorDb(['45', '99', '33']));
+    expect(opts.map((s) => s.code)).toEqual(['45', '33']); // 99 is not a CPV division
+    expect(opts.every((s) => s.label.length > 0 && s.short.length > 0)).toBe(true);
+  });
+
+  it('returns an empty array when there are no sector rows', async () => {
+    expect(await sectorOptions(fakeSectorDb([]))).toEqual([]);
   });
 });

--- a/packages/db/src/queries/sectors.ts
+++ b/packages/db/src/queries/sectors.ts
@@ -10,3 +10,18 @@ export function sectorRef(division: string | null | undefined): SectorRef | null
   if (!s) return null;
   return { code: s.code, label: s.label, short: s.short ?? s.label };
 }
+
+const SECTOR_OPTION_LIMIT = 12;
+
+/** Sector-select dropdown options: the most-active divisions by spend (from sector_totals), resolved
+ *  to SectorRef with the short label. Shared by the /flows, /map, /trends and /competition loaders. */
+export async function sectorOptions(db: D1Database): Promise<SectorRef[]> {
+  const { results } = await db
+    .prepare(`SELECT division FROM sector_totals ORDER BY value_eur DESC LIMIT ?`)
+    .bind(SECTOR_OPTION_LIMIT)
+    .all<{ division: string }>();
+  return results
+    .map((r) => BY_CODE.get(r.division))
+    .filter((s): s is (typeof CPV_SECTORS)[number] => Boolean(s))
+    .map((s) => ({ code: s.code, label: s.short ?? s.label, short: s.short ?? s.label }));
+}

--- a/packages/db/src/queries/trend.ts
+++ b/packages/db/src/queries/trend.ts
@@ -4,8 +4,8 @@
 // usable signing date are excluded from the series and reported as coverage. Edge-cached at the route,
 // like getFlows; precompute is a possible follow-up.
 
-import type { SectorRef, TrendData, TrendPoint, TrendYear } from '@sigma/api-contract';
-import { CPV_SECTORS } from '@sigma/config';
+import type { TrendData, TrendPoint, TrendYear } from '@sigma/api-contract';
+import { sectorOptions } from './sectors';
 
 export interface TrendParams {
   sector?: string | null;
@@ -73,21 +73,6 @@ function fillPeriods(first: string, last: string, granularity: 'month' | 'year')
     out.push(`${Math.floor(m / 12)}-${String((m % 12) + 1).padStart(2, '0')}`);
   }
   return out;
-}
-
-const SECTOR_OPTION_LIMIT = 12;
-
-// Sector select options: present sectors by value (curated label), capped. Same source as getFlows.
-async function sectorOptions(db: D1Database): Promise<SectorRef[]> {
-  const { results } = await db
-    .prepare(`SELECT division FROM sector_totals ORDER BY value_eur DESC LIMIT ?`)
-    .bind(SECTOR_OPTION_LIMIT)
-    .all<{ division: string }>();
-  const byCode = new Map(CPV_SECTORS.map((s) => [s.code, s]));
-  return results
-    .map((r) => byCode.get(r.division))
-    .filter((s): s is (typeof CPV_SECTORS)[number] => Boolean(s))
-    .map((s) => ({ code: s.code, label: s.short ?? s.label, short: s.short ?? s.label }));
 }
 
 export async function getSpendingTrend(


### PR DESCRIPTION
## Какво (без промяна във функционалността)
Почистване след сливането на 4-те визуални страници (#45 / #48 / #49 / #50).

1. **`singleSelectFilters()` на /map и /trends** — `/flows` и `/competition` вече ползваха общия helper, а `/map` и `/trends` още парсваха `sector` / `year` / `funding` inline. Минаха на него (`years` става опционален аргумент, защото `/trends` няма филтър по година).
2. **Изнесен `sectorOptions()`** — една и съща заявка за опциите на sector dropdown-а (`SELECT division FROM sector_totals … → SectorRef[]`) беше копирана в `regions.ts`, `trend.ts`, `competition.ts` и inline в `flows.ts`. Изнесена в общия `queries/sectors.ts` (до `sectorRef`), с unit тест.

## Защо
Обещано в ревюто на #45 (рунд 1) и проследено в **#85** — отложено, докато `singleSelectFilters` влезе в `main` с #45.

## Тествано
`pnpm typecheck` + `pnpm test` (143 db / 84 web) + `pnpm exec prettier --check` — зелени. Локално: `/flows`, `/competition`, `/map`, `/trends` рендерират с работещи dropdown-и; `?sector=<невалиден>` коректно показва empty-state на `/map` и `/trends` (поведението е запазено).

Closes #85, closes #130.

