### PR TITLE
fix(web): stop list pagination next at the displayed last page

### DIFF
--- a/apps/web/app/lib/filters.test.ts
+++ b/apps/web/app/lib/filters.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { CPV_SECTORS } from '@sigma/config';
-import { companyListParams, getMulti, leaderboardRankOffset, MAX_MULTI_VALUES } from './filters';
+import {
+  companyListParams,
+  getMulti,
+  leaderboardRankOffset,
+  MAX_MULTI_VALUES,
+  pageNav,
+} from './filters';
 
 describe('getMulti', () => {
   it('caps repeated and CSV multi-value params', () => {
@@ -55,5 +61,57 @@ describe('leaderboardRankOffset', () => {
     expect(leaderboardRankOffset(1, 25)).toBe(0);
     expect(leaderboardRankOffset(2, 25)).toBe(25);
     expect(leaderboardRankOffset(3, 15)).toBe(30);
+  });
+});
+
+describe('pageNav', () => {
+  const sp = (qs: string) => new URLSearchParams(qs);
+
+  it('forces page 1 and offers Next when there is no cursor', () => {
+    const nav = pageNav({ base: sp(''), total: 100, pageSize: 25, nextCursor: 'c2', prevCursor: null });
+    expect(nav.page).toBe(1);
+    expect(nav.pageCount).toBe(4);
+    expect(nav.prevHref).toBeNull();
+    expect(nav.nextHref).toContain('page=2');
+  });
+
+  it('keeps Next enabled mid-list and advances both cursor and page marker', () => {
+    const nav = pageNav({
+      base: sp('cursor=c2&page=2'),
+      total: 100,
+      pageSize: 25,
+      nextCursor: 'c3',
+      prevCursor: 'c1',
+    });
+    expect(nav.page).toBe(2);
+    expect(nav.nextHref).toContain('page=3');
+    expect(nav.prevHref).toContain('page=1');
+  });
+
+  it('disables Next on the displayed last page even while a cursor remains (#87)', () => {
+    // A stale/forged ?page beyond pageCount clamps to pageCount; Next must not keep walking past it
+    // with a frozen „N от M" / rank. Before the fix nextHref was non-null here.
+    const nav = pageNav({
+      base: sp('cursor=c4&page=9'),
+      total: 100,
+      pageSize: 25,
+      nextCursor: 'c5',
+      prevCursor: 'c3',
+    });
+    expect(nav.pageCount).toBe(4);
+    expect(nav.page).toBe(4); // clamped to pageCount
+    expect(nav.nextHref).toBeNull();
+    expect(nav.prevHref).not.toBeNull();
+  });
+
+  it('disables Next at the true end when the cursor is exhausted', () => {
+    const nav = pageNav({
+      base: sp('cursor=c4&page=4'),
+      total: 100,
+      pageSize: 25,
+      nextCursor: null,
+      prevCursor: 'c3',
+    });
+    expect(nav.nextHref).toBeNull();
   });
 });

--- a/apps/web/app/lib/filters.ts
+++ b/apps/web/app/lib/filters.ts
@@ -215,6 +215,14 @@ export function pageNav(opts: {
     pageCount,
     prevHref:
       page > 1 && prevCursor ? withParams(base, { cursor: prevCursor, page: page - 1 }) : null,
-    nextHref: nextCursor ? withParams(base, { cursor: nextCursor, page: page + 1 }) : null,
+    // Gate Next on the displayed page too, not only on the cursor. When the URL's `page` marker has
+    // drifted to (or past) pageCount while the keyset still yields rows, the old `nextCursor ? …`
+    // kept Next enabled and emitted page+1 — which re-clamps to pageCount, so „Страница N от M" and
+    // the rank column froze while the rows kept advancing (#87). Stopping at the displayed last page
+    // keeps the marker, the rank, and the rows in sync.
+    nextHref:
+      nextCursor && page < pageCount
+        ? withParams(base, { cursor: nextCursor, page: page + 1 })
+        : null,
   };
 }


### PR DESCRIPTION
## What and why

Keyset (cursor) list pagination drives the rows from the cursor, but the "Страница N от M" counter and the rank ("#") column from a separately-clamped `?page` marker. When the `page` marker drifts to/past `pageCount` while the keyset still yields rows, "Следваща" stayed enabled and emitted `page + 1`, which re-clamps to `pageCount` — so the counter and rank **froze** while the rows kept advancing (#87). It lives in the shared `pageNav`, so it affected `/companies`, `/authorities` and `/contracts`.

## The fix

Gate `nextHref` on the displayed page as well as the cursor — the fix proposed in the issue:

```ts
nextHref: nextCursor && page < pageCount ? withParams(base, { cursor: nextCursor, page: page + 1 }) : null
```

Now "Следваща" disables on the displayed last page, keeping the marker, the rank, and the rows in sync. One change in the shared helper fixes all three list pages.

## Type of change

- [x] `fix` — bug fix

## How tested

- `pnpm typecheck` — passes (7/7 packages).
- New `pageNav` tests in `app/lib/filters.test.ts` (there were none before): no cursor → page 1 + Next offered; mid-list → Next advances the marker; **clamped page with a remaining cursor → Next is null** (the #87 regression guard); cursor exhausted → Next is null; Prev behaviour asserted unchanged.
- Full `@sigma/web` suite: **88 passed**.

## Acceptance criteria (from the issue)

- [x] "Следваща" disables on the displayed last page (`page >= pageCount`).
- [x] "Страница N от M" and the rank no longer freeze/contradict the rows on deep listing (Next stops, so the clamped-but-walking state is unreachable via the control).
- [x] Consistent across `/companies`, `/authorities`, `/contracts` (shared `pageNav`).
- [x] Test fixing `nextHref == null` when `page >= pageCount`.
- [x] No regression to keyset Prev/Next or cursor-based scroll restoration (#53) — only the boundary gate changed; cursors and URLs for valid pages are untouched.

## Checklist

- [x] Conventional commit, **no** `Co-Authored-By:` trailer
- [x] One logical change, fork → `midt-bg/sigma:main`
- [x] `pnpm typecheck` passes
- [x] `pnpm test` (affected package) passes
- [ ] `pnpm lint` — pre-existing repo-wide prettier debt (untouched files included; #88/#105). New lines follow the surrounding style; no global `format` run, to avoid unrelated churn.
- [x] No secrets, `.env*` or `.dev.vars`
- [x] No `docs/` change needed (behaviour fix)

Closes #87.
