### PR TITLE
test(db): raise vitest timeout for the sqlite-cli integration suite

### DIFF
--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// The db suite is real-SQLite integration style: tests shell out to the sqlite3 CLI dozens of
+// times each, and the heaviest (ship-domain) legitimately runs for around a minute. On loaded CI
+// runners individual tests can exceed vitest's 5s default timeout and fail flaky (seen on the
+// refresh-slice EOP derivation test), so give the whole suite generous headroom - correctness
+// here is asserted by the checks, not by speed.
+export default defineConfig({
+  test: { testTimeout: 120_000 },
+});


### PR DESCRIPTION
## Проблем

Днешният CI run на #242 падна веднъж на refresh-slice.test.ts (derives new eop base rows...) с Test timed out in 5000ms - vitest default-ът. Тестовете в @sigma/db са real-SQLite интеграционни (десетки извиквания на sqlite3 CLI на тест) и на натоварен runner прескачат 5-те секунди: в същия run съседни тестове минаха за 3.6s и 1.6s, т.е. на ръба. Re-run на същия комит мина зелено - класически flaky от твърде стегнат праг.

Бележка: подвеждащите [FAIL] rollup-reconciliation редове в лога са очакван stderr от тестове, които нарочно инжектират нарушения - аритметиката никъде не е грешала.

## Решение

vitest.config.ts за packages/db с testTimeout: 120_000 (ship-domain и днес легитимно върви ~1 минута - минава само защото е синхронен и vitest не може да го прекъсне). Коректността на suite-а се гарантира от assertion-ите, не от скоростта.

Проверено: 28 файла / 196 теста минават локално с новия config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)