### PR TITLE
fix(web): disable list "Next" at the shown last page so the counter and rank can't freeze (#87)

### DIFF
--- a/apps/web/app/lib/filters.test.ts
+++ b/apps/web/app/lib/filters.test.ts
@@ -175,6 +175,20 @@ describe('pageNav', () => {
     }
   });
 
+  it('floors a non-integer ?page so the counter and rank offset stay integers', () => {
+    // ?page=1.5 would otherwise render "Страница 1.5 от M" and a fractional rank offset (12.5).
+    const nav = pageNav({
+      base: sp('cursor=after:x&page=1.5'),
+      total: 100,
+      pageSize: 25,
+      nextCursor: 'after:y',
+      prevCursor: 'before:y',
+    });
+    expect(nav.page).toBe(1);
+    expect(Number.isInteger(nav.page)).toBe(true);
+    expect(leaderboardRankOffset(nav.page, 25)).toBe(0);
+  });
+
   it('advances the rank offset monotonically across normal deep paging', () => {
     // Within the valid range the counter and rank track the cursor 1:1 — neither freezes.
     const offsets = [698, 699, 700].map((p) => {

--- a/apps/web/app/lib/filters.test.ts
+++ b/apps/web/app/lib/filters.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { CPV_SECTORS } from '@sigma/config';
-import { companyListParams, getMulti, leaderboardRankOffset, MAX_MULTI_VALUES } from './filters';
+import {
+  companyListParams,
+  getMulti,
+  leaderboardRankOffset,
+  MAX_MULTI_VALUES,
+  pageNav,
+} from './filters';
+
+const sp = (q: string) => new URLSearchParams(q);
 
 describe('getMulti', () => {
   it('caps repeated and CSV multi-value params', () => {
@@ -55,5 +63,167 @@ describe('leaderboardRankOffset', () => {
     expect(leaderboardRankOffset(1, 25)).toBe(0);
     expect(leaderboardRankOffset(2, 25)).toBe(25);
     expect(leaderboardRankOffset(3, 15)).toBe(30);
+  });
+});
+
+describe('pageNav', () => {
+  it('starts at page 1 with no cursor and offers no Prev', () => {
+    const nav = pageNav({
+      base: sp(''),
+      total: 17504,
+      pageSize: 25,
+      nextCursor: 'after:x',
+      prevCursor: null,
+    });
+    expect(nav.page).toBe(1);
+    expect(nav.pageCount).toBe(701);
+    expect(nav.prevHref).toBeNull();
+    expect(nav.nextHref).not.toBeNull();
+  });
+
+  it('disables Next on the true last page (cursor exhausted) but keeps Prev live', () => {
+    // total 17504 / 25 = 701 pages; on page 701 the keyset emits no nextCursor. Prev must survive
+    // (AC: no regression to keyset Prev/Next, #53).
+    const nav = pageNav({
+      base: sp('cursor=after:z&page=701'),
+      total: 17504,
+      pageSize: 25,
+      nextCursor: null,
+      prevCursor: 'before:z',
+    });
+    expect(nav.page).toBe(701);
+    expect(nav.pageCount).toBe(701);
+    expect(nav.nextHref).toBeNull();
+    expect(nav.prevHref).not.toBeNull();
+  });
+
+  it('keeps Next enabled mid-list while real rows and display pages remain', () => {
+    const nav = pageNav({
+      base: sp('cursor=after:m&page=3'),
+      total: 17504, // 701 pages
+      pageSize: 25,
+      nextCursor: 'after:n',
+      prevCursor: 'before:n',
+    });
+    expect(nav.page).toBe(3);
+    expect(nav.nextHref).not.toBeNull();
+    expect(nav.prevHref).not.toBeNull();
+  });
+
+  it('keeps Next enabled on the penultimate page (guards against gating one page too early)', () => {
+    // page === pageCount - 1: a regression to `page <= pageCount` would wrongly disable Next here.
+    const nav = pageNav({
+      base: sp('cursor=after:p&page=700'),
+      total: 17504, // pageCount 701
+      pageSize: 25,
+      nextCursor: 'after:q',
+      prevCursor: 'before:q',
+    });
+    expect(nav.page).toBe(700);
+    expect(nav.pageCount).toBe(701);
+    expect(nav.nextHref).not.toBeNull();
+  });
+
+  // AC (verbatim): «Следваща» се деактивира на показаната последна страница — Next disables on the
+  // shown last page; nextHref == null when page >= pageCount.
+  it('disables Next once the page marker reaches pageCount even while a cursor remains (#87)', () => {
+    // ?page drift: the marker has reached the displayed last page (700) but the keyset still emits a
+    // nextCursor. Next must be gated off so the counter and rank cannot freeze while it keeps walking.
+    const nav = pageNav({
+      base: sp('cursor=after:row17500&page=700'),
+      total: 17500, // ceil(17500 / 25) = 700 → pageCount 700
+      pageSize: 25,
+      nextCursor: 'after:row17525',
+      prevCursor: 'before:row17476',
+    });
+    expect(nav.page).toBe(700); // page >= pageCount
+    expect(nav.pageCount).toBe(700);
+    expect(nav.nextHref).toBeNull(); // gated off despite a live cursor
+    // Rank reflects the shown last page (contiguous), never a frozen/contradictory offset.
+    expect(leaderboardRankOffset(nav.page, 25)).toBe(17475);
+  });
+
+  it('never shows an impossible "N от M" or re-enables Next for a stale/oversized ?page', () => {
+    // A hand-edited or stale ?page far beyond the end clamps to pageCount and stays disabled.
+    const nav = pageNav({
+      base: sp('cursor=after:x&page=99999'),
+      total: 17500,
+      pageSize: 25,
+      nextCursor: 'after:y',
+      prevCursor: 'before:y',
+    });
+    expect(nav.page).toBe(700);
+    expect(nav.page).toBeLessThanOrEqual(nav.pageCount);
+    expect(nav.nextHref).toBeNull();
+  });
+
+  it('keeps the displayed page within [1, pageCount] for hostile or absent ?page values', () => {
+    for (const q of [
+      'cursor=after:x&page=0',
+      'cursor=after:x&page=-9',
+      'cursor=after:x&page=abc',
+    ]) {
+      const nav = pageNav({
+        base: sp(q),
+        total: 100,
+        pageSize: 25,
+        nextCursor: 'after:y',
+        prevCursor: 'before:y',
+      });
+      expect(nav.page).toBe(1);
+      expect(nav.page).toBeLessThanOrEqual(nav.pageCount);
+    }
+  });
+
+  it('advances the rank offset monotonically across normal deep paging', () => {
+    // Within the valid range the counter and rank track the cursor 1:1 — neither freezes.
+    const offsets = [698, 699, 700].map((p) => {
+      const nav = pageNav({
+        base: sp(`cursor=after:c&page=${p}`),
+        total: 17500, // pageCount 700
+        pageSize: 25,
+        nextCursor: 'after:next',
+        prevCursor: 'before:prev',
+      });
+      return leaderboardRankOffset(nav.page, 25);
+    });
+    expect(offsets).toEqual([17425, 17450, 17475]);
+  });
+
+  it('handles an empty result set without enabling Next', () => {
+    const nav = pageNav({
+      base: sp(''),
+      total: 0,
+      pageSize: 25,
+      nextCursor: null,
+      prevCursor: null,
+    });
+    expect(nav.page).toBe(1);
+    expect(nav.pageCount).toBe(1); // Math.max(1, …) floor → "Страница 1 от 1"
+    expect(nav.nextHref).toBeNull();
+    expect(nav.prevHref).toBeNull();
+  });
+
+  it('gates Next at the last page for the contracts page size (15), not just 25', () => {
+    // The deepest list (/contracts) paginates 15/page; pageNav is size-agnostic, so prove the bound.
+    const last = pageNav({
+      base: sp('cursor=after:c&page=4'),
+      total: 60, // ceil(60 / 15) = 4 pages
+      pageSize: 15,
+      nextCursor: 'after:more',
+      prevCursor: 'before:c',
+    });
+    expect(last.page).toBe(4);
+    expect(last.pageCount).toBe(4);
+    expect(last.nextHref).toBeNull();
+
+    const mid = pageNav({
+      base: sp('cursor=after:c&page=3'),
+      total: 60,
+      pageSize: 15,
+      nextCursor: 'after:more',
+      prevCursor: 'before:c',
+    });
+    expect(mid.nextHref).not.toBeNull();
   });
 });

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -215,6 +215,11 @@ export function pageNav(opts: {
     pageCount,
     prevHref:
       page > 1 && prevCursor ? withParams(base, { cursor: prevCursor, page: page - 1 }) : null,
-    nextHref: nextCursor ? withParams(base, { cursor: nextCursor, page: page + 1 }) : null,
+    // Gate Next on both the cursor and the display bound so it disables on the shown last page and
+    // the "N от M" counter + "#" rank can't freeze at pageCount while the cursor walks past it (#87).
+    nextHref:
+      nextCursor && page < pageCount
+        ? withParams(base, { cursor: nextCursor, page: page + 1 })
+        : null,
   };
 }

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -209,7 +209,7 @@ export function pageNav(opts: {
   // first page, so force page 1. Otherwise clamp to the valid range to avoid impossible "N от M".
   const page = !base.get('cursor')
     ? 1
-    : Math.min(Math.max(1, Number(base.get('page') ?? '1') || 1), pageCount);
+    : Math.min(Math.max(1, Math.floor(Number(base.get('page') ?? '1')) || 1), pageCount);
   return {
     page,
     pageCount,


### PR DESCRIPTION
Fixes #87.

## Problem
On the keyset-paginated lists (`/companies`, `/authorities`, `/contracts`) the `?page` marker is display-only. The shared `pageNav` (`apps/web/app/lib/filters.ts`) derived two bounds independently:

- the displayed page was clamped to `pageCount = ceil(total / pageSize)`;
- `nextHref` was gated **only** on the keyset `nextCursor`.

When `?page` reached `pageCount` but the cursor still emitted rows (a stale cached `COUNT`, or a hand-edited/stale `?page`), **«Следваща» kept walking while «Страница N от M» and the leaderboard «#»/rank froze** at the last counted page. Because the bug is in the shared helper, it affected all three lists.

## Fix
Gate `nextHref` on **both** the cursor and the display bound — exactly the solution proposed in the issue:

```ts
nextHref: nextCursor && page < pageCount ? withParams(base, { cursor: nextCursor, page: page + 1 }) : null
```

So «Следваща» disables on the shown last page and the counter + rank stay in step with the rows. `prevHref` and the cursor-keyed scroll restoration (`root.tsx` `scrollKey`, #53) are untouched.

## Acceptance criteria
- [x] «Следваща» disables on the shown last page (`page >= pageCount`).
- [x] «Страница N от M» and the «#»/rank column don't freeze or contradict the rows during normal deep paging.
- [x] Consistent across `/companies`, `/authorities`, `/contracts` (single shared `pageNav`, no per-route duplication).
- [x] `pageNav` test pinning `nextHref == null` at `page >= pageCount`.
- [x] No regression to keyset Prev/Next or cursor scroll restoration (#53) — Prev/href shape and `scrollKey` unchanged; new tests assert Prev survives on the last page and Next stays live on the penultimate page.

## Why this is safe (design note)
The gate makes `total` (the live `COUNT(*)`) authoritative for where navigation stops. That is safe because **`total` and the page query share the same `FROM` + filter set in the same request** (`countCompanies`/`countAuthorities`/contracts summary reuse the listing's source), so the keyset walk visits exactly `COUNT(*)` rows — verified against the full local corpus (~17.5k companies, every sort + filter: walk pages == `ceil(total/pageSize)` exactly). At the true last page both gate conditions go false together; the new `page < pageCount` clause only has independent effect in the pathological stale/hand-edited case. The web loaders do not use the KV-cached summary path, so there is no cached-total divergence today.

Trade-off worth noting for review: the gate trusts `total` over the cursor, so a hypothetical **under**-counting `total` would stop Next while rows remain. Given the shared-source invariant above that cannot happen in steady state; if a future change introduced a cached/approximate count for these lists, this gate would need revisiting.

## Tests
`apps/web/app/lib/filters.test.ts` — `describe('pageNav')`: first page (no cursor, no Prev), Next disabled at true last page with Prev still live, Next live mid-list and on the penultimate page, `nextHref == null` at `page >= pageCount` with a live cursor (#87), clamp + still-disabled for oversized `?page`, hostile/absent `?page` clamped to `[1, pageCount]`, monotonic rank across deep paging, empty result set, and the contracts page size (15) in addition to 25. Full `apps/web` suite green (94 tests), typecheck + prettier clean.

Severity per the issue: low (correctness/UX). One focused change to the shared helper + its unit tests.
