### PR TITLE
feat(web): eu-benchmark competition panel on the authority page

### DIFF
--- a/apps/web/app/components/EuBenchmarkStat.tsx
+++ b/apps/web/app/components/EuBenchmarkStat.tsx
@@ -40,6 +40,12 @@ export function EuBenchmarkStat({
         .
       </p>
       <div className="ebs-meter" aria-hidden="true">
+        <span className="ebs-zone ebs-zone-good" style={{ left: 0, width: at(good) }} />
+        <span className="ebs-zone ebs-zone-mid" style={{ left: at(good), width: at(bad - good) }} />
+        <span
+          className="ebs-zone ebs-zone-high"
+          style={{ left: at(bad), width: at(scaleMax - bad) }}
+        />
         <i className={rating === 'bad' ? 'warn' : undefined} style={{ width: at(clamped) }} />
         <span className="ebs-tick" style={{ left: at(good) }}>
           <span className="ebs-tick-label">≤ {pct(good)}</span>

--- a/apps/web/app/components/EuBenchmarkStat.tsx
+++ b/apps/web/app/components/EuBenchmarkStat.tsx
@@ -1,0 +1,57 @@
+import type { IndicatorRating } from '@sigma/config';
+import { pct } from '@sigma/shared';
+
+/**
+ * One competition indicator benchmarked against the EU Single Market Scoreboard: headline share,
+ * a meter with the two EU thresholds as ticks, the verdict in words, and the counts behind it.
+ * Used twice on the authority page („Една оферта" / „Пряко възлагане") so both indicators read
+ * identically. The meter is illustrative (aria-hidden) — every number also lives in the text; the
+ * fill wears the accent only when the share is over the EU „high" threshold, matching .share-bar.warn.
+ */
+export function EuBenchmarkStat({
+  title,
+  qualifier,
+  share,
+  good,
+  bad,
+  rating,
+  ratingLabel,
+  detail,
+}: {
+  title: string;
+  qualifier: string;
+  share: number;
+  good: number;
+  bad: number;
+  rating: IndicatorRating;
+  ratingLabel: string;
+  detail: string;
+}) {
+  const clamped = Math.min(1, Math.max(0, share));
+  // Scale so the threshold zone stays readable: at least 2.5× the „high" cutoff, and never
+  // tighter than the measured share plus headroom.
+  const scaleMax = Math.min(1, Math.max(2.5 * bad, clamped * 1.25));
+  const at = (x: number) => `${((x / scaleMax) * 100).toFixed(1)}%`;
+  return (
+    <div className="ebs">
+      <h3 className="ebs-title">{title}</h3>
+      <p className="ebs-head">
+        <span className="ebs-pct">{pct(clamped)}</span> {qualifier} — <strong>{ratingLabel}</strong>
+        .
+      </p>
+      <div className="ebs-meter" aria-hidden="true">
+        <i className={rating === 'bad' ? 'warn' : undefined} style={{ width: at(clamped) }} />
+        <span className="ebs-tick" style={{ left: at(good) }}>
+          <span className="ebs-tick-label">≤ {pct(good)}</span>
+        </span>
+        <span className="ebs-tick" style={{ left: at(bad) }}>
+          <span className="ebs-tick-label">≥ {pct(bad)}</span>
+        </span>
+      </div>
+      <p className="small muted ebs-thresholds">
+        Прагове на ЕС: целево ≤ {pct(good)} · високо ≥ {pct(bad)}
+      </p>
+      <p className="small muted ebs-detail">{detail}</p>
+    </div>
+  );
+}

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router';
+import { EU_SCOREBOARD, type IndicatorRating, rateLowerIsBetter } from '@sigma/config';
 import { count, money, moneyBare, pct, periodRange, plural } from '@sigma/shared';
 import {
   authorityIdFromSlug,
   getAuthority,
+  getAuthorityProcedureCompetition,
   getAuthoritySingleOffer,
   getEntityNetwork,
   getSpendingTrend,
@@ -45,22 +47,34 @@ export async function loader({ params, context }: Route.LoaderArgs) {
   const db = context.cloudflare.env.DB;
   const authorityId = authorityIdFromSlug(eik);
   return withDbRetry(async () => {
-    const [authority, coverage, trend, network, competition] = await Promise.all([
+    const [authority, coverage, trend, network, competition, procedure] = await Promise.all([
       getAuthority(db, authorityId),
       getCoverageMeta(db),
       getSpendingTrend(db, { authorityId, granularity: 'month' }, { includeSectors: false }),
       getEntityNetwork(db, { kind: 'authority', id: authorityId }, { includeCenterOptions: false }),
       getAuthoritySingleOffer(db, authorityId),
+      getAuthorityProcedureCompetition(db, authorityId),
     ]);
     if (!authority) throw new Response('Not Found', { status: 404 });
-    return { authority, coverage, trend, network, competition };
+    return { authority, coverage, trend, network, competition, procedure };
   });
 }
 
+// Same wording as the /competition page so the two surfaces never disagree on the verdict.
+const RATING_LABEL: Record<IndicatorRating, string> = {
+  good: 'в нормата на ЕС',
+  mid: 'над целевата стойност на ЕС',
+  bad: 'над прага на ЕС',
+};
+
 export default function Authority({ loaderData }: Route.ComponentProps) {
   const a = loaderData.authority;
-  const { trend, network, competition } = loaderData;
+  const { trend, network, competition, procedure } = loaderData;
   const ct = competition;
+  const directAwardRating = rateLowerIsBetter(
+    procedure.nonCompetitiveShare,
+    EU_SCOREBOARD.directAward,
+  );
   const range = coverageRange(loaderData.coverage.coverageEndYear);
   const topSectors = a.sectors
     .slice(0, 3)
@@ -145,26 +159,37 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
 
           <Section
             id="single-offer"
-            title="Една оферта"
-            hint="Дял на договорите с известен брой оферти, възложени само с една оферта."
+            title="Конкуренция"
+            hint="Дял на договорите само с една оферта и дял пряко възлагане (без обявление), спрямо праговете на ЕС."
           >
             {ct.contracts > 0 ? (
-              <div>
-                <SingleOfferPortion
-                  valueEur={ct.singleOfferValueEur}
-                  totalEur={ct.valueEur}
-                  singleOffer={ct.singleOffer}
-                  contracts={ct.contracts}
-                  scopeLabel="на поръчките"
-                  captionSuffix="по стойност"
-                />
-                <p className="small muted mt-8">
-                  <Link to={`/competition?top=50`}>Виж сравнението с други възложители →</Link>
-                </p>
-              </div>
+              <SingleOfferPortion
+                valueEur={ct.singleOfferValueEur}
+                totalEur={ct.valueEur}
+                singleOffer={ct.singleOffer}
+                contracts={ct.contracts}
+                scopeLabel="на поръчките"
+                captionSuffix="по стойност"
+              />
             ) : (
               <p className="muted">Няма договори с известен брой оферти.</p>
             )}
+            <h3 className="mt-8">Пряко възлагане</h3>
+            {procedure.classifiedContracts > 0 ? (
+              <p className="small">
+                <strong>{pct(procedure.nonCompetitiveShare)}</strong> от класифицираните договори са
+                възложени без обявление ({count(procedure.nonCompetitiveContracts)} от{' '}
+                {count(procedure.classifiedContracts)}) — {RATING_LABEL[directAwardRating]} (целево
+                ≤ {pct(EU_SCOREBOARD.directAward.good)}, високо ≥{' '}
+                {pct(EU_SCOREBOARD.directAward.bad)}). Праговете са външен ориентир на Европейската
+                комисия, не оценка на конкретна процедура.
+              </p>
+            ) : (
+              <p className="muted">Няма класифицирани договори по тип процедура.</p>
+            )}
+            <p className="small muted mt-8">
+              <Link to={`/competition?top=50`}>Виж сравнението с други възложители →</Link>
+            </p>
           </Section>
         </div>
 

--- a/apps/web/app/routes/authority.tsx
+++ b/apps/web/app/routes/authority.tsx
@@ -18,7 +18,7 @@ import { DataTable } from '../components/DataTable';
 import { TrendChart } from '../components/TrendChart';
 import { NetworkGraph } from '../components/NetworkGraph';
 import { ContractMiniTable } from '../components/ContractMiniTable';
-import { SingleOfferPortion } from '../components/SingleOfferPortion';
+import { EuBenchmarkStat } from '../components/EuBenchmarkStat';
 import { ShareBar, Chip, Section } from '../components/ui';
 import { publicCache } from '../lib/cache';
 import { coverageRange, getCoverageMeta } from '../lib/coverage';
@@ -71,6 +71,8 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
   const a = loaderData.authority;
   const { trend, network, competition, procedure } = loaderData;
   const ct = competition;
+  // Both verdicts use the COUNT share - the basis the EU Scoreboard thresholds are defined on.
+  const singleOfferRating = rateLowerIsBetter(ct.singleOfferShare, EU_SCOREBOARD.singleBidder);
   const directAwardRating = rateLowerIsBetter(
     procedure.nonCompetitiveShare,
     EU_SCOREBOARD.directAward,
@@ -163,31 +165,39 @@ export default function Authority({ loaderData }: Route.ComponentProps) {
             hint="Дял на договорите само с една оферта и дял пряко възлагане (без обявление), спрямо праговете на ЕС."
           >
             {ct.contracts > 0 ? (
-              <SingleOfferPortion
-                valueEur={ct.singleOfferValueEur}
-                totalEur={ct.valueEur}
-                singleOffer={ct.singleOffer}
-                contracts={ct.contracts}
-                scopeLabel="на поръчките"
-                captionSuffix="по стойност"
+              <EuBenchmarkStat
+                title="Една оферта"
+                qualifier="от договорите с известен брой оферти са с една оферта"
+                share={ct.singleOfferShare}
+                good={EU_SCOREBOARD.singleBidder.good}
+                bad={EU_SCOREBOARD.singleBidder.bad}
+                rating={singleOfferRating}
+                ratingLabel={RATING_LABEL[singleOfferRating]}
+                detail={`${count(ct.singleOffer)} от ${count(ct.contracts)} договора · ${money(ct.singleOfferValueEur)} от ${money(ct.valueEur)} по стойност (${pct(ct.singleOfferValueShare)})`}
               />
             ) : (
               <p className="muted">Няма договори с известен брой оферти.</p>
             )}
-            <h3 className="mt-8">Пряко възлагане</h3>
             {procedure.classifiedContracts > 0 ? (
-              <p className="small">
-                <strong>{pct(procedure.nonCompetitiveShare)}</strong> от класифицираните договори са
-                възложени без обявление ({count(procedure.nonCompetitiveContracts)} от{' '}
-                {count(procedure.classifiedContracts)}) — {RATING_LABEL[directAwardRating]} (целево
-                ≤ {pct(EU_SCOREBOARD.directAward.good)}, високо ≥{' '}
-                {pct(EU_SCOREBOARD.directAward.bad)}). Праговете са външен ориентир на Европейската
-                комисия, не оценка на конкретна процедура.
-              </p>
+              <EuBenchmarkStat
+                title="Пряко възлагане"
+                qualifier="от класифицираните договори са възложени без обявление"
+                share={procedure.nonCompetitiveShare}
+                good={EU_SCOREBOARD.directAward.good}
+                bad={EU_SCOREBOARD.directAward.bad}
+                rating={directAwardRating}
+                ratingLabel={RATING_LABEL[directAwardRating]}
+                detail={`${count(procedure.nonCompetitiveContracts)} от ${count(procedure.classifiedContracts)} класифицирани договора`}
+              />
             ) : (
-              <p className="muted">Няма класифицирани договори по тип процедура.</p>
+              <div className="ebs">
+                <h3 className="ebs-title">Пряко възлагане</h3>
+                <p className="muted">Няма класифицирани договори по тип процедура.</p>
+              </div>
             )}
             <p className="small muted mt-8">
+              Праговете са външен ориентир на Европейската комисия (Single Market Scoreboard), не
+              оценка на конкретна процедура.{' '}
               <Link to={`/competition?top=50`}>Виж сравнението с други възложители →</Link>
             </p>
           </Section>

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -628,25 +628,42 @@ tbody td,
 }
 .ebs-meter {
   position: relative;
-  height: 8px;
+  height: 12px;
   background: var(--rule-soft);
-  margin: var(--s-2) 0 22px;
+  margin: var(--s-2) 0 24px;
+}
+/* Threshold zones: the EU bands are visible across the whole track, not just as ticks -
+   under target (lightest), between target and high (a gray step up), over high (accent wash). */
+.ebs-zone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: block;
+}
+.ebs-zone-good {
+  background: var(--rule-soft);
+}
+.ebs-zone-mid {
+  background: var(--rule);
+}
+.ebs-zone-high {
+  background: var(--accent-bg);
 }
 .ebs-meter > i {
   position: absolute;
-  inset: 0 auto 0 0;
+  inset: 3px auto 3px 0;
   display: block;
   background: var(--ink-mid);
-  border-radius: 0 4px 4px 0;
+  border-radius: 0 3px 3px 0;
 }
 .ebs-meter > i.warn {
   background: var(--accent);
 }
 .ebs-tick {
   position: absolute;
-  top: -3px;
-  bottom: -3px;
-  width: 1px;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
   background: var(--ink);
 }
 .ebs-tick-label {
@@ -654,10 +671,11 @@ tbody td,
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 3px;
-  font-size: 11px;
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 500;
   line-height: 1;
-  color: var(--ink-soft);
+  color: var(--ink-mid);
   white-space: nowrap;
 }
 .ebs-thresholds,

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -607,3 +607,60 @@ tbody td,
     transform 1.2s ease-out,
     opacity 0.1s ease;
 }
+/* EU-benchmark indicator block (authority page „Конкуренция"): identical shape for both
+   indicators - hero share, meter with the two EU thresholds as hairline ticks, verdict and
+   counts in text. The meter is decorative; the fill wears the accent only over the „high"
+   threshold (same convention as .share-bar.warn). */
+.ebs + .ebs {
+  margin-top: var(--s-4);
+}
+.ebs-title {
+  margin-bottom: var(--s-1);
+}
+.ebs-head {
+  margin: 0;
+}
+.ebs-pct {
+  font: 600 28px/1 var(--font-serif);
+  letter-spacing: -0.01em;
+  color: var(--accent);
+  margin-right: 4px;
+}
+.ebs-meter {
+  position: relative;
+  height: 8px;
+  background: var(--rule-soft);
+  margin: var(--s-2) 0 22px;
+}
+.ebs-meter > i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  background: var(--ink-mid);
+  border-radius: 0 4px 4px 0;
+}
+.ebs-meter > i.warn {
+  background: var(--accent);
+}
+.ebs-tick {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 1px;
+  background: var(--ink);
+}
+.ebs-tick-label {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 3px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+.ebs-thresholds,
+.ebs-detail {
+  margin: 0;
+}

--- a/packages/db/src/queries/competition.ts
+++ b/packages/db/src/queries/competition.ts
@@ -107,6 +107,13 @@ export async function getAuthoritySingleOffer(
   return competitionTotals(db, { authorityId });
 }
 
+export async function getAuthorityProcedureCompetition(
+  db: D1Database,
+  authorityId: string,
+): Promise<ProcedureCompetition> {
+  return procedureCompetition(db, { authorityId });
+}
+
 interface AuthorityShareRow {
   authority_id: string;
   name: string;


### PR DESCRIPTION
Надгражда #153: показателите за конкуренция вече се виждат и per-institution, където са най-полезни (идея от ревюто на мърдж вълната).

## Какво добавя

- Секцията „Една оферта" на страницата на възложителя става „Конкуренция" с два еднакви по форма блока: дял с една оферта и дял пряко възлагане (без обявление).
- Всеки блок: голямо число (по брой договори - основата, на която са дефинирани праговете на EU Scoreboard) + присъда с думи + метър със зони на праговете (до целево / между / над високо, с accent-bg тон) + тикове с етикети + бройките и стойността в текст.
- Заменя EU callout-а от глобалната /competition (премахнат в #153) - тук сравнението е контекстно и има мащаб.
- Ползва procedureCompetition() от #153 през тънък wrapper getAuthorityProcedureCompetition() - нула нов SQL.
- Метърът е декоративен (aria-hidden): всички числа са в текста, присъдата е с думи, не само с цвят.

## Проверки

- competition тестове 9/9, prettier чист, web+db typecheck чист
- Преглед на живо с реални данни: възложител над праговете (Авиоотряд 28) и голямо министерство в нормата (МОН)

🤖 Generated with [Claude Code](https://claude.com/claude-code)