### PR TITLE
fix(web): apply the bids filter to the contracts csv export

### DIFF
--- a/apps/web/app/lib/csv-export.test.ts
+++ b/apps/web/app/lib/csv-export.test.ts
@@ -284,6 +284,7 @@ describe('isUnfilteredCsvExport', () => {
         authority: '',
         bidder: '',
         countBucket: '',
+        bids: null,
         q: '   ',
       }),
     ).toBe(true);
@@ -301,6 +302,7 @@ describe('isUnfilteredCsvExport', () => {
     ['eu', { eu: 'eu' }],
     ['authority', { authority: '123456789' }],
     ['bidder', { bidder: 'acme' }],
+    ['contracts.bids', { bids: 'one' }],
     ['q', { q: 'rail' }],
     ['companies.kinds', { kinds: ['company'] }],
     ['companies.countBucket', { countBucket: '2-5' }],

--- a/apps/web/app/lib/csv-export.ts
+++ b/apps/web/app/lib/csv-export.ts
@@ -5,7 +5,10 @@ const CSV_CACHE_CONTROL = 'public, max-age=3600';
 const CSV_MULTIPART_PART_SIZE = 8 * 1024 * 1024;
 
 const ARRAY_FILTERS = ['years', 'sectors', 'procedureGroups', 'kinds', 'types'] as const;
-const SCALAR_FILTERS = ['valueBucket', 'eu', 'authority', 'bidder', 'countBucket'] as const;
+// `bids` ('one' = single-offer) narrows the contracts export. Without it here, `/contracts.csv?bids=1`
+// would be treated as unfiltered and served the cached full-corpus object instead of streaming the
+// filtered rows (#138). Only the contracts params carry a `bids` key, so this is inert elsewhere.
+const SCALAR_FILTERS = ['valueBucket', 'eu', 'authority', 'bidder', 'countBucket', 'bids'] as const;
 const FILENAMES = {
   contracts: 'sigma-contracts.csv',
   companies: 'sigma-companies.csv',

--- a/apps/web/app/lib/filters.test.ts
+++ b/apps/web/app/lib/filters.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { CPV_SECTORS } from '@sigma/config';
-import { companyListParams, getMulti, leaderboardRankOffset, MAX_MULTI_VALUES } from './filters';
+import {
+  companyListParams,
+  contractListParams,
+  getMulti,
+  leaderboardRankOffset,
+  MAX_MULTI_VALUES,
+} from './filters';
 
 describe('getMulti', () => {
   it('caps repeated and CSV multi-value params', () => {
@@ -46,6 +52,40 @@ describe('getMulti', () => {
       sectors: [knownSector],
       years: ['2024', '2016', 'unknown'],
       eu: 'eu',
+    });
+  });
+});
+
+describe('contractListParams', () => {
+  it('parses the bids single-offer flag so the page and CSV filter identically (#138)', () => {
+    expect(contractListParams(new URLSearchParams('bids=1')).bids).toBe('one');
+    expect(contractListParams(new URLSearchParams('')).bids).toBeNull();
+    expect(contractListParams(new URLSearchParams('bids=2')).bids).toBeNull();
+  });
+
+  it('carries the full contract filter set shared by /contracts and /contracts.csv', () => {
+    const knownSector = CPV_SECTORS[0]!.code;
+    const sp = new URLSearchParams();
+    sp.set('sector', `${knownSector},99`);
+    sp.set('year', '2024');
+    sp.set('procedure', 'open');
+    sp.set('value', 'gt100m');
+    sp.set('eu', 'eu');
+    sp.set('authority', '123456789');
+    sp.set('bidder', 'acme');
+    sp.set('q', 'rail');
+    sp.set('bids', '1');
+
+    expect(contractListParams(sp)).toMatchObject({
+      sectors: [knownSector],
+      years: ['2024'],
+      procedureGroups: ['open'],
+      valueBucket: 'gt100m',
+      eu: 'eu',
+      authority: '123456789',
+      bidder: 'acme',
+      q: 'rail',
+      bids: 'one',
     });
   });
 });

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -4,7 +4,7 @@
 
 import { CPV_CATEGORIES, CPV_SECTORS, categoryForDivision } from '@sigma/config';
 import type { EntityKind } from '@sigma/api-contract';
-import { normalizeCompanySort } from '@sigma/db';
+import { normalizeCompanySort, normalizeContractSort } from '@sigma/db';
 import type { CpvCategory } from '@sigma/config';
 import type { FilterCategory, FilterGroup, FilterOption } from '../components/FilterRail';
 
@@ -39,6 +39,25 @@ export function companyListParams(sp: URLSearchParams) {
     years: getMulti(sp, 'year'),
     eu: (sp.get('eu') as 'eu' | 'national' | null) || null,
     q: sp.get('q'),
+  };
+}
+
+// Shared contract list/CSV filter params. Used by BOTH the /contracts page loader and the
+// /contracts.csv export so the two can never drift — the CSV previously parsed these inline and
+// omitted `bids`, downloading every contract for a `?bids=1` view (#138). The page loader adds its
+// own `cursor`/`pageSize` on top; the CSV uses these as-is.
+export function contractListParams(sp: URLSearchParams) {
+  return {
+    sort: normalizeContractSort(sp.get('sort')),
+    years: getMulti(sp, 'year'),
+    sectors: getMulti(sp, 'sector'),
+    procedureGroups: getMulti(sp, 'procedure'),
+    valueBucket: sp.get('value'),
+    eu: (sp.get('eu') as 'eu' | 'national' | null) || null,
+    authority: sp.get('authority'),
+    bidder: sp.get('bidder'),
+    q: sp.get('q'),
+    bids: (sp.get('bids') === '1' ? 'one' : null) as 'one' | null,
   };
 }
 

--- a/apps/web/app/routes/contracts.csv.tsx
+++ b/apps/web/app/routes/contracts.csv.tsx
@@ -1,23 +1,14 @@
-import { streamContractsCsv, normalizeContractSort } from '@sigma/db';
+import { streamContractsCsv } from '@sigma/db';
 import type { Route } from './+types/contracts.csv';
 import { servedCsvExport } from '../lib/csv-export';
-import { getMulti } from '../lib/filters';
+import { contractListParams } from '../lib/filters';
 
-// Resource route (no default export): a streamed text/csv Response honouring the list filters.
+// Resource route (no default export): a streamed text/csv Response honouring the list filters. Uses
+// the same contractListParams as the /contracts page so the export can never drift from the view —
+// notably it now applies `?bids=1` (single-offer), which it previously ignored (#138).
 export async function loader({ request, context }: Route.LoaderArgs) {
   const sp = new URL(request.url).searchParams;
-  const sort = normalizeContractSort(sp.get('sort'));
-  const params = {
-    sort,
-    years: getMulti(sp, 'year'),
-    sectors: getMulti(sp, 'sector'),
-    procedureGroups: getMulti(sp, 'procedure'),
-    valueBucket: sp.get('value'),
-    eu: (sp.get('eu') as 'eu' | 'national' | null) || null,
-    authority: sp.get('authority'),
-    bidder: sp.get('bidder'),
-    q: sp.get('q'),
-  };
+  const params = contractListParams(sp);
   return servedCsvExport({
     env: context.cloudflare.env,
     request,

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -1,11 +1,6 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
 import { count, date, money, moneyBare } from '@sigma/shared';
-import {
-  contractsSummary,
-  getContractFacets,
-  listContracts,
-  normalizeContractSort,
-} from '@sigma/db';
+import { contractsSummary, getContractFacets, listContracts } from '@sigma/db';
 import type { Route } from './+types/contracts';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -15,6 +10,7 @@ import { Pagination } from '../components/Pagination';
 import { Callout } from '../components/ui';
 import {
   buildSectorGroup,
+  contractListParams,
   getMulti,
   leaderboardRankOffset,
   pageNav,
@@ -50,16 +46,7 @@ export function headers() {
 export async function loader({ request, context }: Route.LoaderArgs) {
   const sp = new URL(request.url).searchParams;
   const params = {
-    sort: normalizeContractSort(sp.get('sort')),
-    years: getMulti(sp, 'year'),
-    sectors: getMulti(sp, 'sector'),
-    procedureGroups: getMulti(sp, 'procedure'),
-    valueBucket: sp.get('value'),
-    eu: (sp.get('eu') as 'eu' | 'national' | null) || null,
-    authority: sp.get('authority'),
-    bidder: sp.get('bidder'),
-    q: sp.get('q'),
-    bids: (sp.get('bids') === '1' ? 'one' : null) as 'one' | null,
+    ...contractListParams(sp),
     cursor: sp.get('cursor'),
     pageSize: PAGE_SIZE.contracts,
   };


### PR DESCRIPTION
## What and why

`/contracts.csv` ignored `?bids=1`: the export route parsed its filters **inline** and omitted `bids`, while the `/contracts` page parses it (`contracts.tsx`) and applies `c.bids_received = 1`. So a single-offer view on screen downloaded **every** contract — a silent data-correctness gap for a transparency tool (#138).

There is also a **second, cache-level dimension** worth flagging: `isUnfilteredCsvExport()` (which decides whether to serve the cached full-corpus object vs stream dynamically) checked a fixed filter list that didn't include `bids`. So even once the export reads `bids`, `/contracts.csv?bids=1` would still have been treated as *unfiltered* and served the cached all-contracts file. Both halves are fixed here.

## The fix (root cause, not just the symptom)

- Extracted **`contractListParams(sp)`** in `app/lib/filters.ts` (mirroring the existing `companyListParams`) and used it in **both** `contracts.tsx` and `contracts.csv.tsx`, so the page and the export can no longer drift — the duplicated inline parsing is exactly what let `bids` go missing.
- Added `bids` to the export's filter recognition (`SCALAR_FILTERS` in `csv-export.ts`) so `?bids=1` streams the filtered rows instead of being served the cached full export.

**Parity audit** (the issue asked to "review the other filters"): `/authorities` ↔ `/authorities.csv` already parse the same filters, and `/companies` ↔ `/companies.csv` already share `companyListParams` — both verified in parity and left unchanged to keep this focused. Extracting an `authorityListParams` the same way would be a reasonable follow-up.

The query side already applies the filter: `buildFilters` (`packages/db/src/queries/contracts.ts`) turns `bids: 'one'` into `c.bids_received = 1` and is shared by `listContracts` and `streamContractsCsv` — so passing the param through is all that was missing.

## Type of change

- [x] `fix` — bug fix (with a small `refactor` to remove the duplication that caused it)

## How tested

- `pnpm typecheck` — passes (7/7 packages).
- `app/lib/filters.test.ts` — new `contractListParams` tests: parses `bids=1` → `'one'`, absent/other → `null`, and the full shared filter set.
- `app/lib/csv-export.test.ts` — `bids` added to the "narrowing" cases (so `?bids=1` is no longer treated as unfiltered) and to the unfiltered-fictive case.
- Full `@sigma/web` suite: **87 passed**.

## Checklist

- [x] Conventional commit, **no** `Co-Authored-By:` trailer
- [x] One logical change, fork → `midt-bg/sigma:main`
- [x] `pnpm typecheck` passes
- [x] `pnpm test` (affected package) passes
- [ ] `pnpm lint` — pre-existing repo-wide prettier debt (untouched files included; #88/#105). New lines follow the surrounding style; no global `format` run, to avoid unrelated churn.
- [x] No secrets, `.env*` or `.dev.vars`
- [x] No `docs/` change needed (behaviour fix; methodology unaffected)

Closes #138.
