### PR TITLE
feat(db,web): app-layer read-only D1 guard — getDb chokepoint над env.DB (#199)

### DIFF
--- a/apps/etl/src/readonly-guard.test.ts
+++ b/apps/etl/src/readonly-guard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+// ETL keeps the write-capable D1 binding (#199): the read-only wrapper must never reach the ETL worker,
+// which legitimately writes D1 (staging / refresh-slice). Importing readonlyD1 here would break ingest.
+const SOURCES: Record<string, string> = import.meta.glob('./**/*.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+describe('ETL retains the write-capable D1 binding', () => {
+  it('no ETL source imports the read-only wrapper', () => {
+    const offenders = Object.entries(SOURCES)
+      .filter(([path]) => !path.includes('.test.'))
+      .filter(([, src]) => /\breadonlyD1\b/.test(src))
+      .map(([path]) => path)
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/etl/src/readonly-guard.test.ts
+++ b/apps/etl/src/readonly-guard.test.ts
@@ -1,21 +1,29 @@
+/// <reference types="node" />
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 // ETL keeps the write-capable D1 binding (#199): the read-only wrapper must never reach the ETL worker,
 // which legitimately writes D1 (staging / refresh-slice). Importing readonlyD1 here would break ingest.
-const SOURCES: Record<string, string> = import.meta.glob('./**/*.ts', {
-  query: '?raw',
-  import: 'default',
-  eager: true,
-});
+// Walk the sources with fs (not import.meta.glob) so this guard needs no Vite types in the Worker package.
+const SRC_DIR = dirname(fileURLToPath(import.meta.url)); // apps/etl/src
+
+function tsSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsSources(path));
+    else if (entry.name.endsWith('.ts') && !entry.name.includes('.test.')) out.push(path);
+  }
+  return out;
+}
 
 describe('ETL retains the write-capable D1 binding', () => {
   it('no ETL source imports the read-only wrapper', () => {
-    const offenders = Object.entries(SOURCES)
-      .filter(([path]) => !path.includes('.test.'))
-      .filter(([, src]) => /\breadonlyD1\b/.test(src))
-      .map(([path]) => path)
+    const offenders = tsSources(SRC_DIR)
+      .filter((path) => /\breadonlyD1\b/.test(readFileSync(path, 'utf8')))
       .sort();
-
     expect(offenders).toEqual([]);
   });
 });

--- a/apps/web/app/lib/csv-export.ts
+++ b/apps/web/app/lib/csv-export.ts
@@ -1,4 +1,5 @@
 import { withDataSource } from './dataSource';
+import { getDb } from '@sigma/db';
 
 const CSV_CONTENT_TYPE = 'text/csv; charset=utf-8';
 const CSV_CACHE_CONTROL = 'public, max-age=3600';
@@ -202,7 +203,7 @@ export async function servedCsvExport({
     return markCsvCache(stream(), 'dynamic');
   }
 
-  const version = await freshnessVersion(env.DB);
+  const version = await freshnessVersion(getDb(env));
   // The CSV streamers order strictly by the keyset id column and ignore `sort`, so the unfiltered
   // export bytes are identical regardless of the URL's `sort`. Keying on `sort` would mint a distinct
   // R2 object per arbitrary value (storage/scan amplification) for no benefit, so it is excluded.

--- a/apps/web/app/lib/readonly-db-chokepoint.test.ts
+++ b/apps/web/app/lib/readonly-db-chokepoint.test.ts
@@ -36,6 +36,12 @@ describe('read-only D1 chokepoint', () => {
     expect(offenders(/\b(?:const|let|var)\s*\{[^}]*\bDB\b[^}]*\}\s*=\s*[^;]*\benv\b/)).toEqual([]);
   });
 
+  // Bracket access (`env['DB']` / `env["DB"]`) grabs the same raw binding as `env.DB`, just spelled to
+  // dodge the dot scan above. None today; keeps the guard hermetic (ydimitrof #225 review).
+  it('no web source reads DB via bracket access on the env', () => {
+    expect(offenders(/\benv\s*\[\s*['"]DB['"]\s*\]/)).toEqual([]);
+  });
+
   // getDb throws on .batch()/.withSession()/.dump(); a read-loader calling one would break at runtime and
   // no predicate/corpus test would catch it, so forbid them in web source outright (#225 review).
   it('no web source calls a getDb-blocked method (.batch/.withSession/.dump)', () => {

--- a/apps/web/app/lib/readonly-db-chokepoint.test.ts
+++ b/apps/web/app/lib/readonly-db-chokepoint.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+// Chokepoint guard (#199): web reads D1 only through @sigma/db's getDb — never `env.DB` directly. A raw
+// `env.DB` anywhere in web is a write-capable handle that bypasses the read-only wrapper (enforcement in
+// place of a lint rule; the repo lints with prettier only). Comments are stripped so prose that merely
+// mentions `env.DB` (e.g. sql-guard.ts) is not a false positive.
+const SOURCES: Record<string, string> = import.meta.glob(
+  ['../**/*.{ts,tsx}', '../../workers/**/*.{ts,tsx}'],
+  { query: '?raw', import: 'default', eager: true },
+);
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+describe('read-only D1 chokepoint', () => {
+  it('no web source reads env.DB directly (all D1 access goes through getDb)', () => {
+    const offenders = Object.entries(SOURCES)
+      .filter(([path]) => !path.includes('.test.'))
+      .filter(([, src]) => /\benv\.DB\b/.test(stripComments(src)))
+      .map(([path]) => path)
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/app/lib/readonly-db-chokepoint.test.ts
+++ b/apps/web/app/lib/readonly-db-chokepoint.test.ts
@@ -1,21 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
 // Chokepoint guard (#199): web reads D1 only through @sigma/db's getDb. These are the enforcement in
-// place of a lint rule (the repo lints with prettier only). Covers every web source dir — app/,
-// workers/, and any root-level apps/web file (#225 review). Comments are stripped so prose that merely
-// mentions `env.DB` (e.g. sql-guard.ts) is not a false positive.
-const SOURCES: Record<string, string> = import.meta.glob(
-  ['../**/*.{ts,tsx}', '../../workers/**/*.{ts,tsx}', '../../*.{ts,tsx}'],
-  { query: '?raw', import: 'default', eager: true },
-);
+// place of a lint rule (the repo lints with prettier only). Scans ALL of apps/web recursively (not just
+// app/ + workers/) so a future top-level dir can't smuggle in D1 access unseen (#225 review); build/
+// output and node_modules are excluded. Comments are stripped so prose that merely mentions `env.DB`
+// (e.g. sql-guard.ts) is not a false positive.
+const SOURCES: Record<string, string> = import.meta.glob('../../**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
 
 function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
 }
 
-// [path, comment-stripped code] for every non-test web source file.
+// [path, comment-stripped code] for every non-test web source file (build output excluded).
 const CODE: ReadonlyArray<readonly [string, string]> = Object.entries(SOURCES)
-  .filter(([path]) => !path.includes('.test.'))
+  .filter(([path]) => !path.includes('.test.') && !path.includes('/build/'))
   .map(([path, src]) => [path, stripComments(src)] as const);
 
 const offenders = (re: RegExp): string[] =>
@@ -31,7 +33,7 @@ describe('read-only D1 chokepoint', () => {
   // A destructured DB (`const { DB } = context.cloudflare.env`) would hold the raw write-capable binding
   // and slip past the `env.DB` scan above (#225 review).
   it('no web source destructures DB off the env', () => {
-    expect(offenders(/\bconst\s*\{[^}]*\bDB\b[^}]*\}\s*=\s*[^;]*\benv\b/)).toEqual([]);
+    expect(offenders(/\b(?:const|let|var)\s*\{[^}]*\bDB\b[^}]*\}\s*=\s*[^;]*\benv\b/)).toEqual([]);
   });
 
   // getDb throws on .batch()/.withSession()/.dump(); a read-loader calling one would break at runtime and

--- a/apps/web/app/lib/readonly-db-chokepoint.test.ts
+++ b/apps/web/app/lib/readonly-db-chokepoint.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-// Chokepoint guard (#199): web reads D1 only through @sigma/db's getDb — never `env.DB` directly. A raw
-// `env.DB` anywhere in web is a write-capable handle that bypasses the read-only wrapper (enforcement in
-// place of a lint rule; the repo lints with prettier only). Comments are stripped so prose that merely
+// Chokepoint guard (#199): web reads D1 only through @sigma/db's getDb. These are the enforcement in
+// place of a lint rule (the repo lints with prettier only). Covers every web source dir — app/,
+// workers/, and any root-level apps/web file (#225 review). Comments are stripped so prose that merely
 // mentions `env.DB` (e.g. sql-guard.ts) is not a false positive.
 const SOURCES: Record<string, string> = import.meta.glob(
-  ['../**/*.{ts,tsx}', '../../workers/**/*.{ts,tsx}'],
+  ['../**/*.{ts,tsx}', '../../workers/**/*.{ts,tsx}', '../../*.{ts,tsx}'],
   { query: '?raw', import: 'default', eager: true },
 );
 
@@ -13,14 +13,30 @@ function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
 }
 
+// [path, comment-stripped code] for every non-test web source file.
+const CODE: ReadonlyArray<readonly [string, string]> = Object.entries(SOURCES)
+  .filter(([path]) => !path.includes('.test.'))
+  .map(([path, src]) => [path, stripComments(src)] as const);
+
+const offenders = (re: RegExp): string[] =>
+  CODE.filter(([, code]) => re.test(code))
+    .map(([path]) => path)
+    .sort();
+
 describe('read-only D1 chokepoint', () => {
   it('no web source reads env.DB directly (all D1 access goes through getDb)', () => {
-    const offenders = Object.entries(SOURCES)
-      .filter(([path]) => !path.includes('.test.'))
-      .filter(([, src]) => /\benv\.DB\b/.test(stripComments(src)))
-      .map(([path]) => path)
-      .sort();
+    expect(offenders(/\benv\.DB\b/)).toEqual([]);
+  });
 
-    expect(offenders).toEqual([]);
+  // A destructured DB (`const { DB } = context.cloudflare.env`) would hold the raw write-capable binding
+  // and slip past the `env.DB` scan above (#225 review).
+  it('no web source destructures DB off the env', () => {
+    expect(offenders(/\bconst\s*\{[^}]*\bDB\b[^}]*\}\s*=\s*[^;]*\benv\b/)).toEqual([]);
+  });
+
+  // getDb throws on .batch()/.withSession()/.dump(); a read-loader calling one would break at runtime and
+  // no predicate/corpus test would catch it, so forbid them in web source outright (#225 review).
+  it('no web source calls a getDb-blocked method (.batch/.withSession/.dump)', () => {
+    expect(offenders(/\.(?:batch|withSession|dump)\s*\(/)).toEqual([]);
   });
 });

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { getDb } from '@sigma/db';
 import {
   isRouteErrorResponse,
   Link,
@@ -49,7 +50,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   }
   // Wrapped like the leaf loaders: this chrome read runs on every route, so a transient D1 fault
   // here would 500 the whole page (incl. the entity pages this PR targets) without the retry.
-  const coverage = await withDbRetry(() => getCoverageMeta(context.cloudflare.env.DB));
+  const coverage = await withDbRetry(() => getCoverageMeta(getDb(context.cloudflare.env)));
   return { ...coverage, origin: url.origin };
 }
 

--- a/apps/web/app/routes/analytics.tsx
+++ b/apps/web/app/routes/analytics.tsx
@@ -1,5 +1,11 @@
 import { Link } from 'react-router';
-import { getCompetitionSummary, getFlows, getRegionalSpending, getSpendingTrend } from '@sigma/db';
+import {
+  getCompetitionSummary,
+  getFlows,
+  getRegionalSpending,
+  getSpendingTrend,
+  getDb,
+} from '@sigma/db';
 import { count, money, pct } from '@sigma/shared';
 import type { ReactNode } from 'react';
 import type { Route } from './+types/analytics';
@@ -28,7 +34,7 @@ export function headers() {
 }
 
 export async function loader({ context }: Route.LoaderArgs) {
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const [flows, regional, trend, competition] = await Promise.all([
     getFlows(db, { top: 3 }),
     getRegionalSpending(db, { funding: 'all' }),

--- a/apps/web/app/routes/assistant.chat.tsx
+++ b/apps/web/app/routes/assistant.chat.tsx
@@ -3,6 +3,7 @@
 // server is stateless (spec §5) — nothing per-user is persisted here.
 
 import type { UIMessage } from 'ai';
+import { getDb } from '@sigma/db';
 import type { Route } from './+types/assistant.chat';
 import { runAssistant, type AgentEnv } from '../lib/assistant/agent';
 import {
@@ -93,7 +94,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   // (review #80).
   const question = latestUserText(messages);
   const ctx: ToolContext = {
-    db: env.DB,
+    db: getDb(env),
     ai,
     vectorize,
     results: [],

--- a/apps/web/app/routes/authorities.csv.tsx
+++ b/apps/web/app/routes/authorities.csv.tsx
@@ -1,4 +1,4 @@
-import { streamAuthoritiesCsv } from '@sigma/db';
+import { streamAuthoritiesCsv, getDb } from '@sigma/db';
 import type { Route } from './+types/authorities.csv';
 import { servedCsvExport } from '../lib/csv-export';
 import { authorityListFilters } from '../lib/filters';
@@ -12,6 +12,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     request,
     route: 'authorities',
     params,
-    stream: () => streamAuthoritiesCsv(context.cloudflare.env.DB, params),
+    stream: () => streamAuthoritiesCsv(getDb(context.cloudflare.env), params),
   });
 }

--- a/apps/web/app/routes/authorities.tsx
+++ b/apps/web/app/routes/authorities.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
 import { count, money, moneyBare } from '@sigma/shared';
-import { getAuthorityFacets, listAuthorities } from '@sigma/db';
+import { getAuthorityFacets, listAuthorities, getDb } from '@sigma/db';
 import type { AuthorityListItem } from '@sigma/api-contract';
 import type { Route } from './+types/authorities';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -44,7 +44,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     cursor: sp.get('cursor'),
     pageSize: PAGE_SIZE.authorities,
   };
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const [page, facets, coverage] = await Promise.all([
     listAuthorities(db, params),
     getAuthorityFacets(db),

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -8,6 +8,7 @@ import {
   getAuthoritySingleOffer,
   getEntityNetwork,
   getSpendingTrend,
+  getDb,
 } from '@sigma/db';
 import type { Route } from './+types/authority';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -44,7 +45,7 @@ export function headers() {
 export async function loader({ params, context }: Route.LoaderArgs) {
   const eik = params.eik;
   if (!eik?.trim()) throw new Response('Not Found', { status: 404 });
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const authorityId = authorityIdFromSlug(eik);
   return withDbRetry(async () => {
     const [authority, coverage, trend, network, competition, procedure] = await Promise.all([

--- a/apps/web/app/routes/companies.csv.tsx
+++ b/apps/web/app/routes/companies.csv.tsx
@@ -1,4 +1,4 @@
-import { streamCompaniesCsv } from '@sigma/db';
+import { streamCompaniesCsv, getDb } from '@sigma/db';
 import type { Route } from './+types/companies.csv';
 import { servedCsvExport } from '../lib/csv-export';
 import { companyListFilters } from '../lib/filters';
@@ -11,6 +11,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     request,
     route: 'companies',
     params,
-    stream: () => streamCompaniesCsv(context.cloudflare.env.DB, params),
+    stream: () => streamCompaniesCsv(getDb(context.cloudflare.env), params),
   });
 }

--- a/apps/web/app/routes/companies.tsx
+++ b/apps/web/app/routes/companies.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
 import { count, money, moneyBare, parseConsortiumMembers } from '@sigma/shared';
-import { getCompanyFacets, listCompanies } from '@sigma/db';
+import { getCompanyFacets, listCompanies, getDb } from '@sigma/db';
 import type { CompanyListItem } from '@sigma/api-contract';
 import type { Route } from './+types/companies';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -51,7 +51,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     cursor: sp.get('cursor'),
     pageSize: PAGE_SIZE.companies,
   };
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const [page, facets, coverage] = await Promise.all([
     listCompanies(db, params),
     getCompanyFacets(db),

--- a/apps/web/app/routes/company.tsx
+++ b/apps/web/app/routes/company.tsx
@@ -8,7 +8,7 @@ import {
   periodRange,
   plural,
 } from '@sigma/shared';
-import { bidderIdFromSlug, getCompany, getEntityNetwork, getSpendingTrend } from '@sigma/db';
+import { bidderIdFromSlug, getCompany, getEntityNetwork, getSpendingTrend, getDb } from '@sigma/db';
 import type { Route } from './+types/company';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -65,7 +65,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
   if (!params.eik?.trim()) throw new Response('Not Found', { status: 404 });
   const id = bidderIdFromSlug(params.eik);
   if (!id) throw new Response('Not Found', { status: 404 });
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   return withDbRetry(async () => {
     const [company, coverage, trend, network] = await Promise.all([
       getCompany(db, id),

--- a/apps/web/app/routes/competition.tsx
+++ b/apps/web/app/routes/competition.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@sigma/api-contract';
 import { EU_SCOREBOARD } from '@sigma/config';
 import { count, money, pct } from '@sigma/shared';
-import { getCompetition } from '@sigma/db';
+import { getCompetition, getDb } from '@sigma/db';
 import type { Route } from './+types/competition';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -34,7 +34,7 @@ export function headers() {
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const coverage = await getCoverageMeta(db);
   const years = yearOptions(coverage.coverageEndYear);
   const { sector, year, funding, top, unknownSector, unknownYear } = singleSelectFilters(

--- a/apps/web/app/routes/contract.json.tsx
+++ b/apps/web/app/routes/contract.json.tsx
@@ -1,4 +1,4 @@
-import { contractIdFromSlug, getContract } from '@sigma/db';
+import { contractIdFromSlug, getContract, getDb } from '@sigma/db';
 import type { Route } from './+types/contract.json';
 import { publicCache } from '../lib/cache';
 import { withDataSource } from '../lib/dataSource';
@@ -13,7 +13,7 @@ function safeJson(value: unknown): string {
 // Resource route: the assembled contract record as machine-readable JSON (/contracts/:id.json).
 export async function loader({ params, context }: Route.LoaderArgs) {
   const id = (params.id ?? '').replace(/\.json$/, '');
-  const record = await getContract(context.cloudflare.env.DB, contractIdFromSlug(id));
+  const record = await getContract(getDb(context.cloudflare.env), contractIdFromSlug(id));
   if (!record) return withDataSource(Response.json({ error: 'not_found' }, { status: 404 }));
   return withDataSource(
     new Response(safeJson(record), {

--- a/apps/web/app/routes/contract.tsx
+++ b/apps/web/app/routes/contract.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import { count, longDate, money, moneyBare, plural, signedMoney, signedPct } from '@sigma/shared';
-import { contractIdFromSlug, contractSlug, getContract } from '@sigma/db';
+import { contractIdFromSlug, contractSlug, getContract, getDb } from '@sigma/db';
 import type { ContractDetail } from '@sigma/api-contract';
 import type { Route } from './+types/contract';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -87,7 +87,7 @@ export function headers() {
 
 export async function loader({ params, context }: Route.LoaderArgs) {
   if (!params.id?.trim()) throw new Response('Not Found', { status: 404 });
-  const contract = await getContract(context.cloudflare.env.DB, contractIdFromSlug(params.id));
+  const contract = await getContract(getDb(context.cloudflare.env), contractIdFromSlug(params.id));
   if (!contract) throw new Response('Not Found', { status: 404 });
   return { contract };
 }

--- a/apps/web/app/routes/contracts.csv.tsx
+++ b/apps/web/app/routes/contracts.csv.tsx
@@ -1,4 +1,4 @@
-import { streamContractsCsv } from '@sigma/db';
+import { streamContractsCsv, getDb } from '@sigma/db';
 import type { Route } from './+types/contracts.csv';
 import { servedCsvExport } from '../lib/csv-export';
 import { contractListFilters } from '../lib/filters';
@@ -14,6 +14,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     request,
     route: 'contracts',
     params,
-    stream: () => streamContractsCsv(context.cloudflare.env.DB, params),
+    stream: () => streamContractsCsv(getDb(context.cloudflare.env), params),
   });
 }

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigation, useSearchParams } from 'react-router';
 import { count, date, money, moneyBare } from '@sigma/shared';
-import { contractsSummary, getContractFacets, listContracts } from '@sigma/db';
+import { contractsSummary, getContractFacets, listContracts, getDb } from '@sigma/db';
 import type { Route } from './+types/contracts';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -56,10 +56,10 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   // Page `Cache-Control` (publicCache(1800)) memoises full responses at the edge — no per-query cache.
   return withDbRetry(async () => {
     const [summary, facets] = await Promise.all([
-      contractsSummary(env.DB, params),
-      getContractFacets(env.DB),
+      contractsSummary(getDb(env), params),
+      getContractFacets(getDb(env)),
     ]);
-    const result = await listContracts(env.DB, params, summary);
+    const result = await listContracts(getDb(env), params, summary);
     return { result, facets };
   });
 }

--- a/apps/web/app/routes/contracts.tsx
+++ b/apps/web/app/routes/contracts.tsx
@@ -53,13 +53,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     pageSize: PAGE_SIZE.contracts,
   };
   const { env } = context.cloudflare;
+  const db = getDb(env);
   // Page `Cache-Control` (publicCache(1800)) memoises full responses at the edge — no per-query cache.
   return withDbRetry(async () => {
     const [summary, facets] = await Promise.all([
-      contractsSummary(getDb(env), params),
-      getContractFacets(getDb(env)),
+      contractsSummary(db, params),
+      getContractFacets(db),
     ]);
-    const result = await listContracts(getDb(env), params, summary);
+    const result = await listContracts(db, params, summary);
     return { result, facets };
   });
 }

--- a/apps/web/app/routes/flows.tsx
+++ b/apps/web/app/routes/flows.tsx
@@ -1,6 +1,6 @@
 import { Form, Link, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import { count, moneyBare } from '@sigma/shared';
-import { getFlows } from '@sigma/db';
+import { getFlows, getDb } from '@sigma/db';
 import type { Route } from './+types/flows';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -26,7 +26,7 @@ export function headers() {
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const coverage = await getCoverageMeta(db);
   const years = yearOptions(coverage.coverageEndYear);
   const { sector, year, funding, top, unknownSector, unknownYear } = singleSelectFilters(

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import { count, date, moneyBare } from '@sigma/shared';
-import { getHomeData } from '@sigma/db';
+import { getHomeData, getDb } from '@sigma/db';
 import type { ContractListItem } from '@sigma/api-contract';
 import type { Route } from './+types/home';
 import { PageHeader } from '../components/PageHeader';
@@ -30,7 +30,7 @@ export async function loader({ context }: Route.LoaderArgs) {
   const { env } = context.cloudflare;
   // Identical for every visitor between refreshes — the `Cache-Control` above (publicCache(3600))
   // memoises this response at the edge; no separate data cache.
-  return getHomeData(env.DB);
+  return getHomeData(getDb(env));
 }
 
 function SingleOfferTable({ items, allHref }: { items: ContractListItem[]; allHref: string }) {

--- a/apps/web/app/routes/map.tsx
+++ b/apps/web/app/routes/map.tsx
@@ -1,7 +1,7 @@
 import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import type { MacroRegionSpend, RegionSpend } from '@sigma/api-contract';
 import { count, money, pct } from '@sigma/shared';
-import { getRegionalSpending } from '@sigma/db';
+import { getRegionalSpending, getDb } from '@sigma/db';
 import type { Route } from './+types/map';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -29,7 +29,7 @@ export function headers() {
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const coverage = await getCoverageMeta(db);
   const years = yearOptions(coverage.coverageEndYear);
   const { sector, year, funding, unknownSector, unknownYear } = singleSelectFilters(

--- a/apps/web/app/routes/methodology.tsx
+++ b/apps/web/app/routes/methodology.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import { count, date, money, pct } from '@sigma/shared';
-import { getMethodologyStats } from '@sigma/db';
+import { getMethodologyStats, getDb } from '@sigma/db';
 import type { Route } from './+types/methodology';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -24,7 +24,7 @@ export function headers() {
 
 // Pull the live corpus figures so the credibility-critical copy matches reality, not hard-coded numbers.
 export async function loader({ context }: Route.LoaderArgs) {
-  return getMethodologyStats(context.cloudflare.env.DB);
+  return getMethodologyStats(getDb(context.cloudflare.env));
 }
 
 const TOC = [

--- a/apps/web/app/routes/network.tsx
+++ b/apps/web/app/routes/network.tsx
@@ -5,6 +5,7 @@ import {
   bidderIdFromSlug,
   getEntityNetwork,
   type NetworkParams,
+  getDb,
 } from '@sigma/db';
 import type { Route } from './+types/network';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -46,7 +47,7 @@ function parseCenter(token: string | null): NetworkParams | null {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const center = parseCenter(new URL(request.url).searchParams.get('center'));
-  const data = await getEntityNetwork(context.cloudflare.env.DB, center);
+  const data = await getEntityNetwork(getDb(context.cloudflare.env), center);
   // A well-formed but non-existent ?center should 404 like the other entity pages, not render an
   // empty 200 that then gets edge-cached. A missing or malformed ?center keeps the default centre.
   if (center && !data.center) {

--- a/apps/web/app/routes/search.suggest.tsx
+++ b/apps/web/app/routes/search.suggest.tsx
@@ -1,5 +1,5 @@
 import { data } from 'react-router';
-import { search } from '@sigma/db';
+import { search, getDb } from '@sigma/db';
 import type { SearchGroup, SearchResults } from '@sigma/api-contract';
 import type { Route } from './+types/search.suggest';
 import { publicCache } from '../lib/cache';
@@ -18,7 +18,7 @@ export function trimGroup(group: SearchGroup): SearchGroup {
 // listbox is rendered client-side from this payload; with JS off the form still posts to /search.
 export async function loader({ request, context }: Route.LoaderArgs) {
   const q = new URL(request.url).searchParams.get('q') ?? '';
-  const results = await search(context.cloudflare.env.DB, q);
+  const results = await search(getDb(context.cloudflare.env), q);
   const payload: SearchResults = { ...results, groups: results.groups.map(trimGroup) };
   return data(payload, {
     headers: {

--- a/apps/web/app/routes/search.tsx
+++ b/apps/web/app/routes/search.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';
 import { count, money, plural, searchTokens } from '@sigma/shared';
-import { MAX_QUERY_TOKENS, search } from '@sigma/db';
+import { MAX_QUERY_TOKENS, search, getDb } from '@sigma/db';
 import type { SearchHit } from '@sigma/api-contract';
 import type { Route } from './+types/search';
 import { Breadcrumbs } from '../components/Breadcrumbs';
@@ -66,7 +66,7 @@ function cappedQuery(q: string): string {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const q = cappedQuery(new URL(request.url).searchParams.get('q') ?? '');
-  const results = await search(context.cloudflare.env.DB, q);
+  const results = await search(getDb(context.cloudflare.env), q);
   return { results };
 }
 

--- a/apps/web/app/routes/sitemap-authorities.tsx
+++ b/apps/web/app/routes/sitemap-authorities.tsx
@@ -1,9 +1,9 @@
-import { streamAuthoritySitemap } from '@sigma/db';
+import { streamAuthoritySitemap, getDb } from '@sigma/db';
 import type { Route } from './+types/sitemap-authorities';
 import { withDataSource } from '../lib/dataSource';
 
 export function loader({ request, context }: Route.LoaderArgs) {
   return withDataSource(
-    streamAuthoritySitemap(context.cloudflare.env.DB, new URL(request.url).origin),
+    streamAuthoritySitemap(getDb(context.cloudflare.env), new URL(request.url).origin),
   );
 }

--- a/apps/web/app/routes/sitemap-companies.tsx
+++ b/apps/web/app/routes/sitemap-companies.tsx
@@ -1,9 +1,9 @@
-import { streamCompanySitemap } from '@sigma/db';
+import { streamCompanySitemap, getDb } from '@sigma/db';
 import type { Route } from './+types/sitemap-companies';
 import { withDataSource } from '../lib/dataSource';
 
 export function loader({ request, context }: Route.LoaderArgs) {
   return withDataSource(
-    streamCompanySitemap(context.cloudflare.env.DB, new URL(request.url).origin),
+    streamCompanySitemap(getDb(context.cloudflare.env), new URL(request.url).origin),
   );
 }

--- a/apps/web/app/routes/sitemap-contracts.tsx
+++ b/apps/web/app/routes/sitemap-contracts.tsx
@@ -1,4 +1,4 @@
-import { streamContractSitemap } from '@sigma/db';
+import { streamContractSitemap, getDb } from '@sigma/db';
 import type { Route } from './+types/sitemap-contracts';
 import { withDataSource } from '../lib/dataSource';
 
@@ -10,5 +10,5 @@ export function loader({ request, context }: Route.LoaderArgs) {
   }
 
   const page = rawPage === null ? 1 : Number(rawPage);
-  return withDataSource(streamContractSitemap(context.cloudflare.env.DB, url.origin, page));
+  return withDataSource(streamContractSitemap(getDb(context.cloudflare.env), url.origin, page));
 }

--- a/apps/web/app/routes/sitemap.tsx
+++ b/apps/web/app/routes/sitemap.tsx
@@ -1,11 +1,11 @@
-import { contractSitemapPages } from '@sigma/db';
+import { contractSitemapPages, getDb } from '@sigma/db';
 import type { Route } from './+types/sitemap';
 import { withDataSource } from '../lib/dataSource';
 
 // Sitemap index: the static-pages sitemap + per-type sitemaps (contracts paginated under 50k URLs).
 export async function loader({ request, context }: Route.LoaderArgs) {
   const origin = new URL(request.url).origin;
-  const pages = await contractSitemapPages(context.cloudflare.env.DB);
+  const pages = await contractSitemapPages(getDb(context.cloudflare.env));
   const maps = [
     `${origin}/sitemap-pages.xml`,
     `${origin}/sitemap-authorities.xml`,

--- a/apps/web/app/routes/trends.tsx
+++ b/apps/web/app/routes/trends.tsx
@@ -1,7 +1,7 @@
 import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router';
 import type { TrendYear } from '@sigma/api-contract';
 import { count, money, pct, signedPct } from '@sigma/shared';
-import { getSpendingTrend } from '@sigma/db';
+import { getSpendingTrend, getDb } from '@sigma/db';
 import type { Route } from './+types/trends';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { PageHeader } from '../components/PageHeader';
@@ -30,7 +30,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const sp = new URL(request.url).searchParams;
   const { sector, funding, unknownSector } = singleSelectFilters(sp);
   const granularity = sp.get('g') === 'year' ? 'year' : 'month';
-  const db = context.cloudflare.env.DB;
+  const db = getDb(context.cloudflare.env);
   const data = await getSpendingTrend(db, { sector, funding, granularity });
   return { data, unknownSector };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,6 @@
 export * from './queries';
+
+// Read-only D1 wrapper (issue #199): least-privilege chokepoint the web runtime uses instead of the raw
+// env.DB binding, so a guard bypass on the assistant run_sql path can never reach a D1 write.
+export { readonlyD1, getDb } from './readonly-d1';
+export { isReadOnlySql, assertReadOnly } from './readonly-sql';

--- a/packages/db/src/readonly-corpus.test.ts
+++ b/packages/db/src/readonly-corpus.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   contractSitemapPages,
@@ -203,5 +206,27 @@ describe('read-loader corpus is read-only', () => {
     // pass — prove a representative loader emitted SQL, then assert every captured statement is read-only.
     expect(captured.some((sql) => sql.includes('home_totals'))).toBe(true);
     expect(captured.filter((sql) => !isReadOnlySql(sql))).toEqual([]);
+  });
+});
+
+// A getDb-wrapped handle throws on .batch()/.withSession()/.dump(); the corpus above proves the predicate,
+// but a read-loader reaching for one of those would break only at runtime. @sigma/db queries are all read
+// paths (ETL writes live in @sigma/ingest), so forbid those methods in the query source (#225 review).
+const queriesDir = resolve(dirname(fileURLToPath(import.meta.url)), 'queries');
+const stripComments = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+describe('read-loader query source', () => {
+  it('never calls a getDb-blocked method (.batch/.withSession/.dump)', () => {
+    const offenders = (readdirSync(queriesDir, { recursive: true }) as string[])
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+      .filter((name) =>
+        /\.(?:batch|withSession|dump)\s*\(/.test(
+          stripComments(readFileSync(resolve(queriesDir, name), 'utf8')),
+        ),
+      )
+      .sort();
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/packages/db/src/readonly-corpus.test.ts
+++ b/packages/db/src/readonly-corpus.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import {
+  contractSitemapPages,
+  getAuthority,
+  getAuthorityFacets,
+  getCompany,
+  getCompanyFacets,
+  getCompetition,
+  getCompetitionSummary,
+  getContract,
+  getContractFacets,
+  getEntityNetwork,
+  getFlows,
+  getHomeData,
+  getMethodologyStats,
+  getRegionalSpending,
+  getSpendingTrend,
+  listAuthorities,
+  listCompanies,
+  listContracts,
+  search,
+  streamAuthoritiesCsv,
+  streamAuthoritySitemap,
+  streamCompaniesCsv,
+  streamCompanySitemap,
+  streamContractSitemap,
+  streamContractsCsv,
+} from './queries';
+import { isReadOnlySql } from './readonly-sql';
+
+// Regression guard for the #199 read-only D1 wrapper: the wrapper's predicate must never reject a real
+// loader query (a false-reject 500s a live page). This drives every read loader — including the dynamic
+// list loaders with BOTH an unfiltered and a fully-filtered param set, so the runtime-assembled WHERE /
+// ORDER BY branches are exercised — against a capturing fake D1, then asserts every emitted statement is
+// read-only. The loaders post-process rows; we feed empty canned rows, so some post-processing rejects —
+// irrelevant here (each loader's own unit test covers results), and the SQL is already captured at
+// prepare() time, so we swallow those rejections and assert only on the captured SQL.
+function capturingDb(): { db: D1Database; captured: string[] } {
+  const captured: string[] = [];
+  const zero = new Proxy({}, { get: () => 0 });
+  const stmt = {
+    bind() {
+      return stmt;
+    },
+    async all() {
+      return { results: [], success: true, meta: {} };
+    },
+    async first() {
+      return zero;
+    },
+    async raw() {
+      return [];
+    },
+    async run() {
+      return { results: [], success: true, meta: {} };
+    },
+  };
+  const db = {
+    prepare(sql: string) {
+      captured.push(sql);
+      return stmt;
+    },
+    async exec(sql: string) {
+      captured.push(sql);
+      return { count: 0, duration: 0 };
+    },
+  } as unknown as D1Database;
+  return { db, captured };
+}
+
+const swallow = (p: Promise<unknown>): Promise<unknown> => p.catch(() => undefined);
+
+type Params<F> = F extends (db: D1Database, p: infer P, ...rest: never[]) => unknown ? P : never;
+
+const contractsUnfiltered = {
+  sort: 'value-desc',
+  years: [],
+  sectors: [],
+  procedureGroups: [],
+  valueBucket: null,
+  eu: null,
+  authority: null,
+  bidder: null,
+  q: null,
+  bids: null,
+  cursor: null,
+  pageSize: 15,
+} as unknown as Params<typeof listContracts>;
+const contractsFiltered = {
+  ...contractsUnfiltered,
+  years: ['2024'],
+  sectors: ['45'],
+  procedureGroups: ['open'],
+  valueBucket: '1m-5m',
+  eu: 'eu',
+  authority: 'auth:100000001',
+  bidder: 'eik:200000001',
+  q: 'път',
+  bids: 'one',
+} as unknown as Params<typeof listContracts>;
+
+const companiesUnfiltered = {
+  sort: 'won',
+  kinds: [],
+  countBucket: null,
+  sectors: [],
+  years: [],
+  eu: null,
+  q: null,
+  cursor: null,
+  pageSize: 25,
+} as unknown as Params<typeof listCompanies>;
+const companiesFiltered = {
+  ...companiesUnfiltered,
+  kinds: ['company'],
+  countBucket: '2-5',
+  sectors: ['45'],
+  years: ['2024'],
+  eu: 'national',
+  q: 'строителство',
+} as unknown as Params<typeof listCompanies>;
+
+const authoritiesUnfiltered = {
+  sort: 'spent',
+  types: [],
+  sectors: [],
+  years: [],
+  eu: null,
+  q: null,
+  cursor: null,
+  pageSize: 25,
+} as unknown as Params<typeof listAuthorities>;
+const authoritiesFiltered = {
+  ...authoritiesUnfiltered,
+  types: ['municipality'],
+  sectors: ['45'],
+  years: ['2024'],
+  eu: 'eu',
+  q: 'път',
+} as unknown as Params<typeof listAuthorities>;
+
+const flowsParams = { sector: null, year: null, funding: 'all', top: 20 } as unknown as Params<
+  typeof getFlows
+>;
+const trendParams = {
+  granularity: 'month',
+  sector: null,
+  funding: 'all',
+} as unknown as Params<typeof getSpendingTrend>;
+const competitionParams = {
+  sector: null,
+  year: null,
+  funding: 'all',
+  top: 20,
+  minContracts: 5,
+} as unknown as Params<typeof getCompetition>;
+const networkParams = { center: 'auth:100000001' } as unknown as Params<typeof getEntityNetwork>;
+const regionalParams = { sector: null, year: null, funding: 'all' } as unknown as Params<
+  typeof getRegionalSpending
+>;
+
+// The CSV/sitemap streamers query lazily inside a ReadableStream — reading the body drains them so
+// their SQL is captured too.
+const drain = (res: Response): Promise<unknown> => res.text().catch(() => undefined);
+
+describe('read-loader corpus is read-only', () => {
+  it('emits only read-only SQL across every read loader (no false-reject)', async () => {
+    const { db, captured } = capturingDb();
+
+    await Promise.all([
+      swallow(getHomeData(db)),
+      swallow(getMethodologyStats(db)),
+      swallow(getContractFacets(db)),
+      swallow(getCompanyFacets(db)),
+      swallow(getAuthorityFacets(db)),
+      swallow(getCompetitionSummary(db)),
+      swallow(listContracts(db, contractsUnfiltered)),
+      swallow(listContracts(db, contractsFiltered)),
+      swallow(listCompanies(db, companiesUnfiltered)),
+      swallow(listCompanies(db, companiesFiltered)),
+      swallow(listAuthorities(db, authoritiesUnfiltered)),
+      swallow(listAuthorities(db, authoritiesFiltered)),
+      swallow(getFlows(db, flowsParams)),
+      swallow(getSpendingTrend(db, trendParams)),
+      swallow(getCompetition(db, competitionParams)),
+      swallow(getEntityNetwork(db, null)),
+      swallow(getEntityNetwork(db, networkParams)),
+      swallow(search(db, 'софия строителство')),
+      swallow(getCompany(db, 'eik:200000001')),
+      swallow(getAuthority(db, 'auth:100000001')),
+      swallow(getContract(db, 'e:UNP-1:CONTRACT-1')),
+      swallow(getRegionalSpending(db, regionalParams)),
+      swallow(contractSitemapPages(db)),
+      drain(streamContractsCsv(db, contractsFiltered)),
+      drain(streamCompaniesCsv(db, companiesFiltered)),
+      drain(streamAuthoritiesCsv(db, authoritiesFiltered)),
+      drain(streamContractSitemap(db, 'https://sigma.bg', 1)),
+      drain(streamCompanySitemap(db, 'https://sigma.bg')),
+      drain(streamAuthoritySitemap(db, 'https://sigma.bg')),
+    ]);
+
+    // Non-vacuity (rule-compliant, not a range): a broken import would capture nothing and vacuously
+    // pass — prove a representative loader emitted SQL, then assert every captured statement is read-only.
+    expect(captured.some((sql) => sql.includes('home_totals'))).toBe(true);
+    expect(captured.filter((sql) => !isReadOnlySql(sql))).toEqual([]);
+  });
+});

--- a/packages/db/src/readonly-d1.test.ts
+++ b/packages/db/src/readonly-d1.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { readonlyD1 } from './readonly-d1';
+
+// Minimal fake D1 that records prepared/exec SQL and returns canned rows — same approach as the query
+// unit tests. The wrapper only inspects SQL text, so no real engine is needed; the passthrough tests
+// prove it forwards to the underlying handle unchanged.
+function fakeDb(): { db: D1Database; calls: string[] } {
+  const calls: string[] = [];
+  const db = {
+    prepare(sql: string) {
+      calls.push(`prepare:${sql}`);
+      return {
+        bind(...args: unknown[]) {
+          calls.push(`bind:${JSON.stringify(args)}`);
+          return this;
+        },
+        async all() {
+          return { results: [{ id: 'c:1' }], success: true, meta: {} };
+        },
+        async first() {
+          return { id: 'c:1' };
+        },
+      };
+    },
+    async exec(sql: string) {
+      calls.push(`exec:${sql}`);
+      return { count: 0, duration: 0 };
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+describe('readonlyD1 — write rejection', () => {
+  it('throws a read-only error when prepare() gets a write', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).prepare('DELETE FROM contracts')).toThrow(/read-only/i);
+  });
+
+  it('does not reach the underlying prepare() when rejecting a write (fail-closed before delegation)', () => {
+    const { db, calls } = fakeDb();
+    expect(() => readonlyD1(db).prepare('DROP TABLE contracts')).toThrow(/read-only/i);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('readonlyD1 — read passthrough', () => {
+  it('delegates a SELECT to the underlying prepare with the exact SQL', () => {
+    const { db, calls } = fakeDb();
+    readonlyD1(db).prepare('SELECT id FROM contracts');
+    expect(calls).toEqual(['prepare:SELECT id FROM contracts']);
+  });
+
+  it('returns rows identical to the unwrapped handle for .all()', async () => {
+    const { db } = fakeDb();
+    const rows = await readonlyD1(db).prepare('SELECT id FROM contracts').all();
+    expect(rows).toEqual({ results: [{ id: 'c:1' }], success: true, meta: {} });
+  });
+
+  it('returns the row identical to the unwrapped handle for .first()', async () => {
+    const { db } = fakeDb();
+    const row = await readonlyD1(db).prepare('SELECT id FROM contracts').first();
+    expect(row).toEqual({ id: 'c:1' });
+  });
+
+  it('passes .bind() args through to the underlying statement unchanged', () => {
+    const { db, calls } = fakeDb();
+    readonlyD1(db).prepare('SELECT id FROM contracts WHERE id = ?').bind('c:1');
+    expect(calls).toEqual(['prepare:SELECT id FROM contracts WHERE id = ?', 'bind:["c:1"]']);
+  });
+});
+
+describe('readonlyD1 — exec (multi-statement)', () => {
+  it('allows a read-only multi-statement exec', async () => {
+    const { db, calls } = fakeDb();
+    await readonlyD1(db).exec('SELECT 1; SELECT 2;');
+    expect(calls).toEqual(['exec:SELECT 1; SELECT 2;']);
+  });
+
+  it('throws when the second statement in exec writes', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).exec('SELECT 1; DELETE FROM contracts;')).toThrow(/read-only/i);
+  });
+
+  it('throws when the first statement in exec writes even if the second reads', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).exec('DELETE FROM contracts; SELECT 1;')).toThrow(/read-only/i);
+  });
+});
+
+describe('readonlyD1 — disabled write-capable methods', () => {
+  it('throws on batch()', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).batch([])).toThrow(/read-only/i);
+  });
+
+  it('throws on dump()', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).dump()).toThrow(/read-only/i);
+  });
+
+  it('throws on withSession()', () => {
+    const { db } = fakeDb();
+    expect(() => readonlyD1(db).withSession()).toThrow(/read-only/i);
+  });
+});

--- a/packages/db/src/readonly-d1.ts
+++ b/packages/db/src/readonly-d1.ts
@@ -24,6 +24,9 @@ class ReadonlyD1 implements D1Database {
     throw new Error('@sigma/db: batch() is not available on the read-only D1 handle');
   }
 
+  // Note: this forecloses the D1 Sessions API, i.e. read-replica routing — a deliberate least-privilege
+  // tradeoff for now (web is not replica-scaled). If read-heavy scaling later needs replicas, route reads
+  // through a guarded session handle here rather than dropping the wrapper.
   withSession(_constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession {
     throw new Error('@sigma/db: withSession() is not available on the read-only D1 handle');
   }

--- a/packages/db/src/readonly-d1.ts
+++ b/packages/db/src/readonly-d1.ts
@@ -1,0 +1,52 @@
+import { assertReadOnly, assertReadOnlyExec } from './readonly-sql';
+
+// A read-only view over a D1Database for the web runtime (issue #199). Cloudflare has no read-only D1
+// binding, so env.DB is read+write; this gates the two SQL entry points (.prepare, .exec) on the
+// read-only predicate and throws on the three methods web never uses: .batch takes opaque prepared
+// statements it cannot re-inspect, .withSession returns an unguarded handle, and .dump exfils the whole
+// DB. SQL is fixed at .prepare() time and .bind() only supplies values, so gating .prepare/.exec closes
+// every write entry point. The real D1PreparedStatement is returned unchanged — no per-call proxy on the
+// hot .bind/.all/.first path. Only web goes through here; the ETL worker keeps the raw binding.
+class ReadonlyD1 implements D1Database {
+  constructor(private readonly db: D1Database) {}
+
+  prepare(query: string): D1PreparedStatement {
+    assertReadOnly(query);
+    return this.db.prepare(query);
+  }
+
+  exec(query: string): Promise<D1ExecResult> {
+    assertReadOnlyExec(query);
+    return this.db.exec(query);
+  }
+
+  batch<T = unknown>(_statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    throw new Error('@sigma/db: batch() is not available on the read-only D1 handle');
+  }
+
+  withSession(_constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession {
+    throw new Error('@sigma/db: withSession() is not available on the read-only D1 handle');
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    throw new Error('@sigma/db: dump() is not available on the read-only D1 handle');
+  }
+}
+
+/**
+ * Wrap a D1Database so the web runtime can only read: `.prepare()`/`.exec()` reject any non-SELECT,
+ * `.batch()`/`.withSession()`/`.dump()` throw. Defense-in-depth least-privilege for #199 — the assistant
+ * `run_sql` AST guard is no longer the only barrier between the model and a D1 write.
+ */
+export function readonlyD1(db: D1Database): D1Database {
+  return new ReadonlyD1(db);
+}
+
+/**
+ * The web worker's single read-only D1 chokepoint (#199): wrap the write-capable `env.DB` so web reads
+ * D1 only through here, never the raw binding. The ETL worker keeps the raw binding. Pure (no cache) to
+ * keep @sigma/db stateless — wrapping is one cheap allocation.
+ */
+export function getDb(env: { DB: D1Database }): D1Database {
+  return readonlyD1(env.DB);
+}

--- a/packages/db/src/readonly-sql.test.ts
+++ b/packages/db/src/readonly-sql.test.ts
@@ -32,6 +32,20 @@ const WRITES: ReadonlyArray<readonly [label: string, sql: string]> = [
   ['writefile side-effect fn', "SELECT writefile('/tmp/x', 'data')"],
   ['readfile side-effect fn', "SELECT readfile('/etc/passwd')"],
   ['fts3_tokenizer pointer fn', "SELECT fts3_tokenizer('x', 1)"],
+  // #225 review bypass: a `'` inside a quoted IDENTIFIER must not open a phantom string that hides the
+  // trailing write. SQLite treats "x'"/`x'`/[x'] as identifiers and still executes the DELETE.
+  [
+    'quote in a "…" identifier hides DELETE',
+    `WITH t("x'") AS (SELECT 1) DELETE FROM secrets WHERE x='y'`,
+  ],
+  [
+    'quote in a `…` identifier hides DELETE',
+    "WITH t(`x'`) AS (SELECT 1) DELETE FROM secrets WHERE x='y'",
+  ],
+  [
+    'quote in a […] identifier hides DELETE',
+    `WITH t([x']) AS (SELECT 1) DELETE FROM secrets WHERE x='y'`,
+  ],
   ['empty', '   '],
 ];
 
@@ -54,6 +68,11 @@ const READS: ReadonlyArray<readonly [label: string, sql: string]> = [
   ],
   ['lowercase select', 'select id from contracts'],
   ['leading line comment then SELECT', '-- note\nSELECT id FROM contracts'],
+  // Quoted IDENTIFIERS equal to a write word are column/alias names, not writes — must not false-reject.
+  ['"…" identifier equal to a write word', 'SELECT "DELETE" AS x FROM t'],
+  ['`…` identifier equal to a write word', 'SELECT `UPDATE` FROM t'],
+  ['[…] identifier equal to a write word', 'SELECT [DROP] FROM t'],
+  ['doubled-quote escape inside an identifier', 'SELECT "a""b" FROM t'],
 ];
 
 describe('isReadOnlySql — rejects writes', () => {

--- a/packages/db/src/readonly-sql.test.ts
+++ b/packages/db/src/readonly-sql.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { assertReadOnly, isReadOnlySql } from './readonly-sql';
+
+// Statements that MUST be treated as writes (rejected). One row per construct. The CTE-prefixed and
+// RETURNING rows are the bypasses a naive `^(select|with)` check would miss; the stacked and
+// leading-comment rows exercise the literal-aware comment/statement splitting.
+const WRITES: ReadonlyArray<readonly [label: string, sql: string]> = [
+  ['INSERT', "INSERT INTO contracts (id) VALUES ('c:1')"],
+  ['UPDATE', 'UPDATE contracts SET amount_eur = 0'],
+  ['DELETE', 'DELETE FROM contracts'],
+  ['REPLACE INTO', "REPLACE INTO contracts (id) VALUES ('c:1')"],
+  ['CREATE TABLE', 'CREATE TABLE evil (id TEXT)'],
+  ['DROP TABLE', 'DROP TABLE contracts'],
+  ['ALTER TABLE', 'ALTER TABLE contracts ADD COLUMN evil TEXT'],
+  ['PRAGMA', 'PRAGMA table_info(contracts)'],
+  ['ATTACH', "ATTACH DATABASE 'x.db' AS x"],
+  ['VACUUM', 'VACUUM'],
+  ['REINDEX', 'REINDEX contracts'],
+  ['CTE-scoped DELETE', 'WITH x AS (SELECT 1) DELETE FROM contracts'],
+  ['CTE-scoped UPDATE', 'WITH x AS (SELECT 1) UPDATE contracts SET risk = 0'],
+  ['CTE-scoped INSERT', 'WITH x AS (SELECT 1) INSERT INTO contracts SELECT * FROM x'],
+  ['CTE-scoped REPLACE', 'WITH x AS (SELECT 1) REPLACE INTO contracts SELECT * FROM x'],
+  ['INSERT RETURNING', "INSERT INTO contracts (id) VALUES ('c:1') RETURNING id"],
+  ['stacked SELECT then DROP', 'SELECT 1; DROP TABLE contracts'],
+  ['lowercase delete', 'delete from contracts'],
+  ['mixed-case DeLeTe', 'DeLeTe FROM contracts'],
+  ['leading line comment then DELETE', '-- note\nDELETE FROM contracts'],
+  ['leading block comment then DELETE', '/* n */ DELETE FROM contracts'],
+  ['leading whitespace then DELETE', '   \n\t DELETE FROM contracts'],
+  ['EXPLAIN over a write', 'EXPLAIN DELETE FROM contracts'],
+  ['load_extension side-effect fn', "SELECT load_extension('evil.so')"],
+  ['writefile side-effect fn', "SELECT writefile('/tmp/x', 'data')"],
+  ['readfile side-effect fn', "SELECT readfile('/etc/passwd')"],
+  ['fts3_tokenizer pointer fn', "SELECT fts3_tokenizer('x', 1)"],
+  ['empty', '   '],
+];
+
+// Real read-only shapes that MUST pass — including the literal/identifier cases a naive text blocklist
+// (or an AST gate that fail-closes on unparsed-but-valid SQLite) would false-reject and 500 a live loader.
+const READS: ReadonlyArray<readonly [label: string, sql: string]> = [
+  ['plain SELECT', 'SELECT id FROM contracts'],
+  ['WITH cte then SELECT', 'WITH t AS (SELECT id FROM contracts) SELECT id FROM t'],
+  ['UNION', 'SELECT id FROM contracts UNION SELECT id FROM tenders'],
+  ['subquery', 'SELECT id FROM contracts WHERE id IN (SELECT id FROM contracts LIMIT 1)'],
+  ['EXPLAIN QUERY PLAN', 'EXPLAIN QUERY PLAN SELECT id FROM contracts'],
+  ['write verb as a string literal', "SELECT id FROM contracts WHERE status = 'CREATE'"],
+  ['DELETE as a string literal', "SELECT id FROM parties WHERE action = 'DELETE'"],
+  ['semicolon + DROP inside a literal', "SELECT 'a; DROP TABLE t' AS demo"],
+  ['write verb split across concatenated literals', "SELECT 'DEL' || 'ETE' AS x"],
+  ['replace() scalar function', "SELECT replace(name, 'a', 'b') FROM parties"],
+  [
+    'updated_at / created_at columns (word-boundary)',
+    'SELECT updated_at, created_at FROM contracts',
+  ],
+  ['lowercase select', 'select id from contracts'],
+  ['leading line comment then SELECT', '-- note\nSELECT id FROM contracts'],
+];
+
+describe('isReadOnlySql — rejects writes', () => {
+  it.each(WRITES)('rejects %s', (_label, sql) => {
+    expect(isReadOnlySql(sql)).toBe(false);
+  });
+});
+
+describe('isReadOnlySql — allows reads', () => {
+  it.each(READS)('allows %s', (_label, sql) => {
+    expect(isReadOnlySql(sql)).toBe(true);
+  });
+});
+
+describe('assertReadOnly', () => {
+  it('throws a read-only error for a write', () => {
+    expect(() => assertReadOnly('DELETE FROM contracts')).toThrow(/read-only/i);
+  });
+
+  it('does not throw for a legitimate SELECT', () => {
+    expect(() => assertReadOnly('SELECT id FROM contracts')).not.toThrow();
+  });
+});

--- a/packages/db/src/readonly-sql.ts
+++ b/packages/db/src/readonly-sql.ts
@@ -1,0 +1,175 @@
+// Read-only SQL predicate for the @sigma/db read-only D1 wrapper (issue #199). Answers one question —
+// "would this statement write?" — so the wrapper can gate env.DB.prepare/exec and the web runtime can
+// never mutate D1, even if the assistant run_sql AST guard is bypassed. The check is TEXT-based and
+// literal-aware (a write verb inside a '…' literal is data, not a write). Why not an AST parse here: the
+// loader queries are dynamically assembled and node-sql-parser fail-closes on valid SQLite it cannot
+// parse, so parsing would reject real reads and 500 a live loader. node-sql-parser stays on the
+// assistant run_sql path only. The comment/literal handling mirrors apps/web assistant sql-guard.ts so
+// both layers model strings identically.
+
+// Statement-level write verbs, matched whole-word OUTSIDE string literals. REPLACE is intentionally
+// absent — it collides with the read-only scalar replace(); its write form `REPLACE INTO` is matched
+// separately, and a leading REPLACE is already rejected by the SELECT/WITH/EXPLAIN allow-list.
+const WRITE_VERBS = [
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'DROP',
+  'ALTER',
+  'CREATE',
+  'TRUNCATE',
+  'RENAME',
+  'ATTACH',
+  'DETACH',
+  'PRAGMA',
+  'VACUUM',
+  'REINDEX',
+  'ANALYZE',
+  'TRIGGER',
+  'UPSERT',
+  'MERGE',
+  'GRANT',
+  'REVOKE',
+];
+const WRITE_VERB_RE = new RegExp(`\\b(?:${WRITE_VERBS.join('|')})\\b`, 'i');
+const REPLACE_INTO_RE = /\breplace\s+into\b/i;
+// Side-effect / code-loading functions that carry no write verb, so the blocklist above misses them.
+// Not reachable on Cloudflare D1 (extension loading disabled, no fts3 tokenizer-pointer API) and no
+// loader uses them — rejected here for defense-in-depth.
+const DANGEROUS_FN_RE = /\b(?:load_extension|writefile|readfile|fts3_tokenizer)\s*\(/i;
+const LEADING_READ_RE = /^(?:select|with|explain)\b/i;
+
+// Strip `-- line` and `/* block */` comments, but treat a comment marker inside a '…' literal as data
+// (a `--`/`/*` in a literal is preserved). Mirrors sql-guard.ts; `''` is an escaped quote, not a close.
+function stripComments(sql: string): string {
+  let out = '';
+  let i = 0;
+  const n = sql.length;
+  let inString = false;
+  while (i < n) {
+    const ch = sql[i]!;
+    if (inString) {
+      if (ch === "'" && sql[i + 1] === "'") {
+        out += "''";
+        i += 2;
+        continue;
+      }
+      out += ch;
+      if (ch === "'") inString = false;
+      i++;
+      continue;
+    }
+    if (ch === "'") {
+      inString = true;
+      out += ch;
+      i++;
+      continue;
+    }
+    if (ch === '-' && sql[i + 1] === '-') {
+      i += 2;
+      while (i < n && sql[i] !== '\n') i++;
+      out += ' ';
+      continue;
+    }
+    if (ch === '/' && sql[i + 1] === '*') {
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i += 2;
+      out += ' ';
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+// Split on top-level `;`, treating a `;` inside a '…' literal (with `''` escapes) as data, so a benign
+// `SELECT ';'` is not mis-counted as stacked. Mirrors sql-guard.ts.
+function splitStatements(sql: string): string[] {
+  const out: string[] = [];
+  let current = '';
+  let inString = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i]!;
+    if (ch === "'" && inString && sql[i + 1] === "'") {
+      current += "''";
+      i++;
+    } else if (ch === "'") {
+      inString = !inString;
+      current += ch;
+    } else if (ch === ';' && !inString) {
+      out.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  out.push(current);
+  return out.map((s) => s.trim()).filter(Boolean);
+}
+
+// Blank the contents of every '…' literal (keeping a boundary space) so a write verb used as data —
+// `WHERE status = 'CREATE'`, `'DEL' || 'ETE'` — cannot trip the whole-word write-verb blocklist.
+function stripStringLiterals(sql: string): string {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i]!;
+    if (inString) {
+      if (ch === "'" && sql[i + 1] === "'") {
+        i++;
+        continue;
+      }
+      if (ch === "'") {
+        inString = false;
+        out += ' ';
+        continue;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inString = true;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * True when `rawSql` is a single read-only statement safe to run on a read-only D1 handle. Rejects
+ * stacked statements, anything not leading with SELECT/WITH/EXPLAIN, and any statement-level write verb
+ * (incl. CTE-prefixed DML like `WITH … DELETE`) found outside a string literal.
+ */
+export function isReadOnlySql(rawSql: string): boolean {
+  const stripped = stripComments(rawSql).trim();
+  if (!stripped) return false;
+  const statements = splitStatements(stripped);
+  if (statements.length !== 1) return false;
+  const stmt = statements[0]!;
+  if (!LEADING_READ_RE.test(stmt)) return false;
+  const code = stripStringLiterals(stmt);
+  return !WRITE_VERB_RE.test(code) && !REPLACE_INTO_RE.test(code) && !DANGEROUS_FN_RE.test(code);
+}
+
+/** Throw unless `rawSql` is read-only. The error message contains "read-only" for the wrapper's tests. */
+export function assertReadOnly(rawSql: string): void {
+  if (isReadOnlySql(rawSql)) return;
+  const preview = rawSql.trim().replace(/\s+/g, ' ').slice(0, 80);
+  throw new Error(
+    `@sigma/db: refusing a non-read-only statement on the read-only D1 handle: ${preview}`,
+  );
+}
+
+/**
+ * Assert EVERY statement in a (possibly multi-statement) `.exec()` string is read-only. `.exec()` runs
+ * more than one statement, so a first-statement-only check would miss `SELECT 1; DELETE …`.
+ */
+export function assertReadOnlyExec(rawSql: string): void {
+  const statements = splitStatements(stripComments(rawSql));
+  if (statements.length === 0) {
+    throw new Error('@sigma/db: refusing an empty statement on the read-only D1 handle');
+  }
+  for (const stmt of statements) assertReadOnly(stmt);
+}

--- a/packages/db/src/readonly-sql.ts
+++ b/packages/db/src/readonly-sql.ts
@@ -1,13 +1,13 @@
 // Read-only SQL predicate for the @sigma/db read-only D1 wrapper (issue #199). Answers one question —
 // "would this statement write?" — so the wrapper can gate env.DB.prepare/exec and the web runtime can
 // never mutate D1, even if the assistant run_sql AST guard is bypassed. The check is TEXT-based and
-// literal-aware (a write verb inside a '…' literal is data, not a write). Why not an AST parse here: the
-// loader queries are dynamically assembled and node-sql-parser fail-closes on valid SQLite it cannot
-// parse, so parsing would reject real reads and 500 a live loader. node-sql-parser stays on the
-// assistant run_sql path only. The comment/literal handling mirrors apps/web assistant sql-guard.ts so
-// both layers model strings identically.
+// quote-aware: it tracks all four SQLite quoted regions — '…' string, "…"/`…`/[…] identifiers — so a
+// write verb inside any of them is data, and a quote inside an identifier cannot open a phantom string
+// that hides a following write (the #225 review bypass). Why not an AST parse here: the loader queries
+// are dynamically assembled and node-sql-parser fail-closes on valid SQLite it cannot parse, so parsing
+// would reject real reads and 500 a live loader. node-sql-parser stays on the assistant run_sql path only.
 
-// Statement-level write verbs, matched whole-word OUTSIDE string literals. REPLACE is intentionally
+// Statement-level write verbs, matched whole-word OUTSIDE any quoted region. REPLACE is intentionally
 // absent — it collides with the read-only scalar replace(); its write form `REPLACE INTO` is matched
 // separately, and a leading REPLACE is already rejected by the SELECT/WITH/EXPLAIN allow-list.
 const WRITE_VERBS = [
@@ -39,28 +39,39 @@ const REPLACE_INTO_RE = /\breplace\s+into\b/i;
 const DANGEROUS_FN_RE = /\b(?:load_extension|writefile|readfile|fts3_tokenizer)\s*\(/i;
 const LEADING_READ_RE = /^(?:select|with|explain)\b/i;
 
-// Strip `-- line` and `/* block */` comments, but treat a comment marker inside a '…' literal as data
-// (a `--`/`/*` in a literal is preserved). Mirrors sql-guard.ts; `''` is an escaped quote, not a close.
+// SQLite quoted regions and their closing delimiter. '…'/"…"/`…` escape the delimiter by doubling it
+// (`''`, `""`, `` `` ``); […] has no escape and ends at the first `]`. Tracking all four — not just `'…'`
+// — is what closes the identifier-quote bypass (#225): a `'` inside `"x'"` is an identifier char, not a
+// string open, so it can't hide a following write.
+const QUOTE_CLOSE: Record<string, string> = { "'": "'", '"': '"', '`': '`', '[': ']' };
+
+function isQuoteOpen(ch: string): boolean {
+  return ch === "'" || ch === '"' || ch === '`' || ch === '[';
+}
+
+// Strip `-- line` and `/* block */` comments, but treat a comment marker inside any quoted region as
+// data (a `--`/`/*` inside a string or identifier is preserved).
 function stripComments(sql: string): string {
   let out = '';
   let i = 0;
   const n = sql.length;
-  let inString = false;
+  let quote: string | null = null; // open delimiter of the current quoted region, or null
   while (i < n) {
     const ch = sql[i]!;
-    if (inString) {
-      if (ch === "'" && sql[i + 1] === "'") {
-        out += "''";
+    if (quote) {
+      const close = QUOTE_CLOSE[quote]!;
+      if (ch === close && quote !== '[' && sql[i + 1] === close) {
+        out += ch + close; // doubled delimiter is an escape, not a close
         i += 2;
         continue;
       }
       out += ch;
-      if (ch === "'") inString = false;
+      if (ch === close) quote = null;
       i++;
       continue;
     }
-    if (ch === "'") {
-      inString = true;
+    if (isQuoteOpen(ch)) {
+      quote = ch;
       out += ch;
       i++;
       continue;
@@ -84,52 +95,64 @@ function stripComments(sql: string): string {
   return out;
 }
 
-// Split on top-level `;`, treating a `;` inside a '…' literal (with `''` escapes) as data, so a benign
-// `SELECT ';'` is not mis-counted as stacked. Mirrors sql-guard.ts.
+// Split on top-level `;`, treating a `;` inside any quoted region as data, so a benign `SELECT ';'` or a
+// `;` inside a "…" identifier is not mis-counted as a stacked statement.
 function splitStatements(sql: string): string[] {
   const out: string[] = [];
   let current = '';
-  let inString = false;
+  let quote: string | null = null;
   for (let i = 0; i < sql.length; i++) {
     const ch = sql[i]!;
-    if (ch === "'" && inString && sql[i + 1] === "'") {
-      current += "''";
-      i++;
-    } else if (ch === "'") {
-      inString = !inString;
+    if (quote) {
+      const close = QUOTE_CLOSE[quote]!;
+      if (ch === close && quote !== '[' && sql[i + 1] === close) {
+        current += ch + close;
+        i++;
+        continue;
+      }
       current += ch;
-    } else if (ch === ';' && !inString) {
+      if (ch === close) quote = null;
+      continue;
+    }
+    if (isQuoteOpen(ch)) {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === ';') {
       out.push(current);
       current = '';
-    } else {
-      current += ch;
+      continue;
     }
+    current += ch;
   }
   out.push(current);
   return out.map((s) => s.trim()).filter(Boolean);
 }
 
-// Blank the contents of every '…' literal (keeping a boundary space) so a write verb used as data —
-// `WHERE status = 'CREATE'`, `'DEL' || 'ETE'` — cannot trip the whole-word write-verb blocklist.
-function stripStringLiterals(sql: string): string {
+// Blank the contents of every quoted region (string OR identifier), keeping a boundary space, so a write
+// verb used as data — `WHERE status = 'CREATE'`, a `"DELETE"` column identifier — cannot trip the
+// write-verb blocklist, and a quote inside an identifier cannot hide a following write.
+function stripQuoted(sql: string): string {
   let out = '';
-  let inString = false;
+  let quote: string | null = null;
   for (let i = 0; i < sql.length; i++) {
     const ch = sql[i]!;
-    if (inString) {
-      if (ch === "'" && sql[i + 1] === "'") {
-        i++;
+    if (quote) {
+      const close = QUOTE_CLOSE[quote]!;
+      if (ch === close && quote !== '[' && sql[i + 1] === close) {
+        i++; // doubled-delimiter escape — drop both, stay in the region
         continue;
       }
-      if (ch === "'") {
-        inString = false;
-        out += ' ';
+      if (ch === close) {
+        quote = null;
+        out += ' '; // closing delimiter → boundary space
         continue;
       }
-      continue;
+      continue; // drop the region's content
     }
-    if (ch === "'") {
-      inString = true;
+    if (isQuoteOpen(ch)) {
+      quote = ch;
       continue;
     }
     out += ch;
@@ -140,7 +163,7 @@ function stripStringLiterals(sql: string): string {
 /**
  * True when `rawSql` is a single read-only statement safe to run on a read-only D1 handle. Rejects
  * stacked statements, anything not leading with SELECT/WITH/EXPLAIN, and any statement-level write verb
- * (incl. CTE-prefixed DML like `WITH … DELETE`) found outside a string literal.
+ * (incl. CTE-prefixed DML like `WITH … DELETE`) found outside a quoted region.
  */
 export function isReadOnlySql(rawSql: string): boolean {
   const stripped = stripComments(rawSql).trim();
@@ -149,7 +172,7 @@ export function isReadOnlySql(rawSql: string): boolean {
   if (statements.length !== 1) return false;
   const stmt = statements[0]!;
   if (!LEADING_READ_RE.test(stmt)) return false;
-  const code = stripStringLiterals(stmt);
+  const code = stripQuoted(stmt);
   return !WRITE_VERB_RE.test(code) && !REPLACE_INTO_RE.test(code) && !DANGEROUS_FN_RE.test(code);
 }
 

--- a/packages/db/src/readonly-sql.ts
+++ b/packages/db/src/readonly-sql.ts
@@ -10,6 +10,10 @@
 // Statement-level write verbs, matched whole-word OUTSIDE any quoted region. REPLACE is intentionally
 // absent — it collides with the read-only scalar replace(); its write form `REPLACE INTO` is matched
 // separately, and a leading REPLACE is already rejected by the SELECT/WITH/EXPLAIN allow-list.
+// Deliberately broad: some entries aren't standalone SQLite statements (MERGE/UPSERT/GRANT/REVOKE/
+// TRUNCATE, and RENAME/TRIGGER which only occur inside ALTER/CREATE) — kept as forward-proofing. The
+// cost is a theoretical false-reject if a *column/alias* is named after one (e.g. `SELECT trigger …`);
+// the read-loader corpus test rules that out for every real query, so it stays a non-issue in practice.
 const WRITE_VERBS = [
   'INSERT',
   'UPDATE',


### PR DESCRIPTION
## Какво

App-layer read-only D1 guard за web worker-а. D1 няма native runtime read-only binding — `env.DB` е пълен read+write — затова least-privilege за четене се постига на app-layer: тънък read-only wrapper над `env.DB`, изложен от `@sigma/db`, през който минава целият web D1 достъп.

## Как

- **`readonlyD1(db)`** (`@sigma/db`) — обвива `D1Database` така, че `.prepare()` / `.exec()` отхвърлят всичко освен четене, а `.batch()` / `.withSession()` / `.dump()` хвърлят грешка. Връща реалния prepared statement (чист passthrough — четенето не се променя).
- **`getDb(env)`** — единственият chokepoint, изложен от `@sigma/db`; целият web чете D1 само през него, никога директно през `env.DB`. Чиста функция, без module state, за да остане `@sigma/db` stateless.
- **Read-only проверката** — текстова и literal-aware (write verb в `'…'` литерал е данни, не запис). Умишлено НЕ е AST разбор: loader заявките се сглобяват динамично и `node-sql-parser` fail-closes на валиден SQLite, който не може да анализира — това би отхвърлило реални четения и би счупило жива страница. `node-sql-parser` остава само по assistant `run_sql` пътя.
- 27-те места в web, които ползваха `env.DB` директно, минаха през `getDb`. ETL worker-ът запазва raw binding-а — той легитимно пише в D1.

## Ефект

Assistant `run_sql` вече минава през read-only handle — AST guard-ът в `sql-guard.ts` спира да е единствената носеща защита срещу запис (тройна защита: L1 текст → L2 AST → wrapper).

## Тестове

- **Adversarial проверка**: 45 варианта на запис (CTE-DML, `RETURNING`, stacked, comment/case/BOM трикове, `PRAGMA` / `ATTACH` / `VACUUM`, `load_extension`) — всички отхвърлени; cross-check срещу реален sqlite: нито един statement не променя базата и не минава read-only проверката.
- **Corpus guard**: всеки read loader (unfiltered + напълно филтриран) се прекарва през read-only проверката → 0 false-reject.
- **Chokepoint guard**: CI проверка, че web няма нито едно директно `env.DB`. **ETL guard**: че ETL не ползва wrapper-а.

## Обхват и граници

- **App-layer мярка** — raw write-capable binding-ът физически съществува; `getDb` ограничава достъпа на ниво код. Не е и не заменя:
  - неотменяемия per-query timeout за `run_sql` (#83);
  - capability-level read-only binding (spec §9.4) — по-силният бъдещ слой.
- Enforcement-ът е **source-grep vitest guard**, а не lint правило: репото lint-ва само с `prettier` (няма ESLint).
- Имплементира read-only частта на **#134**; част от launch-gate **#83**.

Closes #199
