### PR TITLE
fix(etl): detect wrangler's SQLITE errors from stdout in safeD1

### DIFF
--- a/scripts/import.mjs
+++ b/scripts/import.mjs
@@ -131,7 +131,8 @@ function safeD1(sql) {
   try {
     return d1(sql);
   } catch (err) {
-    const msg = String(err?.message ?? err);
+    // wrangler writes the SQLITE error to stdout, not the exception message.
+    const msg = `${err?.message ?? err} ${err?.stdout ?? ''} ${err?.stderr ?? ''}`;
     if (/no such table|does not exist/i.test(msg)) return [];
     throw err;
   }


### PR DESCRIPTION
Изваден от #188 на @StanislavBG. Кодът е негов, дословно, и коммитът пази авторството му, тъй че при squash заслугата остава при него.

## Защо отделно

#188 („индекс на качеството на договорите") е голям feature PR - миграции, derive стъпки, две нови страници, 40+ коммита. Тази поправка е случайно попаднала вътре: два реда в `scripts/import.mjs`, които нямат нищо общо с индекса на качеството. Ако остане там, тръгва чак когато цялата функционалност мине ревю, а дотогава `--plan-only` стои счупен. Затова я разделяме - поправката да върви със своя скорост, а #188 да се преглежда по същество.

Няма нужда @StanislavBG да прави нещо. Когато това се слее, хънкът в #188 или ще се разреши сам при rebase, или ще е тривиален конфликт с еднакъв резултат.

## Проблемът

`safeD1` търсеше „no such table" в `err.message`. Но wrangler печата грешката от SQLite като JSON на **stdout**, а изключението остава голо `Command failed: wrangler d1 execute ...`. Проверката така никога не хващаше, `safeD1` пре-хвърляше вместо да върне `[]`, и fallback-ът към `data_freshness` в `latestLoadedDate` беше недостижим.

Видимият ефект: `pnpm run import --catchup --plan-only` гърми, когато transient staging таблиците ги няма - а това е нормалното им състояние, понеже `drop-transient-staging` ги маха в `finally`, а `--plan-only` излиза преди основният поток да ги пресъздаде. Обикновените пускания не са засегнати: те първо създават празен `raw_contracts` и стигат до fallback-а.

## Проверка

Срещу истинска локална база, след като transient staging таблиците са махнати (тоест в нормалното steady-state състояние):

Преди - `--plan-only` гърми:

```
Error: Command failed: wrangler d1 execute sigma --local --json --command ...
    "text": "no such table: raw_contracts: SQLITE_ERROR"
```

След - fallback-ът работи и планът се отпечатва, exit 0:

```
==> catchup plan maxLoadedDate=2026-07-27 from=2026-07-24 to=2026-07-28 gapDays=5 derive=slice
```

`prettier --check` е чист.

## За теста

Първата редакция тук казваше, че тест няма как да се направи: `import.mjs` изпълнява код при внасяне, тъй че `safeD1` не се тества модулно. Това вече не е вярно - #270 донесе `scripts/import-guard.test.mjs`, който кара **истинския** `import.mjs` като отделен процес с подставен `wrangler` най-отпред в PATH. Същата сглобка става и тук.

Тестът обаче нарочно **не** влиза в този PR: коммитът е един и е на @StanislavBG, тъй че при squash заслугата остава при него. Втори коммит от мен би я прехвърлил. Тестът идва с отделен PR.

Затова поправката е проверена с изпълнение, в двете посоки, със същата сглобка. Подставеният `wrangler` връща грешката така, както я връща истинският - JSON на stdout, голо съобщение на изключението:

Без поправката `--catchup --plan-only` гърми:

```
    "text": "no such table: raw_contracts: SQLITE_ERROR"
Node.js v22.22.3
```

С поправката fallback-ът към `data_freshness` се достига и планът се отпечатва:

```
==> catchup plan maxLoadedDate=2026-07-27 from=2026-07-24 to=2026-08-08 gapDays=16 derive=slice
```

Клонът е пребазиран върху `main` (а не слят), за да остане един коммит и авторството да се запази при squash.
