### PR TITLE
build(deps): clear osv-scanner CVEs blocking CI

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -23,3 +23,15 @@
 id = "GHSA-f88m-g3jw-g9cj"
 ignoreUntil = 2026-10-01T00:00:00Z
 reason = "sharp is a dev-only transitive of miniflare (local Workers simulator), pinned to 0.34.5 upstream and never bundled into the deployed Worker. Remove once miniflare/wrangler pins sharp >= 0.35.0 (pnpm why sharp)."
+
+# ── react-router 7.18.0 — GHSA-qwww-vcr4-c8h2 (High, CVSS 7.1), fixed in 8.3.0 ────────────
+# WHY IGNORED: CSRF bypass in react-router's UNSTABLE RSC (React Server Components) code paths
+# only. Sigma runs plain SSR (React Router v7) and uses NO unstable_/RSC APIs — see
+# apps/web/react-router.config.ts (no unstable_ flags) — so the vulnerable path is unreachable.
+# The only fix is 8.3.0, a MAJOR upgrade requiring a planned migration (no 7.x backport exists
+# as of the advisory).
+# REMOVE WHEN: apps/web is migrated to react-router >= 8.3.0, or a 7.x patch ships.
+[[IgnoredVulns]]
+id = "GHSA-qwww-vcr4-c8h2"
+ignoreUntil = 2026-10-01T00:00:00Z
+reason = "CSRF bypass in react-router unstable RSC APIs only; sigma uses plain SSR with no RSC/unstable_ usage, so unreachable. Fix is 8.3.0 (major). Remove on the react-router 8.x migration."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   vite@8: ^8.0.16
   undici: ^7.28.0
   '@babel/core': ^7.29.6
+  postcss: ^8.5.18
+  valibot: ^1.4.2
 
 importers:
 
@@ -1555,8 +1557,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1597,8 +1599,8 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.3:
@@ -1771,8 +1773,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  valibot@1.4.0:
-    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -2547,7 +2549,7 @@ snapshots:
       react-router: 7.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       semver: 7.8.0
       tinyglobby: 0.2.17
-      valibot: 1.4.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       vite: 8.0.16(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.7.0)
       vite-node: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
     optionalDependencies:
@@ -3145,7 +3147,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   node-releases@2.0.45: {}
 
@@ -3178,9 +3180,9 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss@8.5.15:
+  postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3382,7 +3384,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  valibot@1.4.0(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
@@ -3412,7 +3414,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.24
       rollup: 4.60.4
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -3425,7 +3427,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.24
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -3438,7 +3440,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.24
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,12 @@ overrides:
   #   @babel/core <7.29.6 — arbitrary file read via sourceMappingURL (GHSA-4x5r-pxfx-6jf8);
   #                 dev/build-time only (via @react-router/dev), never ships to the Worker.
   '@babel/core': '^7.29.6'
+  #   postcss <8.5.18 — GHSA-r28c-9q8g-f849 (HIGH); dev/build-time only (via vite→vitest),
+  #                 never ships to the Worker.
+  postcss: '^8.5.18'
+  #   valibot <1.4.2 — GHSA-5qjj-4xww-7phc (MEDIUM); transitive, build-time only, never
+  #                 ships to the Worker.
+  valibot: '^1.4.2'
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Проблем

`osv-scanner` (задължителната стъпка „Dependency audit" в `check`) пада на **всеки** клон, включително `main`, откакто са публикувани три нови сигнала срещу lockfile-а. В момента нито един PR не може да мине CI:

| Пакет | Сигнал | Тежест | Поправено в |
|---|---|---|---|
| postcss 8.5.15 | GHSA-r28c-9q8g-f849 | High (7.5) | 8.5.18 |
| valibot 1.4.0 | GHSA-5qjj-4xww-7phc | Medium (6.9) | 1.4.2 |
| react-router 7.18.0 | GHSA-qwww-vcr4-c8h2 | High (7.1) | 8.3.0 (мажорна) |

## Решение

Придържам се към политиката от #265: **истински бумп за всичко, което може да се бумпне; изключение само за недостижимото.**

- **postcss** и **valibot** - override-и в `pnpm-workspace.yaml`. И двата са преходни, само за разработка и билд, не влизат в качения Worker.
- **react-router** - изключение в `osv-scanner.toml`. Уязвимостта е заобикаляне на CSRF защита **само в нестабилните RSC пътища**; СИГМА върви на обикновен SSR и не ползва никакви `unstable_` API-та (в `apps/web/react-router.config.ts` няма нито един такъв флаг), тоест уязвимият път е недостижим. Единствената поправка е 8.3.0 - мажорна миграция, без backport към 7.x. Изключението е с дата за преглед и с условие за премахване, точно както при sharp.

Нула промени по кода на приложението.

## Проверка

- `osv-scanner` v2.4.0 локално срещу обновения lockfile: **No issues found** (2 филтрирани по документираните изключения).
- `pnpm lint`, `pnpm typecheck` (7/7), `pnpm test` - всичко зелено.
- Lockfile-ът вдига postcss на 8.5.24 и valibot на 1.4.2; react-router остава 7.18.0.

## Бележка за координация

@lyubomir-bozhinov е направил същото в #226 (комит 9239dcc), плюс бумп на `fast-xml-parser`, който е зависимост само на онзи клон. Този PR е отделѐн, за да отпуши CI веднага, без да чака #226. При merge на #226 двете промени би трябвало да се слеят без конфликт по същество.