### PR TITLE
feat(web): add scroll-to-top button

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -3548,3 +3548,55 @@ tbody td,
 .external-eik-link svg {
   opacity: 0.7;
 }
+
+/* Scroll to top button */
+.scroll-to-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 50;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(16px);
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease, background 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.scroll-to-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.scroll-to-top:hover,
+.scroll-to-top:focus-visible {
+  background: var(--accent);
+  outline: none;
+}
+.scroll-to-top:focus-visible {
+  box-shadow: 0 0 0 3px var(--paper), 0 0 0 5px var(--accent);
+}
+
+.scroll-to-top svg {
+  width: 24px;
+  height: 24px;
+}
+
+@media (max-width: 760px) {
+  .scroll-to-top {
+    bottom: 16px;
+    right: 16px;
+    width: 44px;
+    height: 44px;
+  }
+}

--- a/apps/web/app/components/ScrollToTop.tsx
+++ b/apps/web/app/components/ScrollToTop.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+export function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 400) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility, { passive: true });
+    // Initial check in case the page is loaded already scrolled down
+    toggleVisibility();
+
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`scroll-to-top ${isVisible ? 'is-visible' : ''}`}
+      onClick={scrollToTop}
+      aria-label="Към началото"
+      aria-hidden={!isVisible}
+      tabIndex={isVisible ? 0 : -1}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="12" y1="19" x2="12" y2="5" />
+        <polyline points="5 12 12 5 19 12" />
+      </svg>
+    </button>
+  );
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -19,6 +19,7 @@ import { useNonce } from './nonce';
 import { SiteHeader } from './components/SiteHeader';
 import { SiteFooter } from './components/SiteFooter';
 import { AccessibilityWidget } from './components/AccessibilityWidget';
+import { ScrollToTop } from './components/ScrollToTop';
 import { PageHeader } from './components/PageHeader';
 import { getCoverageMeta } from './lib/coverage';
 import { withDbRetry } from './lib/retry';
@@ -188,6 +189,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
         refreshedAt={loaderData.refreshedAt}
         endYear={loaderData.coverageEndYear}
       />
+      <ScrollToTop />
       <AccessibilityWidget />
     </>
   );


### PR DESCRIPTION
## Какво и защо

Този PR добавя функционалност и бутон "Към началото" (Scroll to Top) в основния лейаут (`root.tsx`), за да се подобри UX/UI изживяването на потребителите.

**Потребителска история:**
Като потребител на платформата СИГМА, често преглеждам дълги списъци с договори, институции и компании. Когато скролирам надолу, искам да имам удобен и бърз начин да се върна в началото на страницата, за да използвам основната навигация или търсачката, без да се налага да скролирам ръчно обратно нагоре.

**Детайли по имплементацията:**
- Създаден е нов компонент `ScrollToTop.tsx` с плавно визуализиране при скролиране над 400px надолу.
- Интегриран глобално в `root.tsx`.
- Използвани са вградените дизайн токъни (`var(--ink)`, `var(--accent)`) за визуална консистентност с editorial стила на СИГМА.
- Осигурена е пълна достъпност с ARIA атрибути (`aria-label`) и фокус мениджмънт чрез клавиатура (tabIndex и focus-visible стилове).

## Свързан issue

N/A (Самостоятелно UX/UI подобрение)

## Вид промяна

- [ ] `fix` — поправка на бъг
- [x] `feat` — нова функционалност
- [ ] `docs` — документация
- [ ] `refactor` / `perf` / `style` — без промяна в поведението
- [ ] `test` / `ci` / `build` / `chore` — поддръжка

## Как е тествано

- Ръчно тестване: потвърдено е плавното скролиране, визуализацията и скриването на компонента.
- Проверка за адаптивност на мобилни устройства.
- Тестване за клавиатурна достъпност (Tab навигация, Enter активация и ясен контур на фокуса).

## Чеклист

- [x] Комитите следват [conventional commits](https://www.conventionalcommits.org) и **нямат** `Co-Authored-By:` trailer
- [x] PR-ът е с **един логически обхват** и е от форк към `midt-bg/sigma:main`
- [ ] `pnpm typecheck` минава
- [ ] `pnpm test` (поне за засегнатите пакети) минава
- [ ] `pnpm lint` е чисто
- [x] Няма комитнати тайни, `.env*` или `.dev.vars`
- [x] Документацията в `docs/` е обновена, ако промяната го налага