### PR TITLE
fix(ingest): анексите, които намаляват договора, губят разликата си

### DIFF
--- a/packages/ingest/src/base.test.ts
+++ b/packages/ingest/src/base.test.ts
@@ -12,6 +12,7 @@ import {
   toInt,
   toPeriodDate,
   toReal,
+  toSignedReal,
 } from './base';
 
 const FIXED_NOW = new Date('2026-06-11T12:00:00Z');
@@ -110,6 +111,44 @@ describe('base EOP mapper', () => {
     expect(toPeriodDate('9999-01-01', FIXED_NOW)).toBeNull();
     expect(toPeriodDate('2025-06-01', FIXED_NOW)).toBe('2025-06-01');
     expect(baseSqlLiteral('tenders', 'end_date', '2043-12-31')).toBe("'2043-12-31'");
+  });
+
+  // An annex can REDUCE a contract, and ЦАИС ЕОП publishes that as a negative
+  // contractValueDifference. Coercing it with toReal dropped the sign - and with it the whole row's
+  // delta - so every value-reducing annex silently lost its recorded change.
+  it('keeps a value-reducing annex delta negative instead of nulling it', () => {
+    const row = mapBaseRecord(
+      'annexes',
+      {
+        uniqueProcurementNumber: '00224-2025-0005',
+        contractNumber: '212221',
+        publicationDate: '05.03.2026',
+        lastContractValue: '24837,96',
+        currentContractValue: '24492,80',
+        contractValueDifference: '-345,16',
+      },
+      { day: '2026-03-05', fetchedAt: '2026-03-05T00:00:00Z' },
+    );
+
+    expect(row?.value_before).toBe(24837.96);
+    expect(row?.value_after).toBe(24492.8);
+    expect(row?.value_delta).toBe(-345.16);
+    // The literal must stay a bare number, not a quoted string, or the staging INSERT changes type.
+    expect(baseSqlLiteral('annexes', 'value_delta', row?.value_delta)).toBe('-345.16');
+  });
+
+  it('coerces signed reals without loosening the magnitude-only fields', () => {
+    expect(toSignedReal('-345,16')).toBe(-345.16);
+    expect(toSignedReal('-1 234,56')).toBe(-1234.56);
+    expect(toSignedReal('5833333,33')).toBe(5833333.33);
+    expect(toSignedReal('0')).toBe(0);
+    expect(toSignedReal(null)).toBeNull();
+    expect(toSignedReal('')).toBeNull();
+    expect(toSignedReal('--5')).toBeNull();
+    expect(toSignedReal('-abc')).toBeNull();
+    expect(toSignedReal(-(MAX_PLAUSIBLE_VALUE + 1))).toBeNull();
+    // Magnitude fields keep rejecting a minus sign: there a negative means corrupt input.
+    expect(toReal('-345,16')).toBeNull();
   });
 });
 

--- a/packages/ingest/src/base.ts
+++ b/packages/ingest/src/base.ts
@@ -7,6 +7,7 @@ export type BaseCoercionKind =
   | 'real'
   | 'bool'
   | 'date'
+  | 'real_signed'
   | 'secured_inverse'
   | 'variants_enum';
 export type BaseStagingValue = string | number | null;
@@ -94,6 +95,19 @@ export function toReal(v: unknown): number | null {
   return Number.isFinite(n) && n >= 0 && n <= MAX_PLAUSIBLE_VALUE ? n : null;
 }
 
+// contractValueDifference is the one published figure that is legitimately negative - an annex can
+// reduce a contract, and ЦАИС ЕОП publishes that as e.g. "-345,16". Every other REAL column here is a
+// magnitude (values, estimates, subcontracting), where a minus sign means corrupt input, so toReal
+// keeps rejecting negatives rather than being loosened for all of them.
+export function toSignedReal(v: unknown): number | null {
+  const s = clean(v);
+  if (s === null) return null;
+  const compact = s.replace(/\s/g, '');
+  if (!compact.startsWith('-')) return toReal(compact);
+  const magnitude = toReal(compact.slice(1));
+  return magnitude === null ? null : -magnitude;
+}
+
 export function toBool(v: unknown): number | null {
   const s = clean(v);
   if (s === null) return null;
@@ -131,6 +145,7 @@ function toVariants(v: unknown): number | null {
 export function coerce(kind: BaseCoercionKind, v: unknown): BaseStagingValue {
   if (kind === 'int') return toInt(v);
   if (kind === 'real') return toReal(v);
+  if (kind === 'real_signed') return toSignedReal(v);
   if (kind === 'bool') return toBool(v);
   if (kind === 'date') return toISODate(v);
   if (kind === 'secured_inverse') return toSecuredFinancing(v);
@@ -297,7 +312,7 @@ export const BASE_CATEGORIES: Record<BaseCategory, BaseCategoryConfig> = {
       field('contract_date', 'contractDate', 'date'),
       field('value_before', 'lastContractValue', 'real'),
       field('value_after', 'currentContractValue', 'real'),
-      field('value_delta', 'contractValueDifference', 'real'),
+      field('value_delta', 'contractValueDifference', 'real_signed'),
       field('currency', 'contractCurrency', 'text'),
       field('contract_subject', 'contractSubject', 'text'),
       field('awarded_to_group', 'awardedToGroup', 'bool'),
@@ -432,7 +447,7 @@ export function baseSqlLiteral(
 ): string {
   if (value === null || value === undefined) return 'NULL';
   const kind = baseColumnKind(cat, column);
-  if (['int', 'real', 'bool', 'secured_inverse', 'variants_enum'].includes(kind)) {
+  if (['int', 'real', 'real_signed', 'bool', 'secured_inverse', 'variants_enum'].includes(kind)) {
     return String(value);
   }
   return escapeSqlText(String(value));


### PR DESCRIPTION
Излиза от проверка на данните в `amendments` срещу източника в ЦАИС ЕОП. Дефектът не е заведен никъде.

## Какво е счупено

`toReal()` отхвърля всяко отрицателно число, а `value_delta` минава през него ([base.ts:300](../blob/main/packages/ingest/src/base.ts#L300) → [base.ts:92](../blob/main/packages/ingest/src/base.ts#L92)). Затова всеки анекс, който **намалява** договора, губи разликата си.

Измерено на `sigma-stage-green`:

| | |
| --- | --- |
| редове в `amendments` | 30 425 |
| с `value_delta < 0` | **0** |
| с `NULL` разлика и `value_after < value_before` | **916** |
| с `NULL` разлика и `value_after > value_before` | 0 |

Тоест губи се точно едната посока. Източникът наистина ги публикува - в `open-data-2026-03-05` договор 212221 носи `contractValueDifference "-345,16"` (`24837,96` → `24492,80`), а на staging този ред е с `value_delta = NULL`.

## Обхват на щетата

Екранът не е засегнат: [details.ts](../blob/main/packages/db/src/queries/details.ts) преизчислява `deltaEur` от преди/след, вместо да чете колоната. Но колоната мълчаливо губи данни, влиза в `natural_key` при съдържателния отпечатък ([derive-amendments.sql:21](../blob/main/scripts/derive-amendments.sql#L21)) и всеки бъдещ потребител на полето систематично няма да вижда намаленията.

## Поправката

Отделен coercion `real_signed`, вързан само за `value_delta`. Останалите REAL колони - стойности, прогнози, подизпълнение - са големини, където минусът значи повреден вход, затова `toReal` остава непокътнат и продължава да ги отхвърля.

## Поправка на бележката за ключа (след ревю)

Първата редакция твърдеше, че смененият ключ „ще се уреди при следващото пълно пресъздаване". **Това беше грешно** и го проверих сам.

`scripts/refresh-slice.sql` вмъква с `INSERT OR REPLACE`, а първичният ключ **е** отпечатъкът (`SELECT natural_key, natural_key, …`). Значи при **постъпково** опресняване сменен отпечатък не заменя стария ред, а добавя втори - и `annex_count`, който брои редовете в `amendments`, става 2 вместо 1. Стойността на договора не се влияе (двата реда носят едно и също `value_after` и `published_at`).

Обхватът днес обаче е нулев, също проверено на `sigma-stage-green`:

| проверка | брой |
| --- | --- |
| редове, ползващи съдържателния отпечатък (`id LIKE '%:content:%'`) | **0** |
| от тях застрашени от смяна на ключа | **0** |
| редове с изгубена разлика (`value_delta IS NULL AND value_after < value_before`) | 917 |

Тоест това е заложен капан за бъдещ анекс, който пристигне без `document_number`, `correction_number` и `seq_no` - не повреда при мърдж. Реших да не пипам самия отпечатък: смяната му би сменила ключовете на цялата таблица заради случай, който днес няма нито един ред.

**За вече счупените 917 реда:** тримесечният прозорец на крона не се връща към тях, но пълното презареждане ги оправя, понеже разчита наново от дневните файлове. Тоест те се лекуват от предстоящия ребилд, не искат отделна миграция.

## Проверка

- Целият набор на `@sigma/ingest`: 50 теста минават; `tsc --noEmit` чист.
- Мутационна проверка: връщането на полето към `'real'` проваля точно новия тест.
- Тестът пази и двете страни - че `toReal('-345,16')` **остава** `null`, за да не се разхлаби глобално.

## Какво НЕ влиза тук

Проверката извади и втори, по-голям проблем: всичките 4 239 анекса от OCDS са с `unp`, съдържащ OCID вместо УНП, и не се свързват с нито един договор. Той иска и промяна на семантиката на стойностите от OCDS, затова го оставям за отделно issue.
