### PR TITLE
fix(deploy): per-env names for REPORTS + VECTORIZE bindings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,8 @@ jobs:
       SIGMA_WORKFLOW_NAME: ${{ vars.SIGMA_WORKFLOW_NAME }}
       SIGMA_D1_NAME: ${{ vars.SIGMA_D1_NAME }}
       SIGMA_CSV_CACHE_NAME: ${{ vars.SIGMA_CSV_CACHE_NAME }}
+      SIGMA_REPORTS_NAME: ${{ vars.SIGMA_REPORTS_NAME }}
+      SIGMA_VECTORIZE_NAME: ${{ vars.SIGMA_VECTORIZE_NAME }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -115,6 +117,8 @@ jobs:
           check "$SIGMA_WORKFLOW_NAME"  sigma-refresh   SIGMA_WORKFLOW_NAME
           check "$SIGMA_D1_NAME"        sigma           SIGMA_D1_NAME
           check "$SIGMA_CSV_CACHE_NAME" sigma-csv-cache SIGMA_CSV_CACHE_NAME
+          check "$SIGMA_REPORTS_NAME"   sigma-reports   SIGMA_REPORTS_NAME
+          check "$SIGMA_VECTORIZE_NAME" sigma-assistant SIGMA_VECTORIZE_NAME
           [ "$fail" = 0 ] || { echo "Refusing to deploy '${{ needs.detect.outputs.env }}' with production resource names."; exit 1; }
 
       - name: Typecheck

--- a/scripts/wrangler-render.mjs
+++ b/scripts/wrangler-render.mjs
@@ -5,8 +5,9 @@
 // `wrangler deploy` needs the real IDs — this script substitutes them from env vars and
 // writes a sibling `wrangler.deploy.<ext>` that the package `deploy` script passes via
 // `--config`. Optional deploy-time name env vars (`SIGMA_WEB_NAME`, `SIGMA_ETL_NAME`,
-// `SIGMA_WORKFLOW_NAME`, `SIGMA_D1_NAME`, `SIGMA_CSV_CACHE_NAME`) explicitly override resource
-// names for alternate environments while leaving committed names unchanged when unset.
+// `SIGMA_WORKFLOW_NAME`, `SIGMA_D1_NAME`, `SIGMA_CSV_CACHE_NAME`, `SIGMA_REPORTS_NAME`,
+// `SIGMA_VECTORIZE_NAME`) explicitly override resource names for alternate environments while
+// leaving committed names unchanged when unset.
 //
 // usage: node scripts/wrangler-render.mjs <path/to/wrangler.toml|jsonc>
 
@@ -64,8 +65,16 @@ if (ext === '.json' || ext === '.jsonc') {
     webName: process.env.SIGMA_WEB_NAME || '',
     d1Name: process.env.SIGMA_D1_NAME || '',
     csvCacheName: process.env.SIGMA_CSV_CACHE_NAME || '',
+    reportsName: process.env.SIGMA_REPORTS_NAME || '',
+    vectorizeName: process.env.SIGMA_VECTORIZE_NAME || '',
   };
-  if (names.webName || names.d1Name || names.csvCacheName) {
+  if (
+    names.webName ||
+    names.d1Name ||
+    names.csvCacheName ||
+    names.reportsName ||
+    names.vectorizeName
+  ) {
     out = renderJson(out, names);
   }
   // Most rate limiters fail OPEN at runtime (apps/web/workers/rate-limit.ts), so a missing binding or a
@@ -120,16 +129,27 @@ function assertRateLimiters(text, source) {
 }
 
 function renderJson(text, names) {
-  const obj = JSON.parse(stripJsonLineComments(text));
+  // JSONC: strip line comments AND trailing commas before JSON.parse (mirrors assertRateLimiters).
+  const obj = JSON.parse(stripJsonLineComments(text).replace(/,(\s*[}\]])/g, '$1'));
   if (names.webName) obj.name = names.webName;
   if (names.d1Name && Array.isArray(obj.d1_databases)) {
     for (const db of obj.d1_databases) {
       if (db && typeof db === 'object') db.database_name = names.d1Name;
     }
   }
-  if (names.csvCacheName && Array.isArray(obj.r2_buckets)) {
+  if (Array.isArray(obj.r2_buckets)) {
+    // Target buckets by BINDING, not blanket: a single name var must not rename every bucket
+    // (e.g. staging's SIGMA_CSV_CACHE_NAME would otherwise clobber the REPORTS bucket too).
     for (const bucket of obj.r2_buckets) {
-      if (bucket && typeof bucket === 'object') bucket.bucket_name = names.csvCacheName;
+      if (!bucket || typeof bucket !== 'object') continue;
+      if (names.csvCacheName && bucket.binding === 'CSV_CACHE')
+        bucket.bucket_name = names.csvCacheName;
+      if (names.reportsName && bucket.binding === 'REPORTS') bucket.bucket_name = names.reportsName;
+    }
+  }
+  if (names.vectorizeName && Array.isArray(obj.vectorize)) {
+    for (const index of obj.vectorize) {
+      if (index && typeof index === 'object') index.index_name = names.vectorizeName;
     }
   }
   return `${JSON.stringify(obj, null, 2)}\n`;


### PR DESCRIPTION
Fixes the broken staging deploy by giving the two resources #80 added (`REPORTS` R2 bucket, `VECTORIZE` index) proper **per-environment** names, matching how the worker/D1/CSV-cache are already parameterized.

**Changes (2 files):**
- `scripts/wrangler-render.mjs`: renderJson targets R2 buckets **by binding** (`CSV_CACHE`→`SIGMA_CSV_CACHE_NAME`, `REPORTS`→`SIGMA_REPORTS_NAME`) instead of blanket-renaming every bucket; substitutes the Vectorize `index_name` from `SIGMA_VECTORIZE_NAME`; and strips trailing commas before `JSON.parse` (mirrors `assertRateLimiters`) so the JSONC parses.
- `.github/workflows/deploy.yml`: passes `SIGMA_REPORTS_NAME` + `SIGMA_VECTORIZE_NAME`; the non-prod guard rejects reusing the production names.

**Resources already provisioned** (both envs): R2 `sigma-reports`/`sigma-reports-stage`, Vectorize `sigma-assistant`/`sigma-assistant-stage` (1024-dim, cosine). Staging env vars set to the `-stage` names.

**Prod is untouched**: it keeps committed defaults (`sigma-reports`/`sigma-assistant`) and only deploys on a version tag. Verified locally: staging render → `-stage` names; prod render → unchanged.