### PR TITLE
fix(web): без застъпване на етикета на центъра в графа на мрежата

### DIFF
--- a/apps/web/app/components/NetworkGraph.tsx
+++ b/apps/web/app/components/NetworkGraph.tsx
@@ -109,14 +109,19 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
                     <title>{label}</title>
                   </circle>
                 )}
-                <text
-                  className="node-label"
-                  x={right ? pt.x + r + 4 : pt.x - r - 4}
-                  y={pt.y + 3}
-                  textAnchor={right ? 'start' : 'end'}
-                >
-                  {truncate(n.label)}
-                </text>
+                {/* No label on the centre node: it is already named in the page title, the centre
+                    dropdown and the legend (it is the only accent-red node). A label here would either
+                    collide with a neighbour or sit on an edge. Ring nodes label outward. */}
+                {n.hop !== 0 && (
+                  <text
+                    className="node-label"
+                    x={right ? pt.x + r + 4 : pt.x - r - 4}
+                    y={pt.y + 3}
+                    textAnchor={right ? 'start' : 'end'}
+                  >
+                    {truncate(n.label)}
+                  </text>
+                )}
               </g>
             );
           })}


### PR DESCRIPTION
## Какво
Етикетът на централния възел в `/network` се застъпваше със съседен възел (центърът е ограден от възли от всички страни, а етикетът тръгва навън; на демо данните „Община Примерна" застъпваше „Бета Сервиз ЕООД"). Махам надписа на центъра от графа: той вече е именуван в заглавието на страницата („Връзки около …"), в dropdown-а „Център" и в легендата (единственият акцентно-червен възел). Околните възли запазват етикетите си; лимитът на изрязване минава 22 -> 26.

## Без промяна в данни/оформление
Позиции на възли, връзки, размери и цветове остават непокътнати; пада само надписът на центъра (един файл).

## Тествано
`pnpm typecheck` + `pnpm exec prettier --check` зелени; локален рендер на `/network` (центърът без застъпване, възли/връзки непроменени).

## Резултат
**Преди**
<img width="1328" height="1061" alt="Screenshot 2026-06-24 at 0 25 37" src="https://github.com/user-attachments/assets/3be541cd-23c6-47ca-bbaa-d116d75a1316" />
**След**:
<img width="1308" height="937" alt="Screenshot 2026-06-24 at 0 55 42" src="https://github.com/user-attachments/assets/e1efd162-6054-456f-97a0-43ed67b11a9b" />

