### PR TITLE
ci: replace pnpm audit with osv-scanner lockfile scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,22 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Dependency audit
-        run: pnpm audit --audit-level=high
+        # `pnpm audit` is broken upstream: npm retired its audit endpoints (HTTP 410 as of
+        # 2026-07-15) and pnpm - including 11.x - still calls them. Scan the lockfile against
+        # OSV.dev instead (covers GHSA, which includes the npm advisory database). Stricter than
+        # the previous `--audit-level=high`: ANY known vulnerability fails the build; intentional
+        # exceptions are recorded in an osv-scanner.toml config, per the OSV-Scanner docs.
+        env:
+          # https://github.com/google/osv-scanner/releases/tag/v2.4.0
+          OSV_SCANNER_VERSION: '2.4.0'
+          # sha256 of osv-scanner_linux_amd64 from the upstream release osv-scanner_SHA256SUMS
+          OSV_SCANNER_SHA256: '15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0'
+        run: |
+          curl -sSfL -o "$RUNNER_TEMP/osv-scanner" \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  $RUNNER_TEMP/osv-scanner" | sha256sum -c -
+          chmod +x "$RUNNER_TEMP/osv-scanner"
+          "$RUNNER_TEMP/osv-scanner" scan source -L pnpm-lock.yaml
       - name: Lint
         # Blocking: the repo-wide `pnpm format` pass cleared the pre-existing prettier debt, so
         # `pnpm lint` (prettier --check .) now gates merges and keeps the tree formatted (#88).


### PR DESCRIPTION
## Проблем

От 2026-07-15 npm пенсионира audit endpoint-ите си (HTTP 410 - This endpoint is being retired). pnpm, включително най-новият 11.13.0, още вика старите endpoint-и, така че стъпката Dependency audit (pnpm audit --audit-level=high) пада във всеки CI run и блокира всички PR-и (check e задължителен статус).

## Решение

Замяна с OSV-Scanner (Google) - сканира pnpm-lock.yaml директно срещу OSV.dev, която покрива GHSA (вкл. npm advisory базата) и не зависи от pnpm-ските endpoint-и. Следва същия модел като gitleaks стъпката в този workflow: пинната версия + sha256 проверка на бинара, без нов GitHub action.

Бележки:
- По-строго от преди: всяка известна уязвимост събаря билда (старият праг беше high). Съзнателни изключения се записват в osv-scanner.toml.
- Проверено локално срещу текущия lockfile: 0 уязвимости в 325 пакета, exit 0.
- Checksum-ът е сверен срещу официалния osv-scanner_SHA256SUMS от release-а.
- Останалите отворени PR-и ще имат червен CI, докато не направят Update branch (старият ci.yml живее в тях).

🤖 Generated with [Claude Code](https://claude.com/claude-code)