### PR TITLE
feat(web): add in-table search to entity list pages

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2066,6 +2066,54 @@ details.row .body .signal .why {
 .list-controls p {
   margin: 0;
 }
+
+/* In-table search — a quiet utility field on its own row above the count/sort strip. Deliberately
+   lighter than the hero/header .smart-search; it filters the list in place via the `q` URL param. */
+.list-controls-bar {
+  margin: 0 0 var(--s-3);
+}
+.table-search {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  margin: 0 0 var(--s-3);
+}
+.table-search input[type='search'] {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid var(--rule);
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  padding: 8px var(--s-3);
+}
+.table-search input[type='search']:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.table-search input[type='search']::placeholder {
+  color: var(--ink-soft);
+  font-style: italic;
+}
+/* Style the input's native clear button to match the quiet ink palette instead of the browser
+   default. The X is drawn as a mask so its colour comes from background-color (CSP allows the data:
+   URI via `img-src 'self' data:`). WebKit/Blink only — Firefox renders no clear button for search. */
+.table-search input[type='search']::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-inline-start: var(--s-2);
+  cursor: pointer;
+  background-color: var(--ink-soft);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 4l8 8M12 4l-8 8' stroke='%23000' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 4l8 8M12 4l-8 8' stroke='%23000' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+}
+.table-search input[type='search']::-webkit-search-cancel-button:hover {
+  background-color: var(--ink);
+}
 .paging .ctrl a {
   display: inline-flex;
   align-items: center;

--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -2075,8 +2075,14 @@ details.row .body .signal .why {
 .table-search {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--s-3);
   margin: 0 0 var(--s-3);
+}
+/* The „no searchable terms" hint sits on its own row under the field (full-width flex item). */
+.table-search-hint {
+  flex-basis: 100%;
+  margin: 0;
 }
 .table-search input[type='search'] {
   flex: 1 1 auto;

--- a/apps/web/app/components/FilterRail.tsx
+++ b/apps/web/app/components/FilterRail.tsx
@@ -97,6 +97,9 @@ export function FilterRail({
       </label>
       <Form method="get" onChange={onChange}>
         <input type="hidden" name="sort" value={sort} />
+        {/* Preserve an active in-table search when filters change without JS (the JS path already
+            carries `q` through withParams). */}
+        {sp.get('q') && <input type="hidden" name="q" value={sp.get('q')!} />}
         {preservedScope.map(({ key, value }) => (
           <input type="hidden" name={key} value={value} key={`${key}-${value}`} />
         ))}

--- a/apps/web/app/components/ListControls.tsx
+++ b/apps/web/app/components/ListControls.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import { Form, Link, useNavigation, useSubmit } from 'react-router';
-import { hasSearchableTerms } from '@sigma/shared';
+import { hasSearchableTerms, MAX_QUERY_CHARS } from '@sigma/shared';
 import { searchHref, sortHref } from '../lib/filters';
+import { isComposingAfter, shouldAdoptUrlQ, shouldSubmitLive } from '../lib/tableSearch';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 
 export interface SortOption {
@@ -33,11 +34,11 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
   // Adopt the URL's q on EXTERNAL navigation only (back/forward, links, filter changes). Never touch
   // the field while it's focused — the user is mid-edit, and a stale loader landing late would
   // otherwise revert keystrokes typed since (React Router aborts superseded GETs, so our own live
-  // submits can't land out of order; this guard only covers interleaved external navigation).
+  // submits can't land out of order; this guard only covers interleaved external navigation). The
+  // onBlur handler is the partner for the case where external nav lands while the field is focused.
   useEffect(() => {
-    if (urlQ === value) return;
-    if (inputRef.current && inputRef.current === document.activeElement) return;
-    setValue(urlQ);
+    const focused = inputRef.current === document.activeElement;
+    if (shouldAdoptUrlQ({ urlQ, value, focused, settled: value === debounced })) setValue(urlQ);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- resync keys off the URL's q only
   }, [urlQ]);
 
@@ -45,9 +46,7 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
   // navigation, and submitting mid-IME-composition (so a Cyrillic word commits whole, not „мо" for
   // „мост"). Depends on `debounced` only — `base` gets a new identity every navigation.
   useEffect(() => {
-    if (composingRef.current) return;
-    if (debounced.trim() === urlQ.trim()) return;
-    go(debounced, true);
+    if (shouldSubmitLive({ composing: composingRef.current, debounced, urlQ })) go(debounced, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fire only when the settled value changes
   }, [debounced]);
 
@@ -71,17 +70,33 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
         type="search"
         name="q"
         value={value}
+        maxLength={MAX_QUERY_CHARS}
         autoComplete="off"
         placeholder="Търси в таблицата…"
         onChange={(e) => setValue(e.target.value)}
         onCompositionStart={() => {
-          composingRef.current = true;
+          composingRef.current = isComposingAfter('start');
         }}
         onCompositionEnd={(e) => {
-          // Re-arm the debounce with the committed word; setting value here (rather than relying on a
-          // trailing input event) makes us robust to compositionend/input ordering across browsers.
-          composingRef.current = false;
-          setValue(e.currentTarget.value);
+          // Submit the committed word now. Just re-arming the debounce (setValue alone) is a no-op when
+          // the IME already fired the final input before compositionend — and if the debounce burned out
+          // mid-composition, the word would never live-submit. setValue still keeps the controlled input
+          // in sync for the opposite (compositionend-before-input) ordering; the later debounce settle
+          // sees value === urlQ via shouldSubmitLive, so there's no double submit.
+          composingRef.current = isComposingAfter('end');
+          const committed = e.currentTarget.value;
+          setValue(committed);
+          go(committed, true);
+        }}
+        onBlur={() => {
+          // Un-stick a composition that never fired compositionend (compositioncancel, or focus loss
+          // mid-IME) so it can't mute every later live submit. And adopt the URL's q if external nav
+          // landed while the field was focused (the resync effect bails in that window) — but only once
+          // typing has settled, so we don't wipe a value the user typed then blurred mid-debounce.
+          composingRef.current = isComposingAfter('blur');
+          if (shouldAdoptUrlQ({ urlQ, value, focused: false, settled: value === debounced })) {
+            setValue(urlQ);
+          }
         }}
       />
       {/* No-JS preservation: carry every active param except q/cursor/page. Omitting cursor/page

--- a/apps/web/app/components/ListControls.tsx
+++ b/apps/web/app/components/ListControls.tsx
@@ -1,48 +1,129 @@
-import type { ReactNode } from 'react';
-import { Link, useNavigation } from 'react-router';
-import { sortHref } from '../lib/filters';
+import { useEffect, useId, useState, type ReactNode } from 'react';
+import { Form, Link, useNavigation, useSubmit } from 'react-router';
+import { searchHref, sortHref } from '../lib/filters';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
 
 export interface SortOption {
   value: string;
   label: string;
 }
 
-// The strip above a list: a result-count line on the left, sort links on the right. Sort links keep
-// the current filters and reset paging (see lib/filters.sortHref).
+const SEARCH_DEBOUNCE_MS = 300;
+
+// In-table search. A real `<Form method="get">` so it filters the list without JS (plain Enter /
+// the visible submit), progressively enhanced with a debounced live submit via `useSubmit`. Setting
+// `q` keeps every other filter/sort and resets paging (see lib/filters.searchHref); clearing drops
+// `q` only. `searchLabel` names the search landmark so it's distinct from the site-wide header search.
+function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel: string }) {
+  const submit = useSubmit();
+  const urlQ = base.get('q') ?? '';
+  const [value, setValue] = useState(urlQ);
+  const debounced = useDebouncedValue(value, SEARCH_DEBOUNCE_MS);
+  const labelId = useId();
+
+  // Navigate to the search href. `replace` for live typing (don't trace every keystroke in history),
+  // push for deliberate actions (Enter, clear). Building params from searchHref — not submitting the
+  // raw form — is what guarantees canonical order + cursor/page reset on the JS path.
+  const go = (q: string, replace: boolean) =>
+    submit(new URLSearchParams(searchHref(base, q)), { method: 'get', replace });
+
+  // Adopt the URL's q on EXTERNAL navigation only (back/forward, links, filter changes); never clobber
+  // what the user is typing. Skip when already in sync or when this is the echo of our own submit.
+  useEffect(() => {
+    if (urlQ === value || urlQ === debounced.trim()) return;
+    setValue(urlQ);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resync keys off the URL's q only
+  }, [urlQ]);
+
+  // Live submit once typing settles. The guard suppresses the mount fire and the echo of our own
+  // navigation, breaking the type→submit→type loop. Depends on `debounced` only — `base` gets a new
+  // identity every navigation and would otherwise re-fire this.
+  useEffect(() => {
+    if (debounced.trim() === urlQ.trim()) return;
+    go(debounced, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire only when the settled value changes
+  }, [debounced]);
+
+  return (
+    <Form
+      method="get"
+      role="search"
+      aria-label={searchLabel}
+      className="table-search"
+      onSubmit={(e) => {
+        e.preventDefault();
+        go(value, false);
+      }}
+    >
+      <label htmlFor={labelId} className="sr-only">
+        Търси в таблицата
+      </label>
+      <input
+        id={labelId}
+        type="search"
+        name="q"
+        value={value}
+        autoComplete="off"
+        placeholder="Търси в таблицата…"
+        onChange={(e) => setValue(e.target.value)}
+      />
+      {/* No-JS preservation: carry every active param except q/cursor/page. Omitting cursor/page
+          means a native GET drops them, so a search resets to page 1 without JS too. */}
+      {Array.from(base.entries())
+        .filter(([key]) => key !== 'q' && key !== 'cursor' && key !== 'page')
+        .map(([key, val], i) => (
+          <input key={`${key}-${i}-${val}`} type="hidden" name={key} value={val} />
+        ))}
+      {/* The clear affordance is the input's native `type="search"` cancel button (styled below);
+          clicking it empties the field, and the onChange→debounced submit drops `q` from the URL. */}
+      <noscript>
+        <button type="submit">Търси</button>
+      </noscript>
+    </Form>
+  );
+}
+
+// The strip above a list: an optional in-table search row, then a result-count line on the left and
+// sort links on the right. Sort links keep the current filters and reset paging (see lib/filters).
 export function ListControls({
   count,
   base,
   sorts,
   activeSort,
+  searchLabel,
 }: {
   count: ReactNode;
   base: URLSearchParams;
   sorts: SortOption[];
   activeSort: string;
+  searchLabel?: string;
 }) {
   // Reflect in-flight navigation/revalidation so slow networks get quiet feedback.
   const busy = useNavigation().state !== 'idle';
   return (
-    <div className="list-controls" aria-busy={busy || undefined}>
-      <p className="muted small" aria-live="polite">
-        {count}
-        {busy ? <span className="muted small"> · Зарежда…</span> : null}
-      </p>
-      <p className="muted small">
-        Подреди:{' '}
-        {sorts.map((s, i) => (
-          <span key={s.value}>
-            {i > 0 ? ' · ' : ''}
-            {s.value === activeSort ? (
-              <Link to={sortHref(base, s.value)} aria-current="true">
-                <strong>{s.label}</strong>
-              </Link>
-            ) : (
-              <Link to={sortHref(base, s.value)}>{s.label}</Link>
-            )}
-          </span>
-        ))}
-      </p>
+    <div className="list-controls-bar">
+      {searchLabel && <TableSearch base={base} searchLabel={searchLabel} />}
+      <div className="list-controls" aria-busy={busy || undefined}>
+        <p className="muted small" aria-live="polite">
+          {count}
+          {busy ? <span className="muted small"> · Зарежда…</span> : null}
+        </p>
+        <p className="muted small">
+          Подреди:{' '}
+          {sorts.map((s, i) => (
+            <span key={s.value}>
+              {i > 0 ? ' · ' : ''}
+              {s.value === activeSort ? (
+                <Link to={sortHref(base, s.value)} aria-current="true">
+                  <strong>{s.label}</strong>
+                </Link>
+              ) : (
+                <Link to={sortHref(base, s.value)}>{s.label}</Link>
+              )}
+            </span>
+          ))}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/components/ListControls.tsx
+++ b/apps/web/app/components/ListControls.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useState, type ReactNode } from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import { Form, Link, useNavigation, useSubmit } from 'react-router';
+import { hasSearchableTerms } from '@sigma/shared';
 import { searchHref, sortHref } from '../lib/filters';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 
@@ -20,6 +21,8 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
   const [value, setValue] = useState(urlQ);
   const debounced = useDebouncedValue(value, SEARCH_DEBOUNCE_MS);
   const labelId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const composingRef = useRef(false);
 
   // Navigate to the search href. `replace` for live typing (don't trace every keystroke in history),
   // push for deliberate actions (Enter, clear). Building params from searchHref — not submitting the
@@ -27,18 +30,22 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
   const go = (q: string, replace: boolean) =>
     submit(new URLSearchParams(searchHref(base, q)), { method: 'get', replace });
 
-  // Adopt the URL's q on EXTERNAL navigation only (back/forward, links, filter changes); never clobber
-  // what the user is typing. Skip when already in sync or when this is the echo of our own submit.
+  // Adopt the URL's q on EXTERNAL navigation only (back/forward, links, filter changes). Never touch
+  // the field while it's focused — the user is mid-edit, and a stale loader landing late would
+  // otherwise revert keystrokes typed since (React Router aborts superseded GETs, so our own live
+  // submits can't land out of order; this guard only covers interleaved external navigation).
   useEffect(() => {
-    if (urlQ === value || urlQ === debounced.trim()) return;
+    if (urlQ === value) return;
+    if (inputRef.current && inputRef.current === document.activeElement) return;
     setValue(urlQ);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- resync keys off the URL's q only
   }, [urlQ]);
 
-  // Live submit once typing settles. The guard suppresses the mount fire and the echo of our own
-  // navigation, breaking the type→submit→type loop. Depends on `debounced` only — `base` gets a new
-  // identity every navigation and would otherwise re-fire this.
+  // Live submit once typing settles. The guards suppress the mount fire, the echo of our own
+  // navigation, and submitting mid-IME-composition (so a Cyrillic word commits whole, not „мо" for
+  // „мост"). Depends on `debounced` only — `base` gets a new identity every navigation.
   useEffect(() => {
+    if (composingRef.current) return;
     if (debounced.trim() === urlQ.trim()) return;
     go(debounced, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fire only when the settled value changes
@@ -59,6 +66,7 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
         Търси в таблицата
       </label>
       <input
+        ref={inputRef}
         id={labelId}
         type="search"
         name="q"
@@ -66,6 +74,15 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
         autoComplete="off"
         placeholder="Търси в таблицата…"
         onChange={(e) => setValue(e.target.value)}
+        onCompositionStart={() => {
+          composingRef.current = true;
+        }}
+        onCompositionEnd={(e) => {
+          // Re-arm the debounce with the committed word; setting value here (rather than relying on a
+          // trailing input event) makes us robust to compositionend/input ordering across browsers.
+          composingRef.current = false;
+          setValue(e.currentTarget.value);
+        }}
       />
       {/* No-JS preservation: carry every active param except q/cursor/page. Omitting cursor/page
           means a native GET drops them, so a search resets to page 1 without JS too. */}
@@ -79,6 +96,13 @@ function TableSearch({ base, searchLabel }: { base: URLSearchParams; searchLabel
       <noscript>
         <button type="submit">Търси</button>
       </noscript>
+      {/* A query that's only punctuation or a single char yields no FTS terms — the backend ignores
+          it and shows the full list. Tell the user so the box/URL don't look like an active search. */}
+      {value.trim() !== '' && !hasSearchableTerms(value) && (
+        <p role="status" className="muted small table-search-hint">
+          Въведете поне 2 знака; пунктуацията се пренебрегва
+        </p>
+      )}
     </Form>
   );
 }

--- a/apps/web/app/lib/filters.test.ts
+++ b/apps/web/app/lib/filters.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { CPV_SECTORS } from '@sigma/config';
-import { companyListParams, getMulti, leaderboardRankOffset, MAX_MULTI_VALUES } from './filters';
+import {
+  companyListParams,
+  getMulti,
+  leaderboardRankOffset,
+  MAX_MULTI_VALUES,
+  searchHref,
+} from './filters';
 
 describe('getMulti', () => {
   it('caps repeated and CSV multi-value params', () => {
@@ -47,6 +53,48 @@ describe('getMulti', () => {
       years: ['2024', '2016', 'unknown'],
       eu: 'eu',
     });
+  });
+});
+
+describe('searchHref', () => {
+  it('sets q and resets cursor/page while preserving filters and sort', () => {
+    const sp = new URLSearchParams('sort=name&year=2024&cursor=abc&page=3&sector=45');
+    const out = new URLSearchParams(searchHref(sp, 'mostove'));
+
+    expect(out.get('q')).toBe('mostove');
+    expect(out.get('sort')).toBe('name');
+    expect(out.getAll('year')).toEqual(['2024']);
+    expect(out.get('sector')).toBe('45');
+    expect(out.has('cursor')).toBe(false);
+    expect(out.has('page')).toBe(false);
+  });
+
+  it('drops q when the query is empty or whitespace-only', () => {
+    const sp = new URLSearchParams('q=old&sort=won');
+    expect(new URLSearchParams(searchHref(sp, '')).has('q')).toBe(false);
+    expect(new URLSearchParams(searchHref(sp, '   ')).has('q')).toBe(false);
+  });
+
+  it('trims surrounding whitespace from q', () => {
+    expect(new URLSearchParams(searchHref(new URLSearchParams(), '  foo  ')).get('q')).toBe('foo');
+  });
+
+  it('emits q first in canonical order', () => {
+    expect(searchHref(new URLSearchParams('sort=name'), 'x')).toBe('?q=x&sort=name');
+  });
+
+  it('preserves repeated multi-value params', () => {
+    const sp = new URLSearchParams();
+    sp.append('year', '2024');
+    sp.append('year', '2023');
+    sp.set('sector', '45');
+
+    expect(new URLSearchParams(searchHref(sp, 'q')).getAll('year')).toEqual(['2024', '2023']);
+  });
+
+  it('preserves unknown keys not in PARAM_ORDER (e.g. contracts bids)', () => {
+    const sp = new URLSearchParams('bids=1&sort=value-desc');
+    expect(new URLSearchParams(searchHref(sp, 'q')).get('bids')).toBe('1');
   });
 });
 

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -184,6 +184,11 @@ export function sortHref(base: URLSearchParams, sort: string): string {
   return withParams(base, { sort, cursor: null, page: null });
 }
 
+/** A href with the search `q` set/cleared (and cursor/page reset — a new search starts at page 1). */
+export function searchHref(base: URLSearchParams, q: string): string {
+  return withParams(base, { q: q.trim() || null, cursor: null, page: null });
+}
+
 export interface PageNav {
   page: number; // 1-based, for display
   pageCount: number;

--- a/apps/web/app/lib/tableSearch.test.ts
+++ b/apps/web/app/lib/tableSearch.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isComposingAfter, shouldAdoptUrlQ, shouldSubmitLive } from './tableSearch';
+
+describe('shouldAdoptUrlQ', () => {
+  const settled = true;
+
+  it('does not adopt when the field already matches the URL', () => {
+    expect(shouldAdoptUrlQ({ urlQ: 'мост', value: 'мост', focused: false, settled })).toBe(false);
+  });
+
+  it('does not adopt while the field is focused (mid-edit)', () => {
+    // The resync effect bails here so a late loader can't revert keystrokes.
+    expect(shouldAdoptUrlQ({ urlQ: 'нов', value: 'стар', focused: true, settled })).toBe(false);
+  });
+
+  it('adopts external navigation once the field is blurred and settled', () => {
+    // back/forward (or a filter link) changed q while the box held the old text — adopt on blur.
+    expect(shouldAdoptUrlQ({ urlQ: 'нов', value: 'стар', focused: false, settled })).toBe(true);
+  });
+
+  it('does not clobber a value the user typed but has not finished debouncing', () => {
+    // value is ahead of the URL because a live submit is still pending; let the debounce land it.
+    expect(shouldAdoptUrlQ({ urlQ: '', value: 'мост', focused: false, settled: false })).toBe(
+      false,
+    );
+  });
+});
+
+describe('shouldSubmitLive', () => {
+  it('suppresses the submit while an IME composition is in flight', () => {
+    // Guards the composingRef-stuck-true edge: every live submit is muted until composing clears.
+    expect(shouldSubmitLive({ composing: true, debounced: 'мост', urlQ: '' })).toBe(false);
+  });
+
+  it('skips the echo of our own navigation (settled value equals the URL)', () => {
+    expect(shouldSubmitLive({ composing: false, debounced: 'мост', urlQ: 'мост' })).toBe(false);
+  });
+
+  it('ignores surrounding whitespace when comparing to the URL', () => {
+    expect(shouldSubmitLive({ composing: false, debounced: '  мост ', urlQ: 'мост' })).toBe(false);
+  });
+
+  it('submits when the settled value really differs from the URL', () => {
+    expect(shouldSubmitLive({ composing: false, debounced: 'мост', urlQ: '' })).toBe(true);
+  });
+});
+
+describe('isComposingAfter', () => {
+  it('arms only on compositionstart; end/cancel/blur all disarm', () => {
+    expect(isComposingAfter('start')).toBe(true);
+    expect(isComposingAfter('end')).toBe(false);
+    // compositioncancel and a mid-IME blur never fire compositionend — they must still disarm.
+    expect(isComposingAfter('cancel')).toBe(false);
+    expect(isComposingAfter('blur')).toBe(false);
+  });
+});

--- a/apps/web/app/lib/tableSearch.ts
+++ b/apps/web/app/lib/tableSearch.ts
@@ -1,0 +1,52 @@
+// Pure decision helpers for the in-table search input (ListControls.TableSearch). The guard logic has
+// produced several edge bugs because it lived inline in handlers/effects; extracting it makes the
+// decisions unit-testable under the node harness — no DOM/component-test stack needed.
+
+/**
+ * Whether the field should replace its value with the URL's `q`. Adopt only when they differ AND the
+ * field isn't being actively edited (`!focused && settled`): so external navigation (back/forward,
+ * links, filter changes) is reflected, without reverting a keystroke the user is mid-typing or
+ * clobbering a still-pending debounced submit.
+ */
+export function shouldAdoptUrlQ({
+  urlQ,
+  value,
+  focused,
+  settled,
+}: {
+  urlQ: string;
+  value: string;
+  focused: boolean;
+  settled: boolean;
+}): boolean {
+  if (urlQ === value) return false;
+  return !focused && settled;
+}
+
+/**
+ * Whether the settled (debounced) value should be live-submitted. Suppress while an IME composition is
+ * in flight — so a Cyrillic word commits whole, not „мо" for „мост" — and when the value already
+ * matches the URL (the echo of our own navigation, or a no-op). Trim both sides so trailing whitespace
+ * isn't treated as a new query.
+ */
+export function shouldSubmitLive({
+  composing,
+  debounced,
+  urlQ,
+}: {
+  composing: boolean;
+  debounced: string;
+  urlQ: string;
+}): boolean {
+  if (composing) return false;
+  return debounced.trim() !== urlQ.trim();
+}
+
+/**
+ * The composition flag after a composition-related event. Only `start` arms it; `end`, `cancel`, and
+ * `blur` all disarm — so a composition that never fires `compositionend` (compositioncancel, or focus
+ * loss mid-IME) can't leave the flag stuck on and mute every later live submit.
+ */
+export function isComposingAfter(event: 'start' | 'end' | 'cancel' | 'blur'): boolean {
+  return event === 'start';
+}

--- a/apps/web/app/routes/authorities.tsx
+++ b/apps/web/app/routes/authorities.tsx
@@ -150,6 +150,7 @@ export default function Authorities({ loaderData }: Route.ComponentProps) {
             <ListControls
               base={sp}
               activeSort={sort}
+              searchLabel="Търсене сред институциите"
               sorts={[
                 { value: 'spent', label: 'похарчено' },
                 { value: 'count', label: 'договори' },

--- a/apps/web/app/routes/companies.tsx
+++ b/apps/web/app/routes/companies.tsx
@@ -183,6 +183,7 @@ export default function Companies({ loaderData }: Route.ComponentProps) {
             <ListControls
               base={sp}
               activeSort={sort}
+              searchLabel="Търсене сред компаниите"
               sorts={[
                 { value: 'won', label: 'спечелено' },
                 { value: 'count', label: 'договори' },

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -152,6 +152,7 @@ export default function Contracts({ loaderData }: Route.ComponentProps) {
             <ListControls
               base={sp}
               activeSort={sort}
+              searchLabel="Търсене сред договорите"
               sorts={[
                 { value: 'date-desc', label: 'нови' },
                 { value: 'date-asc', label: 'стари' },

--- a/apps/web/app/routes/search.tsx
+++ b/apps/web/app/routes/search.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';
-import { count, money, plural } from '@sigma/shared';
-import { MAX_QUERY_CHARS, MAX_QUERY_TOKENS, search } from '@sigma/db';
+import { count, money, plural, searchTokens } from '@sigma/shared';
+import { MAX_QUERY_TOKENS, search } from '@sigma/db';
 import type { SearchHit } from '@sigma/api-contract';
 import type { Route } from './+types/search';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -51,13 +51,13 @@ function deHomoglyph(q: string): string {
   return q.replace(/[aceopxykmtABCEHKMOPTX]/g, (ch) => HOMOGLYPHS[ch] ?? ch);
 }
 
+// Share the FTS tokenizer with @sigma/db and the in-table search so all three agree on what counts as
+// a searchable term (incl. the ≥MIN_QUERY_TOKEN_CHARS filter — single chars no longer reach MATCH).
+// deHomoglyph is layered on top and is length-preserving, so it doesn't disturb that filtering.
 function normalizedTerms(q: string, limit: number): string[] {
-  const terms =
-    q
-      .slice(0, MAX_QUERY_CHARS)
-      .toLowerCase()
-      .match(/[\p{L}\p{N}]+/gu) ?? [];
-  return terms.slice(0, limit).map((t) => (CYRILLIC.test(t) ? deHomoglyph(t) : t));
+  return searchTokens(q)
+    .slice(0, limit)
+    .map((t) => (CYRILLIC.test(t) ? deHomoglyph(t) : t));
 }
 
 function cappedQuery(q: string): string {

--- a/packages/db/src/queries/search.ts
+++ b/packages/db/src/queries/search.ts
@@ -4,17 +4,14 @@
 // because the tokenizer splits them the same way on both sides.
 
 import type { EntityKind, OwnershipKind, SearchHit, SearchResults } from '@sigma/api-contract';
-import { cleanName, entityName, parseConsortiumMembers } from '@sigma/shared';
+import { cleanName, entityName, parseConsortiumMembers, searchTokens } from '@sigma/shared';
 import { hrefForEntity } from './identity';
 
 export type SearchKind = 'authority' | 'company' | 'contract';
 
-export const MAX_QUERY_CHARS = 160;
-export const MAX_QUERY_TOKENS = 8;
-// Single-character `*`-prefix terms (e.g. „и*") match a huge slice of the FTS index, turning one
-// request into a full-index COUNT + rank scan. Require ≥2 chars per term so a token actually narrows
-// the postings list; shorter tokens are dropped, and a query with nothing left reads as empty.
-export const MIN_QUERY_TOKEN_CHARS = 2;
+// The tokenizer and its caps live in @sigma/shared so the FTS query builder and the search UI agree
+// on what counts as searchable. Re-exported here for existing @sigma/db consumers.
+export { MAX_QUERY_CHARS, MAX_QUERY_TOKENS, MIN_QUERY_TOKEN_CHARS } from '@sigma/shared';
 
 const GROUPS: {
   kind: SearchKind;
@@ -80,16 +77,9 @@ function deHomoglyph(q: string): string {
  *  term like „ALSTOM" passes through untouched, otherwise its Latin a/o/t/m would be swapped to
  *  Cyrillic and the resulting mixed-script token would match nothing in the index. */
 export function searchMatchQuery(q: string): string | null {
-  const terms = q
-    .slice(0, MAX_QUERY_CHARS)
-    .toLowerCase()
-    .match(/[\p{L}\p{N}]+/gu)
-    ?.filter((t) => t.length >= MIN_QUERY_TOKEN_CHARS);
-  if (!terms || terms.length === 0) return null;
-  return terms
-    .slice(0, MAX_QUERY_TOKENS)
-    .map((t) => `${CYRILLIC.test(t) ? deHomoglyph(t) : t}*`)
-    .join(' ');
+  const terms = searchTokens(q);
+  if (terms.length === 0) return null;
+  return terms.map((t) => `${CYRILLIC.test(t) ? deHomoglyph(t) : t}*`).join(' ');
 }
 
 export function searchMoreHref(kind: SearchKind, query: string): string {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from './format';
+export * from './search';

--- a/packages/shared/src/search.test.ts
+++ b/packages/shared/src/search.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasSearchableTerms,
+  MAX_QUERY_CHARS,
+  MAX_QUERY_TOKENS,
+  MIN_QUERY_TOKEN_CHARS,
+  searchTokens,
+} from './search';
+
+describe('searchTokens', () => {
+  it('lowercases and splits on non-letter/digit runs, dropping punctuation', () => {
+    expect(searchTokens('Мост ЕООД, гр. София')).toEqual(['мост', 'еоод', 'гр', 'софия']);
+  });
+
+  it('drops tokens shorter than MIN_QUERY_TOKEN_CHARS', () => {
+    // Single-char `*`-prefix terms scan a huge slice of the FTS index — they must not reach MATCH.
+    expect(MIN_QUERY_TOKEN_CHARS).toBe(2);
+    expect(searchTokens('а и в мост')).toEqual(['мост']);
+  });
+
+  it('returns no tokens for punctuation- or single-char-only queries', () => {
+    expect(searchTokens('!!! ?')).toEqual([]);
+    expect(searchTokens('я')).toEqual([]);
+  });
+
+  it('caps the number of tokens at MAX_QUERY_TOKENS', () => {
+    const q = Array.from({ length: MAX_QUERY_TOKENS + 5 }, (_, i) => `дума${i}`).join(' ');
+    expect(searchTokens(q)).toHaveLength(MAX_QUERY_TOKENS);
+  });
+
+  it('caps the scanned input at MAX_QUERY_CHARS before tokenizing', () => {
+    // A token whose first char sits past the cap is never seen.
+    const padded = `${'a'.repeat(MAX_QUERY_CHARS)} мост`;
+    expect(searchTokens(padded)).not.toContain('мост');
+  });
+
+  it('keeps digit tokens', () => {
+    expect(searchTokens('ЕИК 204918123')).toEqual(['еик', '204918123']);
+  });
+});
+
+describe('hasSearchableTerms', () => {
+  it('is false when nothing survives the FTS filter', () => {
+    expect(hasSearchableTerms('')).toBe(false);
+    expect(hasSearchableTerms('   ')).toBe(false);
+    expect(hasSearchableTerms('.,!')).toBe(false);
+    expect(hasSearchableTerms('я')).toBe(false);
+  });
+
+  it('is true once a token of MIN_QUERY_TOKEN_CHARS or more survives', () => {
+    expect(hasSearchableTerms('мост')).toBe(true);
+    expect(hasSearchableTerms('я мост')).toBe(true);
+  });
+});

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -1,0 +1,30 @@
+// Search-term primitives shared by the FTS query builder (@sigma/db), the /search route, and the
+// in-table list search UI, so they all agree on what counts as a „searchable" query — no drift.
+// Pure string math, safe to bundle into the client.
+
+export const MAX_QUERY_CHARS = 160;
+export const MAX_QUERY_TOKENS = 8;
+// Single-character `*`-prefix terms (e.g. „и*") match a huge slice of the FTS index, turning one
+// request into a full-index COUNT + rank scan. Require ≥2 chars per term so a token actually narrows
+// the postings list; shorter tokens are dropped, and a query with nothing left reads as empty.
+export const MIN_QUERY_TOKEN_CHARS = 2;
+
+/**
+ * The letter/digit tokens of a query that survive the FTS filter: lowercased, ≥MIN_QUERY_TOKEN_CHARS
+ * long, capped at MAX_QUERY_CHARS of input and MAX_QUERY_TOKENS terms. Punctuation is dropped.
+ */
+export function searchTokens(q: string): string[] {
+  return (
+    q
+      .slice(0, MAX_QUERY_CHARS)
+      .toLowerCase()
+      .match(/[\p{L}\p{N}]+/gu)
+      ?.filter((t) => t.length >= MIN_QUERY_TOKEN_CHARS)
+      .slice(0, MAX_QUERY_TOKENS) ?? []
+  );
+}
+
+/** True when a query yields at least one token the backend will actually MATCH on. */
+export function hasSearchableTerms(q: string): boolean {
+  return searchTokens(q).length > 0;
+}


### PR DESCRIPTION
## Какво и защо

Добавя търсачка в самата таблица на трите списъка — **Възложители** (`/authorities`),
**Фирми** (`/companies`) и **Договори** (`/contracts`). Полето задава/изчиства параметъра
`q` в URL адреса, като **запазва останалите филтри и подредбата** и **нулира страницирането**.

Работи и **без JavaScript** (обикновена `GET` форма със скрити полета за активните параметри),
а с JS се подобрява до **търсене на живо** с дебоунс (~300 ms) през `useSubmit`, в тон с
търсачката на сайта. Изчистването е през нативния бутон на `type="search"` полето.

Бекендът (FTS `search_index`) вече четеше `q` — промяната е **само в UI**.

Накратко:
- Нов чист помощник `searchHref` в `app/lib/filters.ts` (огледало на `sortHref`).
- Нов компонент `TableSearch` в `app/components/ListControls.tsx` + проп `searchLabel`.
- Стилове `.table-search` в `app.css` (вкл. стилизиран нативен бутон за изчистване).
- `FilterRail` запазва активното `q` при смяна на филтър без JS.

## Свързан issue

Closes #62

## Вид промяна

- [x] `feat` — нова функционалност

## Как е тествано

Автоматично (минава):
- `pnpm --filter @sigma/web typecheck` → exit 0
- `pnpm --filter @sigma/web test` → 90/90 (вкл. нови тестове за `searchHref` в `filters.test.ts`)
- `pnpm lint` (Prettier) → чисто за засегнатите файлове

Ръчна UI проверка — **предстои** (на /companies, /authorities, /contracts): търсенето филтрира
на живо; филтрите и подредбата се запазват; страницирането се нулира; изчистването връща пълния
списък; работа и без JS (Enter).

## Чеклист

- [x] Комитите следват conventional commits и **нямат** `Co-Authored-By:` trailer
- [x] PR-ът е с **един логически обхват** и е от форк към `midt-bg/sigma:main`
- [x] `pnpm typecheck` минава
- [x] `pnpm test` (за засегнатия пакет) минава
- [x] `pnpm lint` е чисто
- [x] Няма комитнати тайни, `.env*` или `.dev.vars`
- [ ] Документацията в `docs/` — не се налага (само UI)
