### PR TITLE
ci(deploy): harden production deploy auth and add approval gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,12 @@ on:
         type: choice
         options:
           - staging
+          # Once provision-environments.sh has been applied, selecting `production` here only
+          # works when the workflow is dispatched from a `v*` tag ref, e.g.:
+          #   gh workflow run deploy.yml --ref v1.0.1 -f environment=production
+          # Dispatching from a branch ref (e.g. main) is refused by the environment tag policy.
+          # Admins may bypass this via the `admins_can_bypass` setting (Settings → Environments
+          # → production) for emergency situations.
           - production
         default: staging
 
@@ -59,6 +65,11 @@ jobs:
     needs: detect
     if: needs.detect.outputs.env != ''
     runs-on: ubuntu-latest
+    # Explicit cap instead of the 360-min GitHub default: a full build + two-Worker wrangler deploy
+    # runs in single-digit minutes, so a job past 10 min is hung (stalled network I/O, wedged
+    # wrangler) — fail fast rather than burn a 6-hour slot. The required-reviewers wait on
+    # `production` does NOT count against this; the timer starts only once the job hits a runner.
+    timeout-minutes: 10
     environment: ${{ needs.detect.outputs.env }}
     concurrency:
       group: deploy-${{ needs.detect.outputs.env }}
@@ -165,6 +176,10 @@ jobs:
           fi
 
           key="$(openssl rand -hex 32)"
+          # Register the value as a secret with the runner BEFORE it is used anywhere else, so an
+          # accidental echo / set -x trace in a later edit can never leak it. Masking is not
+          # retroactive within a line, hence add-mask on the line right after generation.
+          echo "::add-mask::$key"
           printf '%s' "$key" | pnpm --filter @sigma/web exec wrangler secret put LOG_IP_KEY --name "$SIGMA_WEB_NAME"
 
       - name: Deploy refresh Workflow (sigma-etl)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -119,6 +119,19 @@ Custom token-ът се нуждае само от тези **Account**-ниво 
 не е нужно отделно **Workflows** право — то се покрива от Workers Scripts: Edit; някои dashboard-и не
 изброяват самостоятелен Workflows scope.)
 
+> **Expiry + ротация.** Cloudflare token-ите по подразбиране **не изтичат**. Задайте `expires_on` ~90
+> дни напред при създаване и сложете напомняне за тримесечна ротация: регенерирайте token-а и обновете
+> GitHub секрета `CLOUDFLARE_API_TOKEN`. IP филтриране е непрактично за GitHub-hosted runner-ите
+> (голям, променлив egress диапазон) — пропуснете го, освен ако не минете на self-hosted runner с
+> фиксиран изходящ IP.
+>
+> **Защо все още дълголетен token, а не OIDC?** Към юни 2026 Cloudflare **няма** OIDC / workload
+> identity federation за Wrangler (за разлика от AWS `configure-aws-credentials` / GCP WIF) — няма
+> token-exchange endpoint, който да размени GitHub OIDC token за краткотраен Cloudflare credential.
+> Отвореното искане ([workers-sdk#11434](https://github.com/cloudflare/workers-sdk/discussions/11434))
+> няма отговор от Cloudflare. Затова смекчаването е **минимални scope-ове + expiry + ротация**, не
+> keyless auth. Преразгледайте, ако Cloudflare пусне OIDC.
+
 ## 1. Provisioning на D1 (за всяка среда, локално)
 
 Всяка среда получава **собствена** база. `SIGMA_D1_NAME` избира името (по подразбиране `sigma`):
@@ -187,12 +200,54 @@ domain таблиците и преизчислява rollup-ите + FTS.
 - променливи `SIGMA_WEB_NAME` = `sigma-stage`, `SIGMA_ETL_NAME` = `sigma-etl-stage`,
   `SIGMA_WORKFLOW_NAME` = `sigma-refresh-stage`, `SIGMA_D1_NAME` = `sigma-stage`
 
-> Средата `production` е **неблокираща** за създаване: дори с `environment: production` зададено на
-> job-а, GitHub все още излага repo-ниво секретите, така че production продължава да се деплойва с
-> днешните repo секрети, докато не решите да ги преместите в средата.
+> **Approval gate се прилага** след като `provision-environments.sh` е изпълнен — всеки production
+> деплой изисква ръчно одобрение преди да достигне runner. Средата `production` е **неблокираща само
+> за създаването** на самата среда в Settings: дори с `environment: production` зададено на job-а,
+> GitHub излага repo-ниво секретите, така че production продължава да се деплойва с днешните repo
+> секрети, докато не ги преместите в средата — но одобрението се прилага независимо от това.
 
-> Опционално подсилване: дайте на `production` **required reviewers**, за да изчака prod деплой ръчен
-> клик "Review deployments".
+### Approval gate за production (задължително)
+
+Production деплой **изисква човешко одобрение**. Един `v*` таг сам по себе си повече **не** пуска прод
+автоматично — job-ът спира на „Review deployments“ преди да стигне runner (т.е. преди Cloudflare
+автентикацията изобщо да се изпълни). Това е protection rule на средата, не YAML — затова го кодираме
+в скрипт, за да е възпроизводимо и одитируемо вместо невидим клик в UI-я:
+
+```bash
+REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh   # required reviewers + v* tag policy
+# или с конкретни хора:
+REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
+```
+
+Скриптът ([scripts/provision-environments.sh](../scripts/provision-environments.sh)) задава на
+`production`:
+1. **Required reviewers** (+ `prevent_self_review`) — поне един човек трябва да одобри прод деплоя.
+2. **Deployment tag policy `v*`** — GitHub сам отказва прод деплой, ако ref-ът не е release таг, дори
+   ако `detect` логиката в [deploy.yml](../.github/workflows/deploy.yml) някога сгреши (defense in
+   depth). Job-ът има и изричен `timeout-minutes: 10` вместо 360-мин default.
+
+> **⚠ Four-eyes уговорка.** `prevent_self_review` пречи *само* на инициатора на деплоя да одобри
+> собствения си run. **Един** reviewer не е четири-очен контрол — инициаторът и одобряващият могат да са
+> двама различни души, но без допълнителна политика нищо не пречи на един човек да пусне и одобри
+> последователно. За истинско four-eyes задайте **≥2 индивидуални reviewer-а** (напр.
+> `REVIEWER_USERS="alice,bob"`) или екип с ≥2 членове, така че нито един човек да не може сам да
+> инициира *и* одобри production деплой.
+
+> **`wait_timer`.** PUT-ът на скрипта заменя целия protection-rule set и нулира `wait_timer` на 0,
+> ако не подадете `WAIT_TIMER=<минути>`. Стойност, зададена в GitHub UI, не се запазва при повторно
+> изпълнение без тази променлива.
+
+> Изчакването за одобрение **не** влиза в `timeout-minutes` — таймерът тръгва чак щом job-ът хване
+> runner, след одобрението.
+
+> **`workflow_dispatch` и tag policy.** След като скриптът е изпълнен, ръчното стартиране на деплой
+> към `production` чрез `workflow_dispatch` успява **само от `v*` таг ref**, например:
+> ```bash
+> gh workflow run deploy.yml --ref v1.0.1 -f environment=production
+> ```
+> Стартиране от branch ref (напр. `main`) се отказва автоматично от GitHub на ниво protection rule — не
+> достига до runner-а. Администратори могат да заобиколят това при спешни случаи чрез настройката
+> `admins_can_bypass` (Settings → Environments → production).
 
 ## 4. Деплой
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -215,9 +215,15 @@ Production деплой **изисква човешко одобрение**. Е
 
 ```bash
 REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh   # required reviewers + v* tag policy
-# или с конкретни хора:
+# или с конкретни хора (≥2 за реален four-eyes):
 REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
 ```
+
+> **Provision-вайте с екип, не с личен акаунт.** Прод деплоят минава през **група**
+> (`REVIEWER_TEAMS="midt-bg/maintainers"`), а не през конкретен личен reviewer. Единичен потребител
+> концентрира одобрението на прод деплоя в едно лице и може да **заключи** деплоя, ако този човек е и
+> инициаторът (`prevent_self_review` пази само инициатора — виж four-eyes уговорката по-долу).
+> Примерът с единичен `REVIEWER_USERS` е само илюстрация на синтаксиса — не provision-вайте прод с него.
 
 Скриптът ([scripts/provision-environments.sh](../scripts/provision-environments.sh)) задава на
 `production`:

--- a/scripts/provision-environments.sh
+++ b/scripts/provision-environments.sh
@@ -33,11 +33,11 @@
 #   configure at least two individual reviewers (or a team with ≥2 members), so no single person
 #   can both initiate and approve a production deploy.
 #
-# Usage:
-#   REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
-#   REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh
-#   WAIT_TIMER=10 REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
-#   REPO=other-org/other-repo REVIEWER_USERS="alice" ./scripts/provision-environments.sh
+# Usage (prefer a TEAM over individuals so prod approval isn't concentrated in one person):
+#   REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh   # recommended
+#   REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh             # ≥2 for real four-eyes
+#   WAIT_TIMER=10 REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh
+#   REPO=other-org/other-repo REVIEWER_TEAMS="other-org/maintainers" ./scripts/provision-environments.sh
 #
 set -euo pipefail
 

--- a/scripts/provision-environments.sh
+++ b/scripts/provision-environments.sh
@@ -57,6 +57,16 @@ else
   fi
 fi
 
+# Symmetric path-traversal guard (same intent as the reviewer-ref guards below): REPO is
+# interpolated into the gh api paths, so reject anything that isn't a clean owner/name. Owner is
+# letters/digits/hyphens; repo name additionally allows '.' and '_'. A value with an extra '/' or
+# other characters could otherwise traverse to a different endpoint. Low risk (an admin supplies
+# it), but the check keeps every interpolated segment validated the same way.
+if ! [[ "$REPO" =~ ^[A-Za-z0-9-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "❌ REPO must be in owner/name form (got '$REPO')." >&2
+  exit 1
+fi
+
 ENVIRONMENT="production"
 REVIEWER_USERS="${REVIEWER_USERS:-}"
 REVIEWER_TEAMS="${REVIEWER_TEAMS:-}"

--- a/scripts/provision-environments.sh
+++ b/scripts/provision-environments.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Provision the `production` GitHub Environment's deploy-governance rules for issue #89.
+#
+# Why this exists: Environment protection rules (required reviewers, deployment branch/tag
+# policies) live in repo Settings, NOT in deploy.yml — the workflow only *references* the
+# environment by name. Clicking them in the UI is invisible to review and easy to drift. This
+# script codifies them so the production approval gate is reproducible and auditable.
+#
+# It is idempotent w.r.t. the fields this script manages: re-running re-applies the same rules
+# and converges the tag policy to exactly one `v*` tag policy (removing any stale policies).
+# It does NOT preserve out-of-band UI state such as `wait_timer` unless WAIT_TIMER is passed.
+# If the script aborts mid-run, simply re-run — each step is idempotent individually.
+#
+# What it configures on the `production` environment:
+#   1. Required reviewers (+ prevent self-review) — a human must click "Review deployments"
+#      before a prod deploy reaches a runner (so before Cloudflare auth ever runs).
+#   2. A deployment TAG policy `v*` — GitHub itself refuses to deploy `production` unless the ref
+#      is a release tag, even if deploy.yml's `detect` logic were wrong (defense in depth).
+#
+# Prerequisites:
+#   - gh CLI authenticated with admin rights on the repo (`gh auth status`).
+#   - REPO env var set to owner/name, OR the command must run inside the git checkout so that
+#     `gh repo view` can derive it automatically. If neither is available the script errors out.
+#   - Reviewers passed as env vars (at least one required):
+#       REVIEWER_USERS="alice,bob"             # GitHub logins (≥2 individuals for four-eyes)
+#       REVIEWER_TEAMS="midt-bg/maintainers"   # org/team-slug (optional; team must have ≥2 members)
+#   - WAIT_TIMER (optional, integer minutes): if set, the environment's wait_timer is configured
+#       to this value. Omit to reset it to 0 (the GitHub default).
+#
+# ⚠ Four-eyes note: `prevent_self_review` only prevents the *deploy initiator* from approving
+#   their own deployment — it does NOT enforce genuine four-eyes by itself. For true four-eyes
+#   configure at least two individual reviewers (or a team with ≥2 members), so no single person
+#   can both initiate and approve a production deploy.
+#
+# Usage:
+#   REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
+#   REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh
+#   WAIT_TIMER=10 REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
+#   REPO=other-org/other-repo REVIEWER_USERS="alice" ./scripts/provision-environments.sh
+#
+set -euo pipefail
+
+# Resolve REPO: use explicit env var, otherwise derive from gh; fail loud if neither works.
+if [ -n "${REPO:-}" ]; then
+  : # already set by caller
+else
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
+    echo "❌ Could not determine repository. Set REPO=owner/name explicitly." >&2
+    echo "   Example: REPO=midt-bg/sigma REVIEWER_USERS=\"alice\" $0" >&2
+    exit 1
+  }
+  if [ -z "$REPO" ]; then
+    echo "❌ Could not determine repository. Set REPO=owner/name explicitly." >&2
+    echo "   Example: REPO=midt-bg/sigma REVIEWER_USERS=\"alice\" $0" >&2
+    exit 1
+  fi
+fi
+
+ENVIRONMENT="production"
+REVIEWER_USERS="${REVIEWER_USERS:-}"
+REVIEWER_TEAMS="${REVIEWER_TEAMS:-}"
+WAIT_TIMER="${WAIT_TIMER:-}"
+if [ -n "$WAIT_TIMER" ] && ! [[ "$WAIT_TIMER" =~ ^[0-9]+$ ]]; then
+  echo "❌ WAIT_TIMER must be a non-negative integer (minutes), got '$WAIT_TIMER'." >&2
+  exit 1
+fi
+
+if [ -z "$REVIEWER_USERS" ] && [ -z "$REVIEWER_TEAMS" ]; then
+  echo "❌ No reviewers given. Set REVIEWER_USERS and/or REVIEWER_TEAMS." >&2
+  echo "   Example: REVIEWER_USERS=\"alice,bob\" $0" >&2
+  exit 1
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI not found. Install it or run from a machine with it." >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "❌ jq not found. Install it (used to resolve reviewer ids)." >&2; exit 1; }
+
+# Trim leading/trailing whitespace from a variable — pure bash, no subprocess.
+# Usage: _trim varname  (modifies the variable in-place)
+_trim() {
+  local _var="$1"
+  local _val="${!_var}"
+  # trim leading whitespace
+  _val="${_val#"${_val%%[![:space:]]*}"}"
+  # trim trailing whitespace
+  _val="${_val%"${_val##*[![:space:]]}"}"
+  printf -v "$_var" '%s' "$_val"
+}
+
+# Build the reviewers[] array as JSON: resolve each login/team-slug to its numeric id, which the
+# environments API requires (it rejects names).
+reviewers_json="[]"
+
+add_reviewer() {  # $1=type (User|Team)  $2=id
+  reviewers_json="$(jq -c --arg t "$1" --argjson id "$2" '. += [{"type":$t,"id":$id}]' <<<"$reviewers_json")"
+}
+
+if [ -n "$REVIEWER_USERS" ]; then
+  IFS=',' read -ra users <<<"$REVIEWER_USERS"
+  for u in "${users[@]}"; do
+    _trim u
+    [ -z "$u" ] && continue
+    # Validate before interpolating into the gh api path: a login containing '/' or '.' could
+    # otherwise traverse to a different endpoint. GitHub logins are letters/digits/hyphens only.
+    [[ "$u" =~ ^[A-Za-z0-9-]+$ ]] || { echo "❌ Invalid GitHub username '$u' (allowed: letters, digits, hyphens)." >&2; exit 1; }
+    id="$(gh api "users/$u" --jq .id)" || { echo "❌ Could not resolve user '$u'." >&2; exit 1; }
+    [[ "$id" =~ ^[0-9]+$ ]] || { echo "❌ Could not resolve user '$u' to a numeric id (got: '$id')." >&2; exit 1; }
+    echo "  reviewer (user):  $u → $id"
+    add_reviewer "User" "$id"
+  done
+fi
+
+if [ -n "$REVIEWER_TEAMS" ]; then
+  IFS=',' read -ra teams <<<"$REVIEWER_TEAMS"
+  for t in "${teams[@]}"; do
+    _trim t
+    [ -z "$t" ] && continue
+    if [[ "$t" != */* ]]; then
+      echo "❌ Team '$t' must be in org/team-slug form (e.g. midt-bg/maintainers)." >&2
+      exit 1
+    fi
+    org="${t%%/*}"; slug="${t##*/}"
+    # Same path-traversal guard as for users, applied to both segments before interpolation.
+    if ! [[ "$org" =~ ^[A-Za-z0-9-]+$ ]] || ! [[ "$slug" =~ ^[A-Za-z0-9_-]+$ ]]; then
+      echo "❌ Invalid team ref '$t' (org: letters/digits/hyphens; slug: letters/digits/hyphens/underscores)." >&2
+      exit 1
+    fi
+    id="$(gh api "orgs/$org/teams/$slug" --jq .id)" || { echo "❌ Could not resolve team '$t'." >&2; exit 1; }
+    [[ "$id" =~ ^[0-9]+$ ]] || { echo "❌ Could not resolve team '$t' to a numeric id (got: '$id')." >&2; exit 1; }
+    echo "  reviewer (team):  $t → $id"
+    add_reviewer "Team" "$id"
+  done
+fi
+
+# Guard against malformed input that passes the early non-empty check but resolves to zero
+# reviewers (e.g. REVIEWER_USERS="," or whitespace-only entries). Sending an empty reviewers[]
+# would silently disable the approval gate while the PUT below still reports success — exactly
+# the failure this script exists to prevent. Fail loud instead.
+reviewer_count="$(jq 'length' <<<"$reviewers_json")"
+if [ "$reviewer_count" -eq 0 ]; then
+  echo "❌ No valid reviewers resolved — every entry in REVIEWER_USERS/REVIEWER_TEAMS was empty." >&2
+  echo "   Refusing to apply an environment with no required reviewers (gate would not exist)." >&2
+  exit 1
+fi
+
+# GitHub caps required reviewers at 6 per environment. Catch it here so the user gets a clear
+# message instead of a raw 422 from the PUT below.
+if [ "$reviewer_count" -gt 6 ]; then
+  echo "❌ $reviewer_count reviewers resolved, but GitHub allows at most 6 required reviewers per environment." >&2
+  echo "   Reduce REVIEWER_USERS/REVIEWER_TEAMS to 6 or fewer entries." >&2
+  exit 1
+fi
+
+echo "→ Applying required reviewers + tag policy to '$ENVIRONMENT' on $REPO …"
+
+# 1. Required reviewers, prevent self-review, and enable custom branch/tag policies in one PUT.
+#    Note: PUT /environments replaces the *full* protection-rule set. Re-running this script
+#    re-applies these exact rules. Any `wait_timer` set via the GitHub UI will be reset to 0
+#    unless WAIT_TIMER is passed as an env var.
+wait_timer_json="0"
+if [ -n "$WAIT_TIMER" ]; then
+  wait_timer_json="$WAIT_TIMER"
+fi
+
+gh api -X PUT "repos/$REPO/environments/$ENVIRONMENT" --input - >/dev/null <<JSON
+{
+  "wait_timer": $wait_timer_json,
+  "prevent_self_review": true,
+  "reviewers": $reviewers_json,
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  }
+}
+JSON
+echo "  ✅ required reviewers set (prevent_self_review=true, wait_timer=${wait_timer_json}min)"
+
+# 2. Enforce the v* TAG policy as the ONLY deployment branch/tag policy.
+#    Strategy: enumerate all existing policies, delete any that are NOT {type=tag, name=v*},
+#    then ensure exactly one v* tag policy exists. A LIST failure is fatal (a non-zero exit
+#    is the only way to distinguish a transient error from a genuinely empty policy set),
+#    and pagination is handled so policies beyond page 1 are not missed.
+if ! existing_policies="$(gh api --paginate \
+  "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+  --jq '.branch_policies[]?')"; then
+  echo "❌ Could not list deployment branch policies — aborting before converging tag policy." >&2
+  exit 1
+fi
+
+# Delete any policy that is not the intended v* tag policy.
+while IFS= read -r policy_json; do
+  [ -z "$policy_json" ] && continue
+  pid="$(jq -r '.id' <<<"$policy_json")"
+  pname="$(jq -r '.name' <<<"$policy_json")"
+  ptype="$(jq -r '.type' <<<"$policy_json")"
+  if [ "$ptype" = "tag" ] && [ "$pname" = "v*" ]; then
+    : # this is the one we want — keep it
+  else
+    echo "  🗑  removing stale policy: id=$pid name='$pname' type=$ptype"
+    gh api -X DELETE "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies/$pid" >/dev/null
+  fi
+done <<<"$existing_policies"
+
+# Now ensure the v* tag policy exists (idempotent: only add if missing).
+#    A re-list failure is fatal for the same reason as above.
+if ! remaining="$(gh api --paginate \
+  "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+  --jq '.branch_policies[]? | select(.type == "tag" and .name == "v*") | .name')"; then
+  echo "❌ Could not re-list deployment branch policies — aborting before ensuring v* policy." >&2
+  exit 1
+fi
+if [ -n "$remaining" ]; then
+  echo "  ✅ tag policy 'v*' already present"
+else
+  gh api -X POST "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+    -f "name=v*" -f "type=tag" >/dev/null
+  echo "  ✅ tag policy 'v*' added (only release tags may deploy to production)"
+fi
+
+echo "✅ Done. Environment converged: exactly one tag policy 'v*', required reviewers set."
+echo "   Verify in: Settings → Environments → $ENVIRONMENT"
+echo "   Note: if this run was interrupted earlier, simply re-run — it is idempotent."


### PR DESCRIPTION
## Резюме

Подсилва production deploy пътя с гейт за човешко одобрение и затяга хигиената на CI job-овете. Адресира #89.

- **Approval gate за production (задължителен).** Един `v*` таг сам по себе си вече **не** пуска прод автоматично. Deploy job-ът спира на „Review deployments“ преди да стигне runner (т.е. преди Cloudflare автентикацията изобщо да се изпълни). Кодифицирано в нов идемпотентен скрипт — `scripts/provision-environments.sh` — така че protection rule-ите на средата (required reviewers, `prevent_self_review`, `v*` deployment **tag** policy) са възпроизводими и одитируеми вместо невидими кликове в UI-я.
- **Маскиране на секрети.** `LOG_IP_KEY` се регистрира с `::add-mask::` веднага след генерирането му, преди първата му употреба, така че по-късен случаен `set -x`/echo не може да го изтече.
- **Изричен job timeout.** `deploy` job-ът вече се ограничава до 10 мин вместо 360-мин default на GitHub, така че заклещен wrangler или блокирала мрежа се провалят бързо. Изчакването за одобрение не влиза в таймера (той тръгва чак щом job-ът хване runner).
- **Документация.** `docs/deploy.md` описва approval gate-а, изтичането на token-а + тримесечната ротация, four-eyes уговорката, и защо все още се ползват дълголетни token-и (а не OIDC) — Cloudflare няма OIDC/workload-identity federation за Wrangler към юни 2026 ([workers-sdk#11434](https://github.com/cloudflare/workers-sdk/discussions/11434)).

## Файлове

| Файл | Промяна |
|------|---------|
| `scripts/provision-environments.sh` | Нов — кодифицира `production` required reviewers + `v*` tag policy |
| `.github/workflows/deploy.yml` | `timeout-minutes: 10`, `::add-mask::` за `LOG_IP_KEY`, бележка за `workflow_dispatch` tag policy |
| `docs/deploy.md` | Approval gate, ротация/изтичане на token, four-eyes caveat, OIDC обосновка |

> Тази репо няма `preview.yml`/`preview-reap.yml`, затова preview-частта от референтния подход не се прилага тук.

## Какво трябва да се направи ръчно

Protection rule-ите на средата живеят в repo Settings, **не** в YAML — затова **не** се прилагат автоматично при merge. След merge изпълнете провизиониращия скрипт **веднъж** с admin права:

```bash
REVIEWER_TEAMS="midt-bg/maintainers" ./scripts/provision-environments.sh
# или с конкретни хора:
REVIEWER_USERS="alice,bob" ./scripts/provision-environments.sh
```

Изисквания: `gh` CLI, автентикиран с **admin** права върху repo-то, и `jq`. Проверка след това: Settings → Environments → `production`.

## Acceptance (#89)

- [x] Прод деплой изисква човешко одобрение през Environment (скрипт за required reviewers + `prevent_self_review`).
- [x] Cloudflare credential-ите — минимални скоупове вече документирани; добавена ротация + обосновка защо OIDC не е възможен.
- [x] Deploy job-ът има изричен timeout (`timeout-minutes: 10`).