### PR TITLE
build(deps): вдигане на undici override до ^7.29.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   ws: ^8.21.0
   vite@7: ^7.3.5
   vite@8: ^8.0.16
-  undici: ^7.28.0
+  undici: ^7.29.0
   '@babel/core': ^7.29.6
   sharp: ^0.35.3
   postcss: ^8.5.18
@@ -1867,8 +1867,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3251,7 +3251,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3345,7 +3345,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@22.19.19)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260520.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -3358,7 +3358,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@25.9.1)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260520.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -3641,7 +3641,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,10 +17,14 @@ overrides:
   #                 (GHSA-vmh5-mc38-953g), WebSocket DoS via fragment-count bypass
   #                 (GHSA-vxpw-j846-p89q), cross-origin routing via SOCKS5 pool reuse
   #                 (GHSA-hm92-r4w5-c3mj). miniflare's local fetch only; never ships to the Worker.
+  #   undici <7.29.0 — five further advisories disclosed against 7.28.0 (GHSA-4cwx-7wf7-3272 at
+  #                 CVSS 7.4, plus GHSA-8xcm-r25x-g524, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5,
+  #                 GHSA-v3r7-h72x-cjcm), all fixed in 7.29.0. The range already admitted it; the
+  #                 lockfile had simply not moved, so the audit gate went red on main.
   ws: '^8.21.0'
   vite@7: '^7.3.5'
   vite@8: '^8.0.16'
-  undici: '^7.28.0'
+  undici: '^7.29.0'
   #   @babel/core <7.29.6 — arbitrary file read via sourceMappingURL (GHSA-4x5r-pxfx-6jf8);
   #                 dev/build-time only (via @react-router/dev), never ships to the Worker.
   '@babel/core': '^7.29.6'


### PR DESCRIPTION
Отпушва CI. `main` е червен от `3e76949` насам и нищо не може да се мърджне, включително #281.

Одитът на зависимости в задачата `check` намира пет уязвимости срещу `undici@7.28.0` - `GHSA-4cwx-7wf7-3272` (CVSS 7.4), `GHSA-8xcm-r25x-g524`, `GHSA-jr45-8vmc-qm54`, `GHSA-m8rv-5g2x-5cg5`, `GHSA-v3r7-h72x-cjcm` - всичките поправени в `7.29.0`.

Съществуващият диапазон `^7.28.0` вече допускаше `7.29.0`; заключващият файл просто не беше помръдвал. Вдигам долната граница на `^7.29.0`, за да не може да се върне тихо назад, и опреснявам lock-а.

Дифът в `pnpm-lock.yaml` не съдържа нищо освен `undici`. Пакетът се стига през `wrangler`→`miniflare` (локалният fetch) и никога не влиза в runtime-а на Worker-а, тоест има същия статут като останалите пинове в този блок.