### PR TITLE
feat(web): interactive network graph — edge values, browse in place, collision-guarded

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2497,6 +2497,94 @@ details.row .body .signal .why {
   fill: var(--ink, #111);
   font: 11px var(--font-mono, monospace);
 }
+/* Per-edge value label, rotated in the component to lie along the edge. A thick white halo
+   (paint-order: stroke) keeps the number readable where it crosses edges/nodes. Toggle hides it. */
+.network-svg .edge-label {
+  fill: var(--ink, #222);
+  font: 600 10px var(--font-mono, monospace);
+  paint-order: stroke;
+  stroke: #fff;
+  stroke-width: 3.25px;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+/* Non-centre nodes are anchors to a profile page → show the click affordance and an accent ring. */
+.network-svg a {
+  cursor: pointer;
+}
+.network-svg a:hover .node,
+.network-svg a:focus-visible .node {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+}
+.network-svg a:focus-visible {
+  outline: none;
+}
+/* Edge-label toggle (pure CSS, no JS): unchecked hides every .edge-label. */
+/* Controls row above the graph: the edge-value toggle plus, once you've browsed to another node,
+   the Open / Reset actions. Wraps on narrow screens. */
+.net-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  margin: 0 0 8px;
+}
+.net-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 12px var(--font-mono, monospace);
+  color: var(--ink-soft, #555);
+  cursor: pointer;
+  user-select: none;
+}
+.net-toggle input {
+  accent-color: var(--accent);
+}
+.net-graph:has(.net-toggle input:not(:checked)) .edge-label {
+  display: none;
+}
+/* Browse actions — appear only after a client-side re-centre (no JS = no recentre = hidden). */
+.net-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.net-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font: 600 12px var(--font-mono, monospace);
+  color: #fff;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+}
+.net-btn:hover {
+  filter: brightness(0.94);
+}
+.net-btn-ghost {
+  color: var(--ink, #222);
+  background: transparent;
+  border-color: var(--rule, #d8d6cf);
+}
+.net-loading {
+  font: 12px var(--font-mono, monospace);
+  color: var(--ink-soft, #555);
+}
+.net-hint {
+  font: 12px var(--font-mono, monospace);
+  color: var(--ink-soft, #888);
+}
+.net-error {
+  font: 12px var(--font-mono, monospace);
+  color: var(--danger, #b3261e);
+}
 .net-legend {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/app/components/NetworkGraph.tsx
+++ b/apps/web/app/components/NetworkGraph.tsx
@@ -1,16 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from 'react-router';
 import type { NetworkData, NetworkNode } from '@sigma/api-contract';
-import { money } from '@sigma/shared';
+import { count, money, moneyBare } from '@sigma/shared';
 
-// Static server-rendered radial ego graph (no chart JS, like SankeyDiagram). Centre in the middle,
-// direct counterparties on an inner ring, their top other counterparty on an outer ring. Node size is
-// the sum of incident edge values; edge thickness is the flow value. The accessible data is the
-// connections table beside it; this SVG is a visual summary (role="img" + aria-label).
-const W = 760;
-const H = 540;
+// Server-rendered radial ego graph (no chart JS, like SankeyDiagram). Centre in the middle, direct
+// counterparties on an inner ring, their top other counterparty on an outer ring. Node size is the sum
+// of incident edge values; edge thickness is the flow value. Each edge carries a midpoint value label
+// (toggled by a pure-CSS checkbox).
+//
+// Progressive enhancement — the URL never changes while you browse:
+//  • No JS (SSR / crawlers): each non-centre node is a plain <a> to that entity's profile page.
+//  • With JS (hydrated): clicking a node RE-CENTRES the graph in place — it fetches that node's own
+//    ego-network from the /network loader (the canonical network-data route) via useFetcher and
+//    redraws, leaving the URL untouched. Two controls then appear: "Отвори профила" jumps to the
+//    focused node's page, and "Върни се в началото" resets the graph to the entity the URL points at.
+//    The accessible navigation path is the connections table beside the graph (its cells are links);
+//    this SVG is a visual summary (role="img").
+const W = 820;
+const H = 600;
 const CX = W / 2;
 const CY = H / 2;
-const R1 = 150;
-const R2 = 250;
+const R1 = 170;
+const R2 = 300;
+const LABEL_GAP = 17; // min vertical px between two node labels on the same side (collision guard)
 // Palette tokens only: the centre is the accent, authorities and companies sit on the ink scale and
 // are told apart by shape (circle vs square) + the legend, not by an off-palette blue/green pair.
 const CENTER_FILL = 'var(--accent)'; // centre (focus)
@@ -21,9 +33,60 @@ function truncate(s: string, n = 22): string {
   return s.length > n ? `${s.slice(0, n - 1)}…` : s;
 }
 
+// Each non-centre node's profile (hero) page — the no-JS click target and the "Open" button target.
+const heroHref = (n: { kind: string; slug: string }) =>
+  n.kind === 'authority' ? `/authorities/${n.slug}` : `/companies/${n.slug}`;
+
+// The /network loader's ?center grammar (parsed by parseCenter there): a:<authority-slug> | c:<company-slug>.
+const centerToken = (n: { kind: string; slug: string }) =>
+  `${n.kind === 'authority' ? 'a' : 'c'}:${n.slug}`;
+
 export function NetworkGraph({ data }: { data: NetworkData }) {
-  const { nodes, edges, center } = data;
-  // Defensive guard so the component is safe on its own; network.tsx also gates on the same condition.
+  // `data` is the root ego-network the page rendered server-side (matches the URL). When the user
+  // browses, we hold the re-centred network here; null = showing the root.
+  const fetcher = useFetcher<{ data: NetworkData }>();
+  const [browsed, setBrowsed] = useState<NetworkData | null>(null);
+  const [failed, setFailed] = useState(false);
+  // True between a node click and the adoption of its result. Lets Reset cancel an in-flight load so a
+  // late-arriving fetch can't snap the graph back, and stops us re-adopting stale fetcher.data.
+  const pending = useRef(false);
+  const resetRef = useRef<HTMLButtonElement>(null);
+
+  // The component stays mounted across navigations (RR does not remount on a param/route change), so a
+  // stale `browsed` would otherwise survive a dropdown change on /network or a hop between profiles.
+  // Reset it whenever the page's root network changes.
+  useEffect(() => {
+    setBrowsed(null);
+    setFailed(false);
+    pending.current = false;
+  }, [data]);
+
+  // Adopt a completed re-centre — but only if it's still wanted (Reset clears `pending`) and valid
+  // (has a centre and ≥2 nodes, so the render guard below can never strip the component mid-session).
+  useEffect(() => {
+    if (!pending.current || fetcher.state !== 'idle') return;
+    pending.current = false;
+    const next = fetcher.data?.data;
+    if (next?.center && next.nodes.length >= 2) {
+      setBrowsed(next);
+      setFailed(false);
+    } else {
+      setFailed(true);
+    }
+  }, [fetcher.state, fetcher.data]);
+
+  // After adopting a re-centre, move keyboard focus to Reset (the way back) so focus isn't lost to
+  // <body> when the clicked node is replaced by the non-interactive centre.
+  useEffect(() => {
+    if (browsed) resetRef.current?.focus();
+  }, [browsed]);
+
+  const current = browsed ?? data;
+  const loading = fetcher.state === 'loading';
+  const recentred = Boolean(current.center && data.center && current.center.id !== data.center.id);
+
+  const { nodes, edges, center } = current;
+  // Defensive guard so the component is safe on its own; callers also gate on the same condition.
   if (!center || nodes.length < 2) return null;
 
   const hop1 = nodes.filter((n) => n.hop === 1);
@@ -50,6 +113,22 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
     pos.set(n.id, { x: CX + Math.cos(a) * R2, y: CY + Math.sin(a) * R2 });
   });
 
+  // Collision guard for node labels: labels are anchored to the left or right of their node, so two
+  // nodes close in y on the same side would overlap. Within each side, sort by y and push each label
+  // down until it clears the previous one by LABEL_GAP. Deterministic, server-renderable (no measuring).
+  const labelY = new Map<string, number>();
+  for (const rightSide of [false, true]) {
+    const side = [...pos.entries()]
+      .filter(([, p]) => (rightSide ? p.x >= CX : p.x < CX))
+      .sort((a, b) => a[1].y - b[1].y);
+    let prev = -Infinity;
+    for (const [id, p] of side) {
+      const y = Math.max(p.y, prev + LABEL_GAP);
+      labelY.set(id, y);
+      prev = y;
+    }
+  }
+
   const maxVal = Math.max(1, ...nodes.map((n) => n.valueEur));
   const radius = (n: NetworkNode) => 6 + Math.sqrt(n.valueEur / maxVal) * 22;
   const maxEdge = Math.max(1, ...edges.map((e) => e.valueEur));
@@ -57,8 +136,53 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
   const fill = (n: NetworkNode) =>
     n.hop === 0 ? CENTER_FILL : n.kind === 'authority' ? AUTH_FILL : COMP_FILL;
 
+  // Re-centre on a node without navigating: load that node's ego-network from the /network loader.
+  const recentre = (n: NetworkNode) => {
+    setFailed(false);
+    pending.current = true;
+    fetcher.load(`/network?center=${centerToken(n)}`);
+  };
+  const reset = () => {
+    pending.current = false;
+    setFailed(false);
+    setBrowsed(null);
+  };
+
   return (
-    <>
+    <div className="net-graph" aria-busy={loading || undefined}>
+      <div className="net-controls">
+        {/* Pure-CSS toggle: when unchecked, `.net-graph:has(input:not(:checked)) .edge-label` hides the
+            midpoint value labels — no client JS needed for this part. Default on. */}
+        <label className="net-toggle">
+          <input type="checkbox" defaultChecked />
+          Стойности по връзките
+        </label>
+        {recentred ? (
+          <span className="net-actions">
+            {/* Focused on {center.label} — jump to its page, or reset back to the URL's entity. */}
+            <a className="net-btn" href={heroHref(center)}>
+              Отвори профила →
+            </a>
+            <button ref={resetRef} type="button" className="net-btn net-btn-ghost" onClick={reset}>
+              Върни се в началото
+            </button>
+          </span>
+        ) : (
+          <span className="net-hint" aria-hidden="true">
+            Клик върху възел пренасочва графа
+          </span>
+        )}
+        {loading && (
+          <span className="net-loading" role="status">
+            Зареждане…
+          </span>
+        )}
+        {failed && !loading && (
+          <span className="net-error" role="status">
+            Връзката не можа да се зареди. Опитай пак.
+          </span>
+        )}
+      </div>
       {/* Sankey-style horizontal scroll so the fixed-width graph does not squash on phones; the
           connections table below is the accessible fallback. */}
       <div className="flow-scroll">
@@ -72,16 +196,46 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
             const a = pos.get(e.from);
             const b = pos.get(e.to);
             if (!a || !b) return null;
+            const dx = b.x - a.x;
+            const dy = b.y - a.y;
+            const L = Math.hypot(dx, dy) || 1;
+            // Rotate the value label to lie along the edge, kept upright (never upside-down), and nudged
+            // off the line along its perpendicular so the number does not sit on top of the stroke.
+            let deg = (Math.atan2(dy, dx) * 180) / Math.PI;
+            if (deg > 90) deg -= 180;
+            else if (deg < -90) deg += 180;
+            // Bias the label toward the OUTER node (`to` is always the more-peripheral endpoint) so the
+            // labels of the spokes radiating from the hub fan out instead of piling up on the centre,
+            // and nudge it off the line along the perpendicular.
+            const t = 0.62;
+            const off = 10;
+            const lx = a.x + dx * t + (-dy / L) * off;
+            const ly = a.y + dy * t + (dx / L) * off;
             return (
-              <line
-                key={`e${i}`}
-                className="edge"
-                x1={a.x}
-                y1={a.y}
-                x2={b.x}
-                y2={b.y}
-                style={{ strokeWidth: strokeW(e.valueEur) }}
-              />
+              <g key={`e${i}`}>
+                <line
+                  className="edge"
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  style={{ strokeWidth: strokeW(e.valueEur) }}
+                >
+                  <title>{`${money(e.valueEur)} · ${count(e.contracts)} ${
+                    e.contracts === 1 ? 'договор' : 'договора'
+                  }`}</title>
+                </line>
+                <text
+                  className="edge-label"
+                  x={lx}
+                  y={ly}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  transform={`rotate(${deg} ${lx} ${ly})`}
+                >
+                  {moneyBare(e.valueEur)}
+                </text>
+              </g>
             );
           })}
           {nodes.map((n) => {
@@ -89,35 +243,60 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
             if (!pt) return null;
             const r = radius(n);
             const right = pt.x >= CX;
-            const label = `${n.label}: ${money(n.valueEur)}`;
-            return (
-              <g key={n.id}>
-                {n.kind === 'company' ? (
-                  <rect
-                    className="node"
-                    x={pt.x - r}
-                    y={pt.y - r}
-                    width={r * 2}
-                    height={r * 2}
-                    rx={3}
-                    style={{ fill: fill(n) }}
-                  >
-                    <title>{label}</title>
-                  </rect>
-                ) : (
-                  <circle className="node" cx={pt.x} cy={pt.y} r={r} style={{ fill: fill(n) }}>
-                    <title>{label}</title>
-                  </circle>
-                )}
-                <text
-                  className="node-label"
-                  x={right ? pt.x + r + 4 : pt.x - r - 4}
-                  y={pt.y + 3}
-                  textAnchor={right ? 'start' : 'end'}
+            const isCenter = n.hop === 0;
+            const title = `${n.label}: ${money(n.valueEur)}`;
+            const shape =
+              n.kind === 'company' ? (
+                <rect
+                  className="node"
+                  x={pt.x - r}
+                  y={pt.y - r}
+                  width={r * 2}
+                  height={r * 2}
+                  rx={3}
+                  style={{ fill: fill(n) }}
                 >
-                  {truncate(n.label)}
-                </text>
+                  <title>{title}</title>
+                </rect>
+              ) : (
+                <circle className="node" cx={pt.x} cy={pt.y} r={r} style={{ fill: fill(n) }}>
+                  <title>{title}</title>
+                </circle>
+              );
+            const text = (
+              <text
+                className="node-label"
+                x={right ? pt.x + r + 4 : pt.x - r - 4}
+                y={(labelY.get(n.id) ?? pt.y) + 3}
+                textAnchor={right ? 'start' : 'end'}
+              >
+                {truncate(n.label)}
+              </text>
+            );
+            // Centre node is the current focus → not a link. Every other node is an anchor to its
+            // profile page (the no-JS fallback). With JS, the click is intercepted and re-centres the
+            // graph in place instead; "Отвори профила" is the explicit way to follow the link.
+            return isCenter ? (
+              <g key={n.id}>
+                {shape}
+                {text}
               </g>
+            ) : (
+              <a
+                key={n.id}
+                href={heroHref(n)}
+                aria-label={`Пренасочи графа към ${n.label}`}
+                onClick={(ev) => {
+                  // Honour new-tab / modifier clicks → let the browser follow the href.
+                  if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.button !== 0)
+                    return;
+                  ev.preventDefault();
+                  recentre(n);
+                }}
+              >
+                {shape}
+                {text}
+              </a>
             );
           })}
         </svg>
@@ -133,6 +312,6 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
           <span className="key company" /> Фирма
         </li>
       </ul>
-    </>
+    </div>
   );
 }

--- a/apps/web/app/components/NetworkGraph.tsx
+++ b/apps/web/app/components/NetworkGraph.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useFetcher } from 'react-router';
 import type { NetworkData, NetworkNode } from '@sigma/api-contract';
 import { count, money, moneyBare } from '@sigma/shared';
+import { centerToken, isAdoptableNetwork } from '../lib/network-center';
 
 // Server-rendered radial ego graph (no chart JS, like SankeyDiagram). Centre in the middle, direct
 // counterparties on an inner ring, their top other counterparty on an outer ring. Node size is the sum
@@ -34,12 +35,9 @@ function truncate(s: string, n = 22): string {
 }
 
 // Each non-centre node's profile (hero) page — the no-JS click target and the "Open" button target.
+// (centerToken — the `?center` grammar — is shared with the loader via ../lib/network-center.)
 const heroHref = (n: { kind: string; slug: string }) =>
   n.kind === 'authority' ? `/authorities/${n.slug}` : `/companies/${n.slug}`;
-
-// The /network loader's ?center grammar (parsed by parseCenter there): a:<authority-slug> | c:<company-slug>.
-const centerToken = (n: { kind: string; slug: string }) =>
-  `${n.kind === 'authority' ? 'a' : 'c'}:${n.slug}`;
 
 export function NetworkGraph({ data }: { data: NetworkData }) {
   // `data` is the root ego-network the page rendered server-side (matches the URL). When the user
@@ -67,7 +65,7 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
     if (!pending.current || fetcher.state !== 'idle') return;
     pending.current = false;
     const next = fetcher.data?.data;
-    if (next?.center && next.nodes.length >= 2) {
+    if (next && isAdoptableNetwork(next)) {
       setBrowsed(next);
       setFailed(false);
     } else {
@@ -273,14 +271,13 @@ export function NetworkGraph({ data }: { data: NetworkData }) {
                 {truncate(n.label)}
               </text>
             );
-            // Centre node is the current focus → not a link. Every other node is an anchor to its
-            // profile page (the no-JS fallback). With JS, the click is intercepted and re-centres the
-            // graph in place instead; "Отвори профила" is the explicit way to follow the link.
+            // Centre node is the current focus → not a link. It also carries NO text label: it is
+            // already named in the page title, the centre dropdown and the legend (the only accent
+            // node), and a label here would collide with a neighbour or sit on an edge (aligns with
+            // #124). Every other node is an anchor to its profile page (the no-JS fallback); with JS
+            // the click is intercepted and re-centres the graph in place ("Отвори профила" follows it).
             return isCenter ? (
-              <g key={n.id}>
-                {shape}
-                {text}
-              </g>
+              <g key={n.id}>{shape}</g>
             ) : (
               <a
                 key={n.id}

--- a/apps/web/app/lib/entity-tables.tsx
+++ b/apps/web/app/lib/entity-tables.tsx
@@ -1,10 +1,13 @@
+import { Link } from 'react-router';
 import { count, money, signedPct } from '@sigma/shared';
 import type { NetworkData, TrendYear } from '@sigma/api-contract';
 import { type Column } from '../components/DataTable';
 
 export interface LinkRow {
   from: string;
+  fromHref: string;
   to: string;
+  toHref: string;
   valueEur: number;
   contracts: number;
 }
@@ -32,8 +35,13 @@ export const trendYearColumns: Column<TrendYear>[] = [
 ];
 
 export const networkColumns: Column<LinkRow>[] = [
-  { key: 'from', header: 'От', isTitle: true, cell: (r) => r.from },
-  { key: 'to', header: 'Към', cell: (r) => r.to },
+  {
+    key: 'from',
+    header: 'От',
+    isTitle: true,
+    cell: (r) => (r.fromHref ? <Link to={r.fromHref}>{r.from}</Link> : r.from),
+  },
+  { key: 'to', header: 'Към', cell: (r) => (r.toHref ? <Link to={r.toHref}>{r.to}</Link> : r.to) },
   { key: 'value', header: 'Стойност', align: 'money', cell: (r) => money(r.valueEur) },
   {
     key: 'contracts',
@@ -53,7 +61,9 @@ export function networkRows(data: NetworkData): LinkRow[] {
     const company = a?.kind === 'authority' ? b : a;
     return {
       from: authority?.label ?? e.from,
+      fromHref: authority ? `/authorities/${authority.slug}` : '',
       to: company?.label ?? e.to,
+      toHref: company ? `/companies/${company.slug}` : '',
       valueEur: e.valueEur,
       contracts: e.contracts,
     };

--- a/apps/web/app/lib/network-center.test.ts
+++ b/apps/web/app/lib/network-center.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { authoritySlug, companySlug } from '@sigma/db';
+import type { NetworkData } from '@sigma/api-contract';
+import { centerToken, isAdoptableNetwork, parseCenter } from './network-center';
+
+// The re-centre link side (centerToken) and the loader side (parseCenter) MUST agree on the `?center`
+// grammar, or re-centring breaks silently (the component lands in `failed` with no error). These tests
+// pin that contract and the slug round-trip for every node kind.
+describe('centerToken ↔ parseCenter round-trip', () => {
+  it('round-trips an authority (ЕИК slug)', () => {
+    const id = 'auth:000695089';
+    const token = centerToken({ kind: 'authority', slug: authoritySlug(id) });
+    expect(token).toBe('a:000695089');
+    expect(parseCenter(token)).toEqual({ kind: 'authority', id });
+  });
+
+  it('round-trips a company with a valid ЕИК', () => {
+    const id = 'eik:131063188';
+    const token = centerToken({ kind: 'company', slug: companySlug(id) });
+    expect(token).toBe('c:131063188');
+    expect(parseCenter(token)).toEqual({ kind: 'company', id });
+  });
+
+  it('round-trips a name-keyed company (base64url slug — URL-safe, no stray colon)', () => {
+    const id = 'name:ТЕСТ ООД';
+    const slug = companySlug(id);
+    const token = centerToken({ kind: 'company', slug });
+    expect(slug.startsWith('n')).toBe(true);
+    // Whole token is URL-safe; the only ':' is the grammar separator (so no encodeURIComponent needed).
+    expect(token).toMatch(/^c:n[A-Za-z0-9_-]+$/);
+    expect(parseCenter(token)).toEqual({ kind: 'company', id });
+  });
+});
+
+describe('parseCenter rejects malformed tokens (no silent mis-parse)', () => {
+  it.each([null, '', 'x', 'a:', ':abc', 'z:abc', 'c:!!!', 'c:n@@@'])('returns null for %p', (t) => {
+    expect(parseCenter(t)).toBeNull();
+  });
+});
+
+describe('isAdoptableNetwork', () => {
+  const center = { id: 'auth:1', kind: 'authority', label: 'C', slug: '1', valueEur: 1, hop: 0 };
+  const node = { id: 'eik:2', kind: 'company', label: 'N', slug: '2', valueEur: 1, hop: 1 };
+  const net = (center: unknown, nodes: unknown[]) =>
+    ({ center, nodes, edges: [] }) as unknown as NetworkData;
+
+  it('rejects null, a missing centre, or a centre-only (<2 node) result', () => {
+    expect(isAdoptableNetwork(null)).toBe(false);
+    expect(isAdoptableNetwork(net(null, []))).toBe(false);
+    expect(isAdoptableNetwork(net(center, [center]))).toBe(false);
+  });
+
+  it('accepts a centre with at least one neighbour', () => {
+    expect(isAdoptableNetwork(net(center, [center, node]))).toBe(true);
+  });
+});

--- a/apps/web/app/lib/network-center.ts
+++ b/apps/web/app/lib/network-center.ts
@@ -1,0 +1,32 @@
+import { authorityIdFromSlug, bidderIdFromSlug, type NetworkParams } from '@sigma/db';
+import type { NetworkData } from '@sigma/api-contract';
+
+// The /network `?center` grammar — `a:<authority-slug>` | `c:<company-slug>` — lives here once so the
+// link/re-centre side (centerToken) and the loader side (parseCenter) share a single definition and
+// can never drift apart (a drift would break re-centring silently). See routes/network.tsx (loader)
+// and components/NetworkGraph.tsx (re-centre).
+
+export function centerToken(n: { kind: string; slug: string }): string {
+  return `${n.kind === 'authority' ? 'a' : 'c'}:${n.slug}`;
+}
+
+export function parseCenter(token: string | null): NetworkParams | null {
+  if (!token) return null;
+  const i = token.indexOf(':');
+  if (i < 1) return null;
+  const kind = token.slice(0, i);
+  const slug = token.slice(i + 1);
+  if (kind === 'a' && slug) return { kind: 'authority', id: authorityIdFromSlug(slug) };
+  if (kind === 'c' && slug) {
+    const id = bidderIdFromSlug(slug);
+    return id ? { kind: 'company', id } : null;
+  }
+  return null;
+}
+
+// A re-centre fetch result is adoptable only if it is a real, non-trivial ego-network (has a centre
+// and ≥2 nodes). Otherwise NetworkGraph's render guard would strip the whole component mid-session,
+// stranding the user with no way back. Pure so it can be unit-tested.
+export function isAdoptableNetwork(next: NetworkData | null | undefined): boolean {
+  return Boolean(next?.center && next.nodes.length >= 2);
+}

--- a/apps/web/app/routes/network.tsx
+++ b/apps/web/app/routes/network.tsx
@@ -1,11 +1,6 @@
 import { Form, Link, useNavigation, useSubmit } from 'react-router';
 import { count, money } from '@sigma/shared';
-import {
-  authorityIdFromSlug,
-  bidderIdFromSlug,
-  getEntityNetwork,
-  type NetworkParams,
-} from '@sigma/db';
+import { getEntityNetwork } from '@sigma/db';
 import type { Route } from './+types/network';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -13,6 +8,7 @@ import { DataTable, type Column } from '../components/DataTable';
 import { NetworkGraph } from '../components/NetworkGraph';
 import { Callout, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
+import { centerToken, parseCenter } from '../lib/network-center';
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -27,21 +23,6 @@ export function meta(_: Route.MetaArgs) {
 
 export function headers() {
   return { 'Cache-Control': publicCache(1800) };
-}
-
-// ?center=a:<eik> | c:<slug>; null falls back to the biggest authority in the query layer.
-function parseCenter(token: string | null): NetworkParams | null {
-  if (!token) return null;
-  const i = token.indexOf(':');
-  if (i < 1) return null;
-  const kind = token.slice(0, i);
-  const slug = token.slice(i + 1);
-  if (kind === 'a' && slug) return { kind: 'authority', id: authorityIdFromSlug(slug) };
-  if (kind === 'c' && slug) {
-    const id = bidderIdFromSlug(slug);
-    return id ? { kind: 'company', id } : null;
-  }
-  return null;
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -66,9 +47,7 @@ export default function Network({ loaderData }: Route.ComponentProps) {
   const { data } = loaderData;
   const submit = useSubmit();
   const navigating = useNavigation().state !== 'idle';
-  const centerValue = data.center
-    ? `${data.center.kind === 'authority' ? 'a' : 'c'}:${data.center.slug}`
-    : '';
+  const centerValue = data.center ? centerToken(data.center) : '';
 
   const nodeById = new Map(data.nodes.map((n) => [n.id, n] as const));
   // Normalise each row to the real procurement direction (authority -> company), regardless of how the


### PR DESCRIPTION
## What

Upgrades the profile/`/network` ego-graph from a static picture into a lightweight explorer — **progressive enhancement, the URL stays static while you browse**:

- **Edge € values** rendered along each edge, with a pure-CSS on/off toggle (no JS for this part).
- **Browse in place (with JS):** clicking a node re-centres the graph on it — it fetches that node's own ego-network from the `/network` loader via `useFetcher` and redraws **without changing the URL**. Then two controls appear: **„Отвори профила"** opens the focused node's page, **„Върни се в началото"** resets to the entity the URL points at.
- **No-JS fallback (crawler-safe):** with JS off, a node click is a plain `<a>` to that entity's profile.
- **Collision/overlap protection:** node labels are de-cluttered per side (min vertical gap), edge labels are biased toward the outer node, and the canvas/radii were enlarged — so labels stop overlapping each other and the hub.
- **Accessibility:** the connections table's entity cells are now links (the AT navigation path); Reset is a real `<button>`, Open an `<a>`; focus moves to Reset after a re-centre; `aria-busy`/`role="status"` on load.

## Why

`/network` and the profile embeds currently render a static graph; this makes the relationship graph explorable in place without losing the page you're on.

## Implementation notes

- Files: `apps/web/app/components/NetworkGraph.tsx`, `apps/web/app/lib/entity-tables.tsx` (table cells → links), `apps/web/app/app.css`.
- Re-centre reuses the existing `/network` loader contract (`{ data: NetworkData }`) — no new endpoint, no new data; all live queries.
- Hardening: browse state resets when the page's `data` changes; an intent ref so Reset cancels an in-flight load; only valid (≥2-node) results are adopted; modifier/middle-clicks fall through to the native link.

## Review & checks

- Reviewed by 3 independent passes; all consensus findings (stale-state-on-nav, in-flight-Reset race, the `<2 nodes` guard, a11y nav path, focus, error feedback) are addressed.
- `pnpm --filter @sigma/web typecheck` → clean; the 3 changed files are Prettier-clean.