### PR TITLE
fix(etl): eik_valid enforces Bulstat checksum (#195)

### DIFF
--- a/scripts/normalize-raw.sql
+++ b/scripts/normalize-raw.sql
@@ -251,9 +251,9 @@ FROM (
   SELECT
     contractor_name,
     eik_clean,
-    CASE WHEN eik_clean NOT GLOB '*[^0-9]*' AND LENGTH(eik_clean) IN (9, 13) THEN 1 ELSE 0 END AS eik_valid,
+    eik_valid,
     CASE
-      WHEN eik_clean NOT GLOB '*[^0-9]*' AND LENGTH(eik_clean) IN (9, 13) THEN 'eik:' || eik_clean
+      WHEN eik_valid = 1 THEN 'eik:' || eik_clean
       WHEN contractor_name IS NOT NULL AND TRIM(contractor_name) <> '' THEN 'name:' || UPPER(TRIM(REPLACE(REPLACE(contractor_name, '  ', ' '), '  ', ' ')))
       ELSE NULL
     END AS bidder_key,
@@ -267,8 +267,42 @@ FROM (
   FROM (
     SELECT
       contractor_name,
-      TRIM(CASE WHEN contractor_eik LIKE 'ЕИК %' THEN SUBSTR(contractor_eik, 5) ELSE contractor_eik END) AS eik_clean
-    FROM raw_contracts WHERE source LIKE 'eop:%' OR source LIKE 'ocds:%'
+      eik_clean,
+      -- Bulgarian ЕИК/Булстат control-digit (checksum) validation. A merely SYNTACTIC 9/13-digit
+      -- check let the fake/service code „000000001" and wrong-digit typo twins pass, collapsing
+      -- unrelated foreign suppliers (Elsevier + Clarivate/Web of Science + a gas consultancy + a
+      -- 102 EUR construction line) onto one node (#195). Enforce the real checksum so invalid codes
+      -- get eik_valid = 0 and fall back to the name-based key, which splits them apart again.
+      --   9-digit: weight positions 1..8 by 1..8; control = sum % 11. If that is 10, re-weight by
+      --            3..10; a second 10 → 0. The 9th digit must equal the control.
+      --   13-digit: the leading 9 digits must themselves be a valid 9-digit ЕИК, then weight
+      --            positions 9..12 by 2,7,3,5 (fallback 4,9,5,7; second 10 → 0). The 13th digit
+      --            must equal that control.
+      CASE
+        WHEN eik_clean IS NULL OR eik_clean GLOB '*[^0-9]*' OR LENGTH(eik_clean) NOT IN (9, 13) THEN 0
+        WHEN (
+          CASE
+            WHEN (1 * CAST(SUBSTR(eik_clean, 1, 1) AS INTEGER) + 2 * CAST(SUBSTR(eik_clean, 2, 1) AS INTEGER) + 3 * CAST(SUBSTR(eik_clean, 3, 1) AS INTEGER) + 4 * CAST(SUBSTR(eik_clean, 4, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 5, 1) AS INTEGER) + 6 * CAST(SUBSTR(eik_clean, 6, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 7, 1) AS INTEGER) + 8 * CAST(SUBSTR(eik_clean, 8, 1) AS INTEGER)) % 11 < 10 THEN (1 * CAST(SUBSTR(eik_clean, 1, 1) AS INTEGER) + 2 * CAST(SUBSTR(eik_clean, 2, 1) AS INTEGER) + 3 * CAST(SUBSTR(eik_clean, 3, 1) AS INTEGER) + 4 * CAST(SUBSTR(eik_clean, 4, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 5, 1) AS INTEGER) + 6 * CAST(SUBSTR(eik_clean, 6, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 7, 1) AS INTEGER) + 8 * CAST(SUBSTR(eik_clean, 8, 1) AS INTEGER)) % 11
+            WHEN (3 * CAST(SUBSTR(eik_clean, 1, 1) AS INTEGER) + 4 * CAST(SUBSTR(eik_clean, 2, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 3, 1) AS INTEGER) + 6 * CAST(SUBSTR(eik_clean, 4, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 5, 1) AS INTEGER) + 8 * CAST(SUBSTR(eik_clean, 6, 1) AS INTEGER) + 9 * CAST(SUBSTR(eik_clean, 7, 1) AS INTEGER) + 10 * CAST(SUBSTR(eik_clean, 8, 1) AS INTEGER)) % 11 < 10 THEN (3 * CAST(SUBSTR(eik_clean, 1, 1) AS INTEGER) + 4 * CAST(SUBSTR(eik_clean, 2, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 3, 1) AS INTEGER) + 6 * CAST(SUBSTR(eik_clean, 4, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 5, 1) AS INTEGER) + 8 * CAST(SUBSTR(eik_clean, 6, 1) AS INTEGER) + 9 * CAST(SUBSTR(eik_clean, 7, 1) AS INTEGER) + 10 * CAST(SUBSTR(eik_clean, 8, 1) AS INTEGER)) % 11
+            ELSE 0
+          END
+        ) <> CAST(SUBSTR(eik_clean, 9, 1) AS INTEGER) THEN 0
+        WHEN LENGTH(eik_clean) = 9 THEN 1
+        WHEN (
+          CASE
+            WHEN (2 * CAST(SUBSTR(eik_clean, 9, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 10, 1) AS INTEGER) + 3 * CAST(SUBSTR(eik_clean, 11, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 12, 1) AS INTEGER)) % 11 < 10 THEN (2 * CAST(SUBSTR(eik_clean, 9, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 10, 1) AS INTEGER) + 3 * CAST(SUBSTR(eik_clean, 11, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 12, 1) AS INTEGER)) % 11
+            WHEN (4 * CAST(SUBSTR(eik_clean, 9, 1) AS INTEGER) + 9 * CAST(SUBSTR(eik_clean, 10, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 11, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 12, 1) AS INTEGER)) % 11 < 10 THEN (4 * CAST(SUBSTR(eik_clean, 9, 1) AS INTEGER) + 9 * CAST(SUBSTR(eik_clean, 10, 1) AS INTEGER) + 5 * CAST(SUBSTR(eik_clean, 11, 1) AS INTEGER) + 7 * CAST(SUBSTR(eik_clean, 12, 1) AS INTEGER)) % 11
+            ELSE 0
+          END
+        ) = CAST(SUBSTR(eik_clean, 13, 1) AS INTEGER) THEN 1
+        ELSE 0
+      END AS eik_valid
+    FROM (
+      SELECT
+        contractor_name,
+        TRIM(CASE WHEN contractor_eik LIKE 'ЕИК %' THEN SUBSTR(contractor_eik, 5) ELSE contractor_eik END) AS eik_clean
+      FROM raw_contracts WHERE source LIKE 'eop:%' OR source LIKE 'ocds:%'
+    )
   )
 )
 WHERE bidder_key IS NOT NULL


### PR DESCRIPTION
## Problem (#195)

`eik_valid` in `scripts/normalize-raw.sql` was only a **syntactic** check — digits-only, length 9 or 13, no control digit:

```sql
CASE WHEN eik_clean NOT GLOB '*[^0-9]*' AND LENGTH(eik_clean) IN (9, 13) THEN 1 ELSE 0 END
```

So the fake/service code **„000000001"** passed and became a valid `eik:` key, merging unrelated foreign suppliers — Elsevier + Clarivate/Web of Science + an IGB gas consultancy + a 102 EUR construction line — into one node labelled **„Elsevier B. V."** (`eik:000000001` = 14 contracts, 45.7M EUR). Real publishers also grew a wrong-checksum twin (`131106522` „Просвета" vs typo `131106552`).

## Fix

Add the Bulgarian **ЕИК/Булстат control-digit (checksum)** algorithm to `eik_valid`:

- **9-digit** — weight positions 1..8 by 1..8; control = sum % 11. If that is 10, re-weight by 3..10; a second 10 → 0. The 9th digit must equal the control.
- **13-digit** — the leading 9 digits must themselves be a valid 9-digit ЕИК, then weight positions 9..12 by 2,7,3,5 (fallback 4,9,5,7; second 10 → 0); the 13th digit must equal that control.

Invalid codes now get `eik_valid = 0` and fall back to the name-based key (`name:`), which correctly splits Elsevier from Clarivate from the gas consultancy, and the typo twin from the real publisher. Implemented as a pure SQLite expression over the digit positions; `eik_valid` is computed once and the identity key references it.

## Verification (live corpus, real data)

Cross-checked the SQL expression against an independent JS reference over **all 13,134** currently-valid EIK nodes: **0 mismatches**; **64** previously-valid nodes correctly fail the checksum.

| EIK | label | old `eik_valid` | new `eik_valid` |
|---|---|:--:|:--:|
| `000000001` | fake/service (Elsevier merge node) | 1 | **0** |
| `131106552` | „Просвета" wrong-checksum typo twin | 1 | **0** |
| `1027809198339` | Russian ОАД (foreign 13-digit) | 1 | **0** |
| `0018683136487` | foreign 13-digit | 1 | **0** |
| `131106522` | „Просвета - София" АД (real) | 1 | 1 |
| `2016195800141` | ДГС Батак (real 13-digit branch) | 1 | 1 |
| `8319178340012` | ТУ-НИС (real 13-digit branch) | 1 | 1 |
| `204799888` | ЕМДИ Пропърти ООД (real 9-digit) | 1 | 1 |

End-to-end run of the actual edited `INSERT` on a seeded `raw_contracts`: the single `eik:000000001` node disappears and its four unrelated suppliers split into distinct `name:` nodes; valid EIKs keep their `eik:` node.

## Scope

Checksum only. The optional **alias-merge** (proposal 2 in #195) is intentionally left as follow-up — it needs product input and careful handling.

Closes #195.
