### PR TITLE
fix(web): затваряне на ключа за кеша спрямо реално четените query параметри

### DIFF
--- a/apps/web/workers/app.cache.test.ts
+++ b/apps/web/workers/app.cache.test.ts
@@ -1,0 +1,107 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Exercises the REAL edge-cache middleware in app.ts (handleRequest -> cacheKey -> edgeCache
+// match/put) without the SSR build or D1, to gate that app.ts actually keys the cache by cacheKey.
+// The pure cacheKey test proves keys differ; this proves the middleware USES that key, so a
+// /contracts?bids=1 response can never be served for /contracts (CWE-349, #56).
+
+// Stub the React Router handler: the two URLs return DIFFERENT bodies — the whole reason `bids`
+// must be in the cache key. The import thunk is never invoked, so no real build is loaded.
+vi.mock('react-router', () => ({
+  createRequestHandler: () => async (request: Request) => {
+    const bids = new URL(request.url).searchParams.get('bids');
+    const body = bids === '1' ? 'ROWS: single-bid only (2)' : 'ROWS: all contracts (5)';
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, s-maxage=1800',
+      },
+    });
+  },
+}));
+vi.mock('virtual:react-router/server-build', () => ({}));
+// Pass through the log wrapper; disable rate limiters (they need real DO bindings otherwise).
+vi.mock('./request-log', () => ({
+  withRequestLog: (
+    request: Request,
+    env: unknown,
+    ctx: unknown,
+    handler: (r: Request, e: unknown, c: unknown) => Promise<Response>,
+  ) => handler(request, env, ctx),
+}));
+vi.mock('./aggregation-rate-limit', () => ({ rateLimitAggregationRoute: async () => null }));
+vi.mock('./csv-rate-limit', () => ({ rateLimitCsvExport: async () => null }));
+vi.mock('./search-rate-limit', () => ({ rateLimitSearchRoute: async () => null }));
+
+// Minimal stand-in for caches.default (Cloudflare Cache API), keyed by the cache-key URL.
+function makeFakeCache() {
+  const store = new Map<
+    string,
+    { body: string; status: number; statusText: string; headers: [string, string][] }
+  >();
+  return {
+    store,
+    async match(req: Request | string) {
+      const url = typeof req === 'string' ? req : req.url;
+      const e = store.get(url);
+      return e
+        ? new Response(e.body, {
+            status: e.status,
+            statusText: e.statusText,
+            headers: new Headers(e.headers),
+          })
+        : undefined;
+    },
+    async put(req: Request | string, res: Response) {
+      const url = typeof req === 'string' ? req : req.url;
+      store.set(url, {
+        body: await res.text(),
+        status: res.status,
+        statusText: res.statusText,
+        headers: [...res.headers] as [string, string][],
+      });
+    },
+  };
+}
+
+const fakeCache = makeFakeCache();
+let worker: { fetch: (r: Request, env: unknown, ctx: unknown) => Promise<Response> };
+
+beforeAll(async () => {
+  // edgeCache = caches.default is captured at module load, so stub before importing app.ts.
+  vi.stubGlobal('caches', { default: fakeCache });
+  worker = ((await import('./app')) as { default: typeof worker }).default;
+});
+
+beforeEach(() => fakeCache.store.clear());
+
+async function get(url: string) {
+  const waits: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => void waits.push(p),
+    passThroughOnException: () => {},
+  };
+  const res = await worker.fetch(new Request(url), {}, ctx);
+  const body = await res.clone().text();
+  await Promise.all(waits); // let edgeCache.put (ctx.waitUntil) settle before the next request
+  return { edge: res.headers.get('X-Edge-Cache'), body };
+}
+
+describe('app.ts edge cache middleware', () => {
+  it('caches per response — a repeated GET HITs', async () => {
+    expect((await get('https://x/contracts')).edge).toBe('MISS');
+    expect((await get('https://x/contracts')).edge).toBe('HIT');
+  });
+
+  it('never serves the ?bids=1 body for /contracts (CWE-349, #56)', async () => {
+    const primed = await get('https://x/contracts?bids=1'); // primes the bids=1 entry first
+    expect(primed.edge).toBe('MISS');
+    expect(primed.body).toContain('single-bid only');
+
+    const broad = await get('https://x/contracts'); // distinct key -> MISS, its own body
+    expect(broad.edge).toBe('MISS');
+    expect(broad.body).toContain('all contracts');
+    expect(broad.body).not.toContain('single-bid only'); // the poisoning the fix prevents
+  });
+});

--- a/apps/web/workers/cache-key.test.ts
+++ b/apps/web/workers/cache-key.test.ts
@@ -1,8 +1,50 @@
 import { describe, expect, it } from 'vitest';
-import { cacheKey } from './cache-key';
+import { cacheKey, CACHE_QUERY_PARAMS, INTENTIONALLY_UNKEYED } from './cache-key';
 
 function cacheUrl(input: string): URL {
   return new URL(cacheKey(new Request(input), 'deploy-test').url);
+}
+
+// The edge cache stores rendered SSR HTML, so anything read off the URL during the server render can
+// change the response: route loaders, the shared URL-filter helper (companyListParams /
+// singleSelectFilters / pageNav), AND server-rendered components (e.g. SiteHeader reads `q`). So we
+// scan the whole app/ tree, not just loaders. Loaded as raw text through Vite's glob (workers/* is
+// typed for the Cloudflare runtime, so no Node fs here).
+const APP_SOURCES: Record<string, string> = import.meta.glob('../app/**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+// Statically collect every query param those sources read off the URL. Anchored on the
+// URLSearchParams access patterns actually used so it ignores FormData.get() / Headers.has():
+//   - a var named sp/searchParams/base, the inline `.searchParams` chain, an inline
+//     `new URLSearchParams(...).get(...)` (e.g. root.tsx), and the getMulti() helper.
+// Known, accepted blind spots (guard-completeness, not live leaks today):
+//   - Dynamic keys: `sp.get(someVar)` can't be resolved statically. All current dynamic reads use
+//     a fixed key set already covered here; a future one would slip past — keep keys literal.
+//   - Scope: only app/** is scanned. workers/** is excluded because its param reads are
+//     infrastructure that does NOT shape the cached body — e.g. request-log.ts reads `q` purely for
+//     telemetry (q_present/q_len), and cacheKey itself does the keying. Widening to workers/** would
+//     wrongly force log-/rate-limit-only reads into the key. If a worker ever reads a param to shape
+//     a cached response, key it explicitly here (better: move that read into a loader under app/).
+//   - A new URLSearchParams binding name (other than sp/searchParams/base) needs a pattern added here.
+function consumedQueryParams(): Set<string> {
+  const patterns = [
+    /(?:\bsp|\bsearchParams|\bbase|\.searchParams|URLSearchParams\([^)]*\))\.(?:get|getAll|has)\(\s*['"]([A-Za-z_]\w*)['"]/g,
+    /\bgetMulti\(\s*\w+\s*,\s*['"]([A-Za-z_]\w*)['"]/g,
+  ];
+
+  const found = new Set<string>();
+  for (const [path, src] of Object.entries(APP_SOURCES)) {
+    if (path.includes('.test.')) continue;
+    for (const re of patterns) {
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) found.add(m[1]);
+    }
+  }
+  return found;
 }
 
 describe('cacheKey', () => {
@@ -62,5 +104,36 @@ describe('cacheKey', () => {
   it('falls back to the raw pathname for malformed percent-encoding', () => {
     expect(() => cacheUrl('http://local/contracts/%')).not.toThrow();
     expect(cacheUrl('http://local/contracts/%').pathname).toBe('/contracts/%');
+  });
+
+  it('keys response-affecting params so they cannot collapse to one cache entry (CWE-349, #56)', () => {
+    // ?bids=1 narrows /contracts to single-bid contracts — different rows and totals.
+    expect(cacheUrl('http://local/contracts?bids=1').search).not.toBe(
+      cacheUrl('http://local/contracts').search,
+    );
+    // Same cursor, different page marker => different rank numbers in the rendered HTML.
+    expect(cacheUrl('http://local/contracts?cursor=c5&page=2').search).not.toBe(
+      cacheUrl('http://local/contracts?cursor=c5&page=5').search,
+    );
+  });
+});
+
+describe('CACHE_QUERY_PARAMS drift guard', () => {
+  it('covers every query param the app reads off the URL', () => {
+    const consumed = consumedQueryParams();
+    // Sanity: the scanner must actually find params, else a regex/glob change silently disarms it.
+    expect(consumed.size).toBeGreaterThan(10);
+    expect(consumed.has('bids')).toBe(true);
+    expect(consumed.has('page')).toBe(true);
+
+    const allowed = new Set([...CACHE_QUERY_PARAMS, ...INTENTIONALLY_UNKEYED]);
+    const undeclared = [...consumed].filter((p) => !allowed.has(p)).sort();
+    expect(undeclared).toEqual([]);
+  });
+
+  it('does not retain allow-list entries that nothing reads', () => {
+    const consumed = consumedQueryParams();
+    const stale = [...CACHE_QUERY_PARAMS].filter((p) => !consumed.has(p)).sort();
+    expect(stale).toEqual([]);
   });
 });

--- a/apps/web/workers/cache-key.ts
+++ b/apps/web/workers/cache-key.ts
@@ -1,7 +1,14 @@
-// Keep this allow-list in sync with query params consumed by apps/web/app/routes loaders.
+// Response-affecting query params: every param a route loader (or the SSR render it feeds) reads off
+// the URL must be in this set, or two URLs that yield different responses collapse to one cache entry
+// (CWE-349, see issue #56). Keep it in sync with what apps/web/app/{routes,lib/filters.ts} consume.
+// The drift guard in cache-key.test.ts statically scans those sources and fails CI if a consumed
+// param is missing here (or from INTENTIONALLY_UNKEYED below), so the common case — a literal-key
+// read — can't drift unnoticed. It is not absolute: cache-key.test.ts documents the blind spots it
+// can't see (dynamic keys like sel(k), and workers/** is out of scope).
 export const CACHE_QUERY_PARAMS = new Set([
   'authority',
   'bidder',
+  'bids', // /contracts: c.bids_received = 1 — changes the result set and headline totals
   'center',
   'count',
   'cursor',
@@ -10,15 +17,25 @@ export const CACHE_QUERY_PARAMS = new Set([
   'g',
   'kind',
   'p',
+  'page', // pageNav: rank offset + "page N of M" in the HTML, but only when cursor is set. Keyed
+  // unconditionally — without cursor it's a harmless over-key (never a wrong body); simpler than
+  // coupling the key to cursor presence, and q/cursor already make key cardinality client-unbounded.
   'procedure',
   'q',
   'sector',
   'sort',
-  'top',
+  'top', // singleSelectFilters: top-20 vs top-50 on /flows and /competition
   'type',
   'value',
   'year',
 ]);
+
+// Params a loader reads but that intentionally do NOT change the response (so they're safe to omit
+// from the cache key). None exist today — every consumed param affects output. This constant is not
+// dead: the drift guard treats `consumed ⊆ CACHE_QUERY_PARAMS ∪ INTENTIONALLY_UNKEYED` as the
+// invariant, so any future read-but-ignored param must be listed here with a justification rather
+// than silently absent.
+export const INTENTIONALLY_UNKEYED = new Set<string>([]);
 
 export function cacheKey(request: Request, deployTag: string): Request {
   const url = new URL(request.url);


### PR DESCRIPTION
## Проблем

`cacheKey()` (`apps/web/workers/cache-key.ts`) строи edge-cache ключа от ръчно поддържан allow-list `CACHE_QUERY_PARAMS`. Параметър извън списъка се изхвърля от ключа. Списъкът е излязъл от синхрон с това, което loader-ите реално четат:

- **`bids` липсваше.** `/contracts` чете `?bids=1` (`contracts.tsx:62`) → SQL филтър `c.bids_received = 1` (`packages/db/src/queries/contracts.ts:148`). `/contracts` и `/contracts?bids=1` връщат различни резултати и различни обобщени суми, но collapse-ват в един и същ кеш ключ — непараметризиран вход за кеша (CWE-349): първият кеширан вариант се сервира и за другия.
- **`page` имаше същия дефект** (открит при одита). Чете се през `pageNav` (`lib/filters.ts`) и определя ранг-отместването и „страница N от M“ в SSR HTML-а. При еднакъв `cursor` и различен `page` се рендира различен HTML, но кеш ключът беше еднакъв.

## Поправка

- Добавени `bids` и `page` към `CACHE_QUERY_PARAMS`.
- **`top` се запазва.** Първоначалната диагноза го смяташе за остарял, но се чете от `singleSelectFilters` (`lib/filters.ts:70`) за `/flows` и `/competition` (top-20 / top-50). Премахването му би създало нов cache-poisoning дефект. Нищо в списъка не е остаряло.
- Нова `INTENTIONALLY_UNKEYED` константа (днес празна) за параметри, които съзнателно не влияят на отговора — за да не липсват мълчаливо.
- **Тест срещу разминаване на allow-list-а** (`cache-key.test.ts`): статично сканира **целия `app/**`** (loader-ите, споделения URL-filter helper и server-рендираните компоненти — кешът пази SSR HTML, затова четене в компонент като `q` в `SiteHeader` също влияе), зареден като суров текст през `import.meta.glob`, и проверява инварианта `consumed ⊆ CACHE_QUERY_PARAMS ∪ INTENTIONALLY_UNKEYED`, както и че няма остарели записи. Анкериран към реалните форми за достъп (`sp`/`searchParams`/`base`/`.searchParams`, `new URLSearchParams(...).get(...)`, `getMulti()`), за да не лови `FormData.get()` / `Headers.has()`. Пада при бъдещо разминаване.
- **Тест на middleware-а** (`app.cache.test.ts`): задвижва реалния кеш-път в `app.ts` (`handleRequest` → `cacheKey` → `edgeCache.match/put`) с in-memory `caches.default` и stub request handler; гарантира, че primed запис за `/contracts?bids=1` никога не се сервира за `/contracts`. Без SSR build, D1 или fixtures и **без промяна по `app.ts`**.

Ключът остава детерминистичен (`params.sort()` + `_dt`). Без промяна по caching middleware-а.

## Обхват на одита

Проследени са всички пътища за четене на query параметри по време на SSR — loader-ите, четенето в компонентите (`useSearchParams`, `sel()` обвивки, динамичните ключове във `FilterRail`), `root.tsx` и слоят за заявки в `packages/db`. Пълният консумиран набор е точно 20-те параметъра, които вече са в ключа; няма непараметризиран параметър, който влияе на отговора. Никъде няма масово извличане (`Object.fromEntries` / spread на `searchParams`), така че моделът с allow-list е коректен.

## Проверка

**Три детерминистични CI гейта** (без fixtures, без нови зависимости):
1. `cacheKey` unit тест — различни ключове за `/contracts?bids=1` и `/contracts` (+ `page` при еднакъв `cursor`).
2. Тест срещу разминаване — `consumed ⊆ keyed`, върху целия `app/**`.
3. Тест на `app.ts` middleware — реалният кеш-път не отравя кеша.

**Adversarial негативни проверки** (всяка върната след това):
- Премахване на `bids` или `page` → unit гейтът и гейтът срещу разминаване падат.
- Премахване на `bids` → middleware тестът връща `HIT` с грешния body — `expected 'HIT' to be 'MISS'`.
- Инжектиране на четене на нов параметър в компонент или през `new URLSearchParams().get()` → гейтът срещу разминаване го хваща; `FormData`/`Headers` четене → не дава фалшив сигнал.

**Локална репродукция през miniflare** (реалният `app.ts` кеш, наблюдаван през `X-Edge-Cache`, със seed данни в локалния D1):

| Стъпка | С поправката | Без поправката |
|---|---|---|
| prime `?bids=1` | `MISS` → 2 договора | `MISS` → 2 договора |
| `/contracts` | `MISS` → 5 договора ✅ | `HIT` → 2 договора ☠️ отровено |

- `pnpm --filter web test` — 89/89 зелени.
- `pnpm --filter web typecheck` (`tsc -b`) — 0 грешки.
- Prettier — чисто.

Closes #56
