### PR TITLE
fix(db,web): convert current_value_eur from the amendment currency, not signing currency (#245)

### DIFF
--- a/packages/db/migrations/0002_current_value_currency.sql
+++ b/packages/db/migrations/0002_current_value_currency.sql
@@ -1,0 +1,6 @@
+-- Track the currency of whichever amendment last set contracts.current_value.
+-- current_value can be denominated in a DIFFERENT currency than the contract's
+-- original signing currency (contracts.currency) when the latest amendment was
+-- recorded after ЦАИС ЕОП's 2026 BGN->EUR feed switch. EUR conversions of
+-- current_value must use this column, not contracts.currency.
+ALTER TABLE contracts ADD COLUMN current_value_currency TEXT;

--- a/packages/db/src/etl-parity.test.ts
+++ b/packages/db/src/etl-parity.test.ts
@@ -1,0 +1,118 @@
+/// <reference types="node" />
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const schemaPath = resolve(root, 'packages/db/migrations/0000_init.sql');
+const refreshSlicePath = resolve(root, 'scripts/refresh-slice.sql');
+const normalizePath = resolve(root, 'scripts/normalize-raw.sql');
+
+function sqlite(dbPath: string, sql: string): string {
+  return execFileSync('sqlite3', [dbPath], { input: sql, encoding: 'utf8' });
+}
+
+function sqliteJson<T>(dbPath: string, sql: string): T[] {
+  const out = execFileSync('sqlite3', ['-json', dbPath, sql], { encoding: 'utf8' }).trim();
+  return out ? (JSON.parse(out) as T[]) : [];
+}
+
+function readScript(dbPath: string, path: string): void {
+  execFileSync('sqlite3', [dbPath], {
+    input: `PRAGMA foreign_keys=ON;\n.read ${path}\n`,
+    stdio: 'pipe',
+  });
+}
+
+// Both scripts independently implement "which amendment wins" for a contract via a
+// ROW_NUMBER() OVER (PARTITION BY unp, contract_number ORDER BY published_at DESC, natural_key
+// DESC) tie-break. This pulls the live ORDER BY clause text out of each script file (not a
+// hand-copied duplicate) so that if either script's tie-break is ever edited to diverge again
+// (as happened in the bug fixed by fb3ed1b, PR #257), the extracted clauses stop matching what
+// this test runs and the assertion below goes red.
+function extractOrderBy(scriptText: string, pattern: RegExp, label: string): string {
+  const match = scriptText.match(pattern);
+  if (!match?.[1]) {
+    throw new Error(
+      `Could not locate the amendment_winner ORDER BY clause in ${label} — ` +
+        'the CTE shape has changed; update the extraction regex in etl-parity.test.ts.',
+    );
+  }
+  return match[1].trim();
+}
+
+const refreshSliceOrderBy = extractOrderBy(
+  readFileSync(refreshSlicePath, 'utf8'),
+  /WITH amendment_winner AS \(\s*SELECT a\.unp, a\.contract_number, a\.value_after, a\.currency,\s*ROW_NUMBER\(\) OVER \(\s*PARTITION BY a\.unp, a\.contract_number\s*ORDER BY ([^)]+)\)/,
+  'scripts/refresh-slice.sql',
+);
+
+const normalizeRawOrderBy = extractOrderBy(
+  readFileSync(normalizePath, 'utf8'),
+  /\), amendment_winner AS \(\s*SELECT unp, contract_number, currency,\s*ROW_NUMBER\(\) OVER \(\s*PARTITION BY unp, contract_number\s*ORDER BY ([^)]+)\)/,
+  'scripts/normalize-raw.sql',
+);
+
+describe('amendment_winner tie-break parity (normalize-raw.sql vs refresh-slice.sql, #257)', () => {
+  it('picks the same winning amendment (value_after/currency) on a published_at tie', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'sigma-etl-parity-'));
+    const dbPath = resolve(dir, 'test.sqlite');
+    try {
+      readScript(dbPath, schemaPath);
+
+      // Two amendments tie on published_at for the same contract. `id` is deliberately set to
+      // sort the OPPOSITE way from `natural_key`, so that if either script's tie-break ever
+      // regresses to order by `id` instead of `natural_key` (the exact class of bug fixed in
+      // fb3ed1b), that script picks the other row and this test fails loudly.
+      sqlite(
+        dbPath,
+        `INSERT INTO amendments
+          (id, natural_key, contract_number, unp, value_before, value_after, value_delta,
+           currency, published_at, document_number, description, source)
+        VALUES
+          ('id-aaa', 'nk-zzz-should-win', 'CONTRACT-PARITY', 'UNP-PARITY', 1000, 1500, 500,
+           'EUR', '2026-06-03', 'AMD-PARITY-A', 'Should win the tie', 'eop:annexes:2026-06-01'),
+          ('id-zzz', 'nk-aaa-should-lose', 'CONTRACT-PARITY', 'UNP-PARITY', 1000, 999, -1,
+           'USD', '2026-06-03', 'AMD-PARITY-B', 'Should lose the tie', 'eop:annexes:2026-06-01');`,
+      );
+
+      const refreshWinner = sqliteJson<{ value_after: number; currency: string }>(
+        dbPath,
+        `SELECT value_after, currency FROM (
+           SELECT a.value_after, a.currency,
+             ROW_NUMBER() OVER (PARTITION BY a.unp, a.contract_number ORDER BY ${refreshSliceOrderBy}) AS win_rn
+           FROM amendments a
+           WHERE a.value_after IS NOT NULL
+         ) WHERE win_rn = 1`,
+      )[0];
+
+      const normalizeWinner = sqliteJson<{ value_after: number; currency: string }>(
+        dbPath,
+        `SELECT value_after, currency FROM (
+           SELECT value_after, currency,
+             ROW_NUMBER() OVER (PARTITION BY unp, contract_number ORDER BY ${normalizeRawOrderBy}) AS win_rn
+           FROM amendments
+           WHERE value_after IS NOT NULL
+         ) WHERE win_rn = 1`,
+      )[0];
+
+      expect(refreshWinner).toBeDefined();
+      expect(normalizeWinner).toBeDefined();
+      expect(
+        refreshWinner,
+        `refresh-slice.sql picked value_after=${refreshWinner?.value_after}/currency=${refreshWinner?.currency}, ` +
+          `normalize-raw.sql picked value_after=${normalizeWinner?.value_after}/currency=${normalizeWinner?.currency} — ` +
+          'the two amendment_winner tie-breaks have diverged (see #257 / fb3ed1b).',
+      ).toEqual(normalizeWinner);
+
+      // Sanity check: the winner should be the natural_key-DESC row, not the id-DESC row —
+      // otherwise this fixture wouldn't actually exercise the tie-break at all.
+      expect(refreshWinner).toEqual({ value_after: 1500, currency: 'EUR' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -21,6 +21,8 @@ import {
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const schemaPath = resolve(root, 'packages/db/migrations/0000_init.sql');
+const migration1Path = resolve(root, 'packages/db/migrations/0001_flow_pairs_bidder_index.sql');
+const migration2Path = resolve(root, 'packages/db/migrations/0002_current_value_currency.sql');
 const precomputePath = resolve(root, 'scripts/precompute.sql');
 
 function sqlite(dbPath: string, sql: string): void {
@@ -61,6 +63,8 @@ function freshDb(): string {
   const dir = mkdtempSync(resolve(tmpdir(), 'sigma-integrity-'));
   const dbPath = resolve(dir, 'test.sqlite');
   readScript(dbPath, schemaPath);
+  readScript(dbPath, migration1Path);
+  readScript(dbPath, migration2Path);
   sqlite(dbPath, CLEAN_FIXTURE);
   return dbPath;
 }

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const migration0 = resolve(root, 'packages/db/migrations/0000_init.sql');
 const migration1 = resolve(root, 'packages/db/migrations/0001_flow_pairs_bidder_index.sql');
+const migration2 = resolve(root, 'packages/db/migrations/0002_current_value_currency.sql');
 
 function sqlite(dbPath: string, sql: string): string {
   return execFileSync('sqlite3', [dbPath], { input: sql, encoding: 'utf8' });
@@ -27,6 +28,7 @@ describe('served migrations', () => {
     try {
       readScript(dbPath, migration0);
       readScript(dbPath, migration1);
+      readScript(dbPath, migration2);
 
       expect(
         sqlite(
@@ -72,6 +74,13 @@ describe('served migrations', () => {
       expect(
         sqlite(dbPath, "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'raw_%';").trim(),
       ).toBe('0');
+
+      expect(
+        sqlite(
+          dbPath,
+          "SELECT COUNT(*) FROM pragma_table_info('contracts') WHERE name='current_value_currency';",
+        ).trim(),
+      ).toBe('1');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/db/src/queries/details.ts
+++ b/packages/db/src/queries/details.ts
@@ -391,6 +391,7 @@ interface ContractDetailRow {
   subcontractor_name: string | null;
   subcontract_value: number | null;
   contract_currency: string;
+  current_value_currency: string | null;
   // tender
   title: string;
   unp: string;
@@ -466,6 +467,7 @@ export async function getContract(
               c.signing_value_eur, c.current_value_eur, c.value_flag, c.date_flag,
               c.bids_received, c.bids_rejected, c.bids_sme, c.bids_non_eea,
               c.subcontractor_eik, c.subcontractor_name, c.subcontract_value, c.currency AS contract_currency,
+              c.current_value_currency,
               t.title, t.source_id AS unp, t.procedure_type, t.cpv_code, t.cpv_description, t.num_lots,
               t.eop_tender_id,
               t.estimated_value, t.currency AS tender_currency, t.start_date, t.end_date,
@@ -533,7 +535,8 @@ export async function getContract(
   const signingEur =
     r.signing_value_eur ?? eurFromNative(r.signing_value, r.contract_currency, r.fx_rate);
   const currentRaw =
-    r.current_value_eur ?? eurFromNative(r.current_value, r.contract_currency, r.fx_rate);
+    r.current_value_eur ??
+    eurFromNative(r.current_value, r.current_value_currency || r.contract_currency, r.fx_rate);
   const procedureEstimatedEur = eurFromNative(
     r.estimated_value,
     r.tender_currency,

--- a/packages/db/src/refresh-slice.test.ts
+++ b/packages/db/src/refresh-slice.test.ts
@@ -593,6 +593,109 @@ describe('refresh-slice EOP base derivation', () => {
     }
   });
 
+  it('leaves current_value_eur NULL for a foreign-currency annex over a BGN contract (known limitation, #257)', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'sigma-refresh-slice-'));
+    const dbPath = resolve(dir, 'test.sqlite');
+    try {
+      readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
+      readScript(dbPath, workStagingSchemaPath);
+      sqlite(
+        dbPath,
+        `INSERT INTO authorities (id, name, bulstat, type) VALUES ('auth:523456790', 'Authority Usd', '523456790', 'public');
+         INSERT INTO bidders (id, name, bulstat, eik_normalized, eik_valid, kind) VALUES ('eik:877777778', 'Bidder Usd', '877777778', '877777778', 1, 'company');
+         INSERT INTO tenders (id, source_id, title, authority_id, estimated_value, currency, procedure_type, status)
+           VALUES ('t:UNP-USD', 'UNP-USD', 'Usd tender', 'auth:523456790', 5000, 'BGN', 'open', 'awarded');
+         INSERT INTO contracts
+           (id, tender_id, bidder_id, amount, currency, signed_at, contract_number, signing_value,
+            current_value, current_value_currency, annex_count, value_flag, amount_eur, signing_value_eur, current_value_eur)
+           VALUES
+           ('c:e:usdannex', 't:UNP-USD', 'eik:877777778', 500, 'BGN', '2025-06-02',
+            'CONTRACT-USD', 1000, 500, 'BGN', 1, 'ok', 500 / 1.95583, 1000 / 1.95583, 500 / 1.95583);
+         INSERT INTO raw_amendments
+           (source, dataset_year, dataset_variant, fetched_at, seq_no, document_number,
+            contract_number, contract_date, published_at, unp, authority_eik, authority_name,
+            procurement_subject, contract_kind, value_before, value_after, value_delta,
+            currency, description)
+         VALUES
+           ('eop:annexes:2026-06-02', 2026, 'eop', '2026-06-08T00:00:00Z', '2', 'AMD-USD-2',
+            'CONTRACT-USD', '2026-06-02', '2026-06-03', 'UNP-USD', '523456790', 'Authority Usd',
+            'Usd tender', 'works', 500, 2000, 1500, 'USD', 'Post-switch USD annex');`,
+      );
+
+      readScript(dbPath, refreshSlicePath);
+      const row = sqliteJson<{
+        current_value: number;
+        current_value_currency: string;
+        current_value_eur: number | null;
+      }>(
+        dbPath,
+        `SELECT current_value, current_value_currency, current_value_eur
+         FROM contracts WHERE id = 'c:e:usdannex'`,
+      )[0];
+      expect(row?.current_value).toBe(2000);
+      expect(row?.current_value_currency).toBe('USD');
+      // Known limitation (documented in precompute.sql): a foreign-currency annex on a
+      // non-foreign contract has no annex-date fx rate available, so current_value_eur is NULL
+      // (safe — no wrong number) rather than silently mis-converted.
+      expect(row?.current_value_eur).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the contract currency when an amendment has an empty-string currency (#257)', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'sigma-refresh-slice-'));
+    const dbPath = resolve(dir, 'test.sqlite');
+    try {
+      readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
+      readScript(dbPath, workStagingSchemaPath);
+      sqlite(
+        dbPath,
+        `INSERT INTO authorities (id, name, bulstat, type) VALUES ('auth:523456791', 'Authority Blank', '523456791', 'public');
+         INSERT INTO bidders (id, name, bulstat, eik_normalized, eik_valid, kind) VALUES ('eik:877777779', 'Bidder Blank', '877777779', '877777779', 1, 'company');
+         INSERT INTO tenders (id, source_id, title, authority_id, estimated_value, currency, procedure_type, status)
+           VALUES ('t:UNP-BLANK', 'UNP-BLANK', 'Blank tender', 'auth:523456791', 5000, 'BGN', 'open', 'awarded');
+         INSERT INTO contracts
+           (id, tender_id, bidder_id, amount, currency, signed_at, contract_number, signing_value,
+            current_value, current_value_currency, annex_count, value_flag, amount_eur, signing_value_eur, current_value_eur)
+           VALUES
+           ('c:e:blankannex', 't:UNP-BLANK', 'eik:877777779', 500, 'BGN', '2025-06-02',
+            'CONTRACT-BLANK', 1000, 500, 'BGN', 1, 'ok', 500 / 1.95583, 1000 / 1.95583, 500 / 1.95583);
+         INSERT INTO raw_amendments
+           (source, dataset_year, dataset_variant, fetched_at, seq_no, document_number,
+            contract_number, contract_date, published_at, unp, authority_eik, authority_name,
+            procurement_subject, contract_kind, value_before, value_after, value_delta,
+            currency, description)
+         VALUES
+           ('eop:annexes:2026-06-02', 2026, 'eop', '2026-06-08T00:00:00Z', '2', 'AMD-BLANK-2',
+            'CONTRACT-BLANK', '2026-06-02', '2026-06-03', 'UNP-BLANK', '523456791', 'Authority Blank',
+            'Blank tender', 'works', 500, 2000, 1500, '', 'Post-switch blank-currency annex');`,
+      );
+
+      readScript(dbPath, refreshSlicePath);
+      const row = sqliteJson<{
+        current_value: number;
+        current_value_currency: string;
+        current_value_eur: number | null;
+      }>(
+        dbPath,
+        `SELECT current_value, current_value_currency, current_value_eur
+         FROM contracts WHERE id = 'c:e:blankannex'`,
+      )[0];
+      expect(row?.current_value).toBe(2000);
+      // COALESCE(NULLIF(a.currency, ''), contracts.currency) — empty string falls back to the
+      // contract's own currency, not to a literal '' or NULL.
+      expect(row?.current_value_currency).toBe('BGN');
+      expect(row?.current_value_eur).toBeCloseTo(2000 / 1.95583, 6);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('classifies amendment rollups from the contract-row estimated value', () => {
     const dir = mkdtempSync(resolve(tmpdir(), 'sigma-refresh-slice-'));
     const dbPath = resolve(dir, 'test.sqlite');

--- a/packages/db/src/refresh-slice.test.ts
+++ b/packages/db/src/refresh-slice.test.ts
@@ -9,6 +9,8 @@ import { assertIntegrity } from '../../../scripts/integrity-checks.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const schemaPath = resolve(root, 'packages/db/migrations/0000_init.sql');
+const migration1Path = resolve(root, 'packages/db/migrations/0001_flow_pairs_bidder_index.sql');
+const migration2Path = resolve(root, 'packages/db/migrations/0002_current_value_currency.sql');
 const refreshSlicePath = resolve(root, 'scripts/refresh-slice.sql');
 const normalizePath = resolve(root, 'scripts/normalize-raw.sql');
 const workStagingSchemaPath = resolve(root, 'scripts/work-staging-schema.sql');
@@ -175,6 +177,8 @@ function seedOcdsOnlySharedNumber(dbPath: string): void {
 
 function initWorkDb(dbPath: string): void {
   readScript(dbPath, schemaPath);
+  readScript(dbPath, migration1Path);
+  readScript(dbPath, migration2Path);
   readScript(dbPath, workStagingSchemaPath);
 }
 
@@ -358,6 +362,8 @@ describe('refresh-slice EOP base derivation', () => {
     const dbPath = resolve(dir, 'test.sqlite');
     try {
       readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
       readScript(dbPath, workStagingSchemaPath);
       seedEopBaseDay(dbPath);
 
@@ -437,6 +443,8 @@ describe('refresh-slice EOP base derivation', () => {
     const dbPath = resolve(dir, 'test.sqlite');
     try {
       readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
       readScript(dbPath, workStagingSchemaPath);
       seedEopOnlySharedNumber(dbPath);
       readScript(dbPath, refreshSlicePath);
@@ -485,6 +493,8 @@ describe('refresh-slice EOP base derivation', () => {
     const dbPath = resolve(dir, 'test.sqlite');
     try {
       readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
       readScript(dbPath, workStagingSchemaPath);
       sqlite(
         dbPath,
@@ -528,11 +538,68 @@ describe('refresh-slice EOP base derivation', () => {
     }
   });
 
+  it('converts current_value_eur from the amendment currency, not the contract signing currency (#245)', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'sigma-refresh-slice-'));
+    const dbPath = resolve(dir, 'test.sqlite');
+    try {
+      readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
+      readScript(dbPath, workStagingSchemaPath);
+      sqlite(
+        dbPath,
+        `INSERT INTO authorities (id, name, bulstat, type) VALUES ('auth:523456789', 'Authority Eur', '523456789', 'public');
+         INSERT INTO bidders (id, name, bulstat, eik_normalized, eik_valid, kind) VALUES ('eik:877777777', 'Bidder Eur', '877777777', '877777777', 1, 'company');
+         INSERT INTO tenders (id, source_id, title, authority_id, estimated_value, currency, procedure_type, status)
+           VALUES ('t:UNP-EUR', 'UNP-EUR', 'Eur tender', 'auth:523456789', 5000, 'BGN', 'open', 'awarded');
+         INSERT INTO contracts
+           (id, tender_id, bidder_id, amount, currency, signed_at, contract_number, signing_value,
+            current_value, current_value_currency, annex_count, value_flag, amount_eur, signing_value_eur, current_value_eur)
+           VALUES
+           ('c:e:eurannex', 't:UNP-EUR', 'eik:877777777', 500, 'BGN', '2025-06-02',
+            'CONTRACT-EUR', 1000, 500, 'BGN', 1, 'ok', 500 / 1.95583, 1000 / 1.95583, 500 / 1.95583);
+         INSERT INTO raw_amendments
+           (source, dataset_year, dataset_variant, fetched_at, seq_no, document_number,
+            contract_number, contract_date, published_at, unp, authority_eik, authority_name,
+            procurement_subject, contract_kind, value_before, value_after, value_delta,
+            currency, description)
+         VALUES
+           ('eop:annexes:2026-06-02', 2026, 'eop', '2026-06-08T00:00:00Z', '2', 'AMD-EUR-2',
+            'CONTRACT-EUR', '2026-06-02', '2026-06-03', 'UNP-EUR', '523456789', 'Authority Eur',
+            'Eur tender', 'works', 500, 2000, 1500, 'EUR', 'Post-switch EUR annex');`,
+      );
+
+      readScript(dbPath, refreshSlicePath);
+      const row = sqliteJson<{
+        value_flag: string;
+        current_value: number;
+        current_value_currency: string;
+        current_value_eur: number;
+        signing_value_eur: number;
+      }>(
+        dbPath,
+        `SELECT value_flag, current_value, current_value_currency, current_value_eur, signing_value_eur
+         FROM contracts WHERE id = 'c:e:eurannex'`,
+      )[0];
+      expect(row?.value_flag).toBe('ok');
+      expect(row?.current_value).toBe(2000);
+      expect(row?.current_value_currency).toBe('EUR');
+      // The amendment's own EUR value, unconverted — NOT divided by the BGN peg a second time.
+      expect(row?.current_value_eur).toBeCloseTo(2000, 6);
+      // signing_value stays denominated in the contract's own (BGN) signing currency — unaffected.
+      expect(row?.signing_value_eur).toBeCloseTo(1000 / 1.95583, 6);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('classifies amendment rollups from the contract-row estimated value', () => {
     const dir = mkdtempSync(resolve(tmpdir(), 'sigma-refresh-slice-'));
     const dbPath = resolve(dir, 'test.sqlite');
     try {
       readScript(dbPath, schemaPath);
+      readScript(dbPath, migration1Path);
+      readScript(dbPath, migration2Path);
       readScript(dbPath, workStagingSchemaPath);
       sqlite(
         dbPath,

--- a/scripts/normalize-raw.sql
+++ b/scripts/normalize-raw.sql
@@ -323,13 +323,44 @@ SET ownership_kind = (
 --    the rate, and the EUR value are all auditable without joining fx_rates.
 INSERT OR IGNORE INTO contracts
   (id, tender_id, bidder_id, amount, currency, signed_at,
-   contract_number, signing_value, current_value, annex_count, eu_funded, bids_received,
+   contract_number, signing_value, current_value, current_value_currency, annex_count, eu_funded, bids_received,
    contract_kind, awarded_to_group, value_flag, date_flag, amount_eur, fx_converted, fx_rate,
    lot_id, document_number, published_at, contract_subject,
    eu_programme, duration_days, winner_size, contractor_country,
    bids_sme, bids_rejected, bids_non_eea,
    subcontractor_eik, subcontractor_name, subcontract_value,
    eauction, framework, accelerated, strategic)
+-- amendment_winner: the currency of whichever raw_amendments row supplied contract_number's
+-- current_value (derive-amendments.sql's own rollup, mirrored here so the winning currency
+-- travels alongside the value it minted — computed ONCE over raw_amendments, not per-row).
+WITH amendment_dedup AS (
+  SELECT *,
+    'am:' || COALESCE(unp, '') || ':' || COALESCE(contract_number, '') || ':' ||
+      COALESCE(
+        NULLIF(document_number, ''),
+        NULLIF(correction_number, ''),
+        NULLIF(seq_no, ''),
+        'content:' || COALESCE(published_at, '') || ':' ||
+          COALESCE(CAST(value_before AS TEXT), '') || ':' ||
+          COALESCE(CAST(value_after AS TEXT), '') || ':' ||
+          COALESCE(CAST(value_delta AS TEXT), '') || ':' ||
+          COALESCE(currency, '') || ':' ||
+          COALESCE(description, '')
+      ) AS natural_key
+  FROM raw_amendments
+), amendment_rn AS (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY natural_key ORDER BY source DESC, id DESC) AS rn
+  FROM amendment_dedup
+), amendment_winner AS (
+  SELECT unp, contract_number, currency,
+    ROW_NUMBER() OVER (
+      PARTITION BY unp, contract_number
+      ORDER BY published_at DESC, natural_key DESC
+    ) AS win_rn
+  FROM amendment_rn
+  WHERE rn = 1 AND value_after IS NOT NULL
+)
 SELECT
   CASE
     WHEN x.source LIKE 'eop:%' THEN 'c:e:' || COALESCE(x.unp, '') || ':' || COALESCE(x.contract_number, '') || ':' ||
@@ -346,6 +377,7 @@ SELECT
   x.contract_number,
   x.signing_value,
   x.current_value,
+  x.current_value_currency,
   COALESCE(x.annex_count, 0),
   x.eu_funded,
   x.bids_received,
@@ -398,6 +430,10 @@ FROM (
       WHEN 'annex_suspect' THEN COALESCE(y.signing_value, y.current_value)
       ELSE COALESCE(y.current_value, y.signing_value)
     END AS trusted_native,
+    -- current_value can be denominated in a DIFFERENT currency than the contract's own (when the
+    -- winning amendment_winner row recorded one) — precompute.sql's later current_value_eur pass
+    -- uses this column instead of `currency` so that amendment isn't re-converted a second time.
+    COALESCE(NULLIF(y.amendment_currency, ''), NULLIF(y.currency, ''), 'BGN') AS current_value_currency,
     -- ECB rates are published on business days only; carry the latest prior rate forward for
     -- weekend/holiday signings, never future-dated, and cap the fallback at 10 calendar days.
     CASE WHEN COALESCE(y.currency, 'BGN') NOT IN ('BGN', 'EUR')
@@ -525,9 +561,12 @@ FROM (
               LIMIT 1
             )
           END AS proc_est_eur,
-          t.estimated_value AS proc_est_native
+          t.estimated_value AS proc_est_native,
+          aw.currency AS amendment_currency
         FROM raw_contracts c
         LEFT JOIN tenders t ON t.id = 't:' || c.unp
+        LEFT JOIN amendment_winner aw
+          ON aw.unp = c.unp AND aw.contract_number = c.contract_number AND aw.win_rn = 1
       ) c
       -- EOP always; an OCDS row only when no EOP row shares its contract_number - EOP wins.
       -- Key is contract_number (the public-procurement contract document number, common to both feeds), NOT unp:

--- a/scripts/precompute.sql
+++ b/scripts/precompute.sql
@@ -32,6 +32,12 @@ UPDATE contracts SET
     WHEN COALESCE(currency,'BGN') = 'BGN' THEN signing_value / 1.95583
     WHEN fx_rate IS NOT NULL THEN signing_value * fx_rate
     ELSE NULL END,
+  -- KNOWN LIMITATION: fx_rate is the SIGNING-currency rate at the signing date (NULL for BGN,
+  -- which needs no lookup — it's pegged). A foreign-currency annex (current_value_currency NOT IN
+  -- ('BGN','EUR')) on a non-foreign contract therefore has no matching annex-date fx rate to fall
+  -- back on, so this ELSE leaves current_value_eur NULL rather than mis-converting at the wrong
+  -- rate. Safe (no wrong number shown), but it is data loss. Adding an annex-currency/annex-date
+  -- fx lookup is out of scope here (#245) — see #257 review thread.
   current_value_eur = CASE
     WHEN value_flag IN ('value_suspect','annex_suspect') OR current_value IS NULL THEN NULL
     WHEN COALESCE(NULLIF(current_value_currency, ''), NULLIF(currency, ''), 'BGN') = 'EUR' THEN current_value

--- a/scripts/precompute.sql
+++ b/scripts/precompute.sql
@@ -34,8 +34,8 @@ UPDATE contracts SET
     ELSE NULL END,
   current_value_eur = CASE
     WHEN value_flag IN ('value_suspect','annex_suspect') OR current_value IS NULL THEN NULL
-    WHEN COALESCE(currency,'BGN') = 'EUR' THEN current_value
-    WHEN COALESCE(currency,'BGN') = 'BGN' THEN current_value / 1.95583
+    WHEN COALESCE(NULLIF(current_value_currency, ''), NULLIF(currency, ''), 'BGN') = 'EUR' THEN current_value
+    WHEN COALESCE(NULLIF(current_value_currency, ''), NULLIF(currency, ''), 'BGN') = 'BGN' THEN current_value / 1.95583
     WHEN fx_rate IS NOT NULL THEN current_value * fx_rate
     ELSE NULL END;
 

--- a/scripts/refresh-slice.sql
+++ b/scripts/refresh-slice.sql
@@ -516,6 +516,7 @@ WHERE id IN (
 );
 INSERT OR IGNORE INTO contracts
   (id, tender_id, bidder_id, amount, currency, signed_at, contract_number, signing_value, current_value,
+   current_value_currency,
    annex_count, eu_funded, bids_received, contract_kind, awarded_to_group, value_flag, date_flag, amount_eur,
    fx_converted, fx_rate, signing_value_eur, current_value_eur,
    lot_id, document_number, published_at, contract_subject,
@@ -534,6 +535,7 @@ SELECT
   x.contract_number,
   x.signing_value,
   x.current_value,
+  x.current_value_currency,
   0,
   x.eu_funded,
   x.bids_received,
@@ -582,8 +584,8 @@ FROM (
     END AS signing_value_eur,
     CASE
       WHEN q.value_flag IN ('value_suspect', 'annex_suspect') OR q.current_value IS NULL THEN NULL
-      WHEN COALESCE(q.currency,'BGN') = 'EUR' THEN q.current_value
-      WHEN COALESCE(q.currency,'BGN') = 'BGN' THEN q.current_value / 1.95583
+      WHEN q.current_value_currency = 'EUR' THEN q.current_value
+      WHEN q.current_value_currency = 'BGN' THEN q.current_value / 1.95583
       ELSE q.current_value * q.fx_rate
     END AS current_value_eur
   FROM (
@@ -598,6 +600,10 @@ FROM (
         WHEN 'annex_suspect' THEN COALESCE(y.signing_value, y.current_value)
         ELSE COALESCE(y.current_value, y.signing_value)
       END AS trusted_native,
+      -- current_value at insert time comes straight from raw_contracts (this contract's own
+      -- currency) — amendment-driven current_value_currency overrides only apply later, once
+      -- the amendments table promotion (below) has run.
+      COALESCE(NULLIF(y.currency, ''), 'BGN') AS current_value_currency,
       -- fx: EUR as-is, BGN at the peg, foreign at the signing-date ECB rate (NULL if missing)
       CASE WHEN COALESCE(y.currency,'BGN') NOT IN ('BGN','EUR')
         THEN (
@@ -760,6 +766,7 @@ WHERE id IN (
 
 INSERT OR IGNORE INTO contracts
   (id, tender_id, bidder_id, amount, currency, signed_at, contract_number, signing_value, current_value,
+   current_value_currency,
    annex_count, eu_funded, bids_received, contract_kind, awarded_to_group, value_flag, date_flag, amount_eur,
    fx_converted, fx_rate, signing_value_eur, current_value_eur,
    lot_id, document_number, published_at, contract_subject,
@@ -778,6 +785,7 @@ SELECT
   x.contract_number,
   x.signing_value,
   x.current_value,
+  x.current_value_currency,
   COALESCE(x.annex_count, 0),
   x.eu_funded,
   x.bids_received,
@@ -826,8 +834,8 @@ FROM (
     END AS signing_value_eur,
     CASE
       WHEN q.value_flag IN ('value_suspect', 'annex_suspect') OR q.current_value IS NULL THEN NULL
-      WHEN COALESCE(q.currency,'BGN') = 'EUR' THEN q.current_value
-      WHEN COALESCE(q.currency,'BGN') = 'BGN' THEN q.current_value / 1.95583
+      WHEN q.current_value_currency = 'EUR' THEN q.current_value
+      WHEN q.current_value_currency = 'BGN' THEN q.current_value / 1.95583
       ELSE q.current_value * q.fx_rate
     END AS current_value_eur
   FROM (
@@ -842,6 +850,10 @@ FROM (
         WHEN 'annex_suspect' THEN COALESCE(y.signing_value, y.current_value)
         ELSE COALESCE(y.current_value, y.signing_value)
       END AS trusted_native,
+      -- current_value at insert time comes straight from raw_contracts (this contract's own
+      -- currency) — amendment-driven current_value_currency overrides only apply later, once
+      -- the amendments table promotion (below) has run.
+      COALESCE(NULLIF(y.currency, ''), 'BGN') AS current_value_currency,
       CASE WHEN COALESCE(y.currency,'BGN') NOT IN ('BGN','EUR')
         THEN (
           SELECT f.eur_per_unit
@@ -1063,6 +1075,14 @@ SET
       AND a.value_after IS NOT NULL
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT 1
+  ),
+  current_value_currency = (
+    SELECT COALESCE(NULLIF(a.currency, ''), contracts.currency) FROM amendments a
+    WHERE a.unp = substr(contracts.tender_id, 3)
+      AND a.contract_number = contracts.contract_number
+      AND a.value_after IS NOT NULL
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT 1
   )
 WHERE (id GLOB 'c:[eo]:*' AND EXISTS (
       SELECT 1 FROM raw_contracts rc
@@ -1076,12 +1096,22 @@ WHERE (id GLOB 'c:[eo]:*' AND EXISTS (
    );
 
 WITH contract_base AS (
-  SELECT c.id, c.currency, c.signing_value, c.current_value, c.fx_rate, c.value_flag,
+  SELECT c.id, c.currency, c.signing_value, c.current_value, c.current_value_currency, c.fx_rate, c.value_flag,
     te.estimated_value AS proc_est_native,
     CASE
-      WHEN COALESCE(NULLIF(c.currency, ''), 'BGN') = 'EUR' THEN COALESCE(c.current_value, c.signing_value)
-      WHEN COALESCE(NULLIF(c.currency, ''), 'BGN') = 'BGN' THEN COALESCE(c.current_value, c.signing_value) / 1.95583
-      WHEN c.fx_rate IS NOT NULL THEN COALESCE(c.current_value, c.signing_value) * c.fx_rate
+      -- current_value (when present) is denominated in current_value_currency (whichever
+      -- amendment last set it), NOT contracts.currency — that's the contract's original
+      -- signing currency and only applies to the signing_value fallback.
+      WHEN c.current_value IS NOT NULL THEN
+        CASE
+          WHEN COALESCE(NULLIF(c.current_value_currency, ''), NULLIF(c.currency, ''), 'BGN') = 'EUR' THEN c.current_value
+          WHEN COALESCE(NULLIF(c.current_value_currency, ''), NULLIF(c.currency, ''), 'BGN') = 'BGN' THEN c.current_value / 1.95583
+          WHEN c.fx_rate IS NOT NULL THEN c.current_value * c.fx_rate
+          ELSE NULL
+        END
+      WHEN COALESCE(NULLIF(c.currency, ''), 'BGN') = 'EUR' THEN c.signing_value
+      WHEN COALESCE(NULLIF(c.currency, ''), 'BGN') = 'BGN' THEN c.signing_value / 1.95583
+      WHEN c.fx_rate IS NOT NULL THEN c.signing_value * c.fx_rate
       ELSE NULL
     END AS eff_eur,
     CASE
@@ -1131,7 +1161,7 @@ WITH contract_base AS (
         AND a.contract_number = c.contract_number
     )
 ), base AS (
-  SELECT id, currency, signing_value, current_value, fx_rate, proc_est_eur, proc_est_native,
+  SELECT id, currency, signing_value, current_value, current_value_currency, fx_rate, proc_est_eur, proc_est_native,
     CASE
       WHEN c.value_flag <> 'annex_suspect'
         AND NOT (c.current_value IS NOT NULL AND (c.current_value < 0 OR (c.signing_value > 0 AND c.current_value / c.signing_value >= 100)))
@@ -1156,8 +1186,8 @@ WITH contract_base AS (
     END AS trusted_native,
     CASE
       WHEN new_value_flag IN ('value_suspect', 'annex_suspect') OR current_value IS NULL THEN NULL
-      WHEN COALESCE(currency, 'BGN') = 'EUR' THEN current_value
-      WHEN COALESCE(currency, 'BGN') = 'BGN' THEN current_value / 1.95583
+      WHEN COALESCE(NULLIF(current_value_currency, ''), NULLIF(currency, ''), 'BGN') = 'EUR' THEN current_value
+      WHEN COALESCE(NULLIF(current_value_currency, ''), NULLIF(currency, ''), 'BGN') = 'BGN' THEN current_value / 1.95583
       WHEN fx_rate IS NOT NULL THEN current_value * fx_rate
       ELSE NULL
     END AS new_current_value_eur,

--- a/scripts/refresh-slice.sql
+++ b/scripts/refresh-slice.sql
@@ -1061,6 +1061,18 @@ SELECT
 FROM dedup
 WHERE rn = 1;
 
+-- amendment_winner: same tie-break as normalize-raw.sql/derive-amendments.sql
+-- (published_at DESC, natural_key DESC) — value and currency are read from this ONE winning
+-- row for each contract, so they can never diverge onto different annexes on a published_at tie.
+WITH amendment_winner AS (
+  SELECT a.unp, a.contract_number, a.value_after, a.currency,
+    ROW_NUMBER() OVER (
+      PARTITION BY a.unp, a.contract_number
+      ORDER BY a.published_at DESC, a.natural_key DESC
+    ) AS win_rn
+  FROM amendments a
+  WHERE a.value_after IS NOT NULL
+)
 UPDATE contracts
 SET
   annex_count = (
@@ -1069,20 +1081,16 @@ SET
       AND a.contract_number = contracts.contract_number
   ),
   current_value = (
-    SELECT a.value_after FROM amendments a
-    WHERE a.unp = substr(contracts.tender_id, 3)
-      AND a.contract_number = contracts.contract_number
-      AND a.value_after IS NOT NULL
-    ORDER BY a.published_at DESC, a.id DESC
-    LIMIT 1
+    SELECT w.value_after FROM amendment_winner w
+    WHERE w.unp = substr(contracts.tender_id, 3)
+      AND w.contract_number = contracts.contract_number
+      AND w.win_rn = 1
   ),
   current_value_currency = (
-    SELECT COALESCE(NULLIF(a.currency, ''), contracts.currency) FROM amendments a
-    WHERE a.unp = substr(contracts.tender_id, 3)
-      AND a.contract_number = contracts.contract_number
-      AND a.value_after IS NOT NULL
-    ORDER BY a.published_at DESC, a.id DESC
-    LIMIT 1
+    SELECT COALESCE(NULLIF(w.currency, ''), contracts.currency) FROM amendment_winner w
+    WHERE w.unp = substr(contracts.tender_id, 3)
+      AND w.contract_number = contracts.contract_number
+      AND w.win_rn = 1
   )
 WHERE (id GLOB 'c:[eo]:*' AND EXISTS (
       SELECT 1 FROM raw_contracts rc


### PR DESCRIPTION
## What changed

Fixes #245 — contracts originally signed in BGN that received a EUR-denominated amendment (e.g. after ЦАИС ЕОП's 2026 feed switch to EUR) showed `current_value_eur` at roughly **half** its true value. The EUR amendment amount was being divided by the BGN peg (1.95583) a second time.

**Root cause:** `contracts.current_value` is set from the latest amendment's `value_after`, denominated in *that amendment's own* currency — but every EUR conversion of `current_value` used `contracts.currency` (the contract's original signing currency) instead.

**Fix:** added `contracts.current_value_currency` (migration `0002_current_value_currency.sql`) to track which currency last set `current_value`, and routed every `current_value → EUR` conversion through it instead of `contracts.currency`:
- `scripts/refresh-slice.sql` (both O/E code paths + the incremental recalc block, plus the `eff_eur`/`annex_suspect` detection feeding `company_totals`/`authority_totals`/`home_totals`)
- `scripts/normalize-raw.sql` (full-rebuild parity)
- `scripts/precompute.sql`
- `packages/db/src/queries/details.ts`'s EUR fallback

`signing_value`/`signing_value_eur` are unchanged — signing is genuinely denominated in the contract's own currency, so this is an intentionally asymmetric fix.

**Review round (ydimitrof, 2026-07-20):**
- `refresh-slice.sql`'s final `UPDATE` picked `current_value` and `current_value_currency` from two independent `ORDER BY published_at DESC, a.id DESC` subqueries, diverging from the `published_at DESC, natural_key DESC` tie-break used everywhere else (`normalize-raw.sql`'s `amendment_winner` CTE, `derive-amendments.sql`). On an equal `published_at`, the two subqueries could pick different annexes, pairing a value with the wrong currency. Consolidated both columns onto a single `amendment_winner` CTE so they always come from the same winning row (`fb3ed1b`).
- Documented the known `current_value_eur` NULL-on-foreign-annex limitation directly in `precompute.sql` (`fb3ed1b`): when the winning annex's currency isn't BGN/EUR, there's no FX rate for it as of the amendment date, so `current_value_eur` stays NULL rather than silently using the wrong rate.
- Extended the regression test with the two cases requested on review: a USD annex over a BGN contract (asserts `current_value_eur` stays NULL per the documented limitation) and an annex with an empty-string currency (asserts the `COALESCE(NULLIF(...), contract currency)` fallback resolves correctly) (`a8ff2cc`).

## How tested

Reproduced the exact case from #245 locally: contract `c:e:00044-2024-0047:174654:eik:831646048:1` (УНП 00044-2024-0047) — `current_value_eur` was `53557088.0086715`, should be `104748559.44` (the amendment's own EUR value, confirmed against the amendments table).

`packages/db/src/refresh-slice.test.ts` now covers three cases for the winning-annex currency handling: BGN contract + EUR-denominated last amendment (equals the amendment's raw EUR value, unconverted; `signing_value_eur` unaffected), USD annex over a BGN contract (NULL `current_value_eur`, documented limitation), and an annex with an empty-string currency (falls back to the contract's currency). Verified independently in a clean worktree (not just the authoring run):

- `pnpm --filter @sigma/db test` — 28/28 files, 200/200 tests pass

## Quality checks run

- Unit tests (`@sigma/db`) — pass
- No open PR on this repo fixes #245 — checked all 35 open PRs (mine + others') for anything touching the currency-conversion files; none address the root cause

Not stacked on #203 (ETL rewrite) or #188 (unrelated quality-index fix) — this targets `main` directly since it's a data-correctness fix.