### PR TITLE
build(deps): вдигни nanoid до 3.3.17+ (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   sharp: ^0.35.3
   postcss: ^8.5.18
   valibot: ^1.4.2
+  nanoid: ^3.3.17
 
 importers:
 
@@ -1643,8 +1644,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3369,7 +3370,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.45: {}
 
@@ -3406,7 +3407,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,10 @@ overrides:
   #   valibot <1.4.2 — GHSA-5qjj-4xww-7phc (MEDIUM); transitive, build-time only, never
   #                 ships to the Worker.
   valibot: '^1.4.2'
+  #   nanoid <3.3.17 — GHSA-2v37-7h3g-55p8 (HIGH, 8.2); pulled in by postcss (itself pinned
+  #                 above), so postcss 8.5.24 keeps resolving 3.3.16 on its own. Build-time
+  #                 only, via vite/vitest — never ships to the Worker.
+  nanoid: '^3.3.17'
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
`main` беше зелен в 20:51, а всеки отворен PR почервеня в 21:56 - между двете е обявено ново предупреждение с висока тежест.

## Какво

`GHSA-2v37-7h3g-55p8` (HIGH, 8.2) срещу `nanoid` < 3.3.17. Проверката за зависимости пада на него, тоест блокира всичко отворено.

## Защо иска изрично закачане

`nanoid` идва през `postcss`, който вече е закачен по-горе - но `postcss@8.5.24` сам по себе си продължава да решава `nanoid@3.3.16`. Затова закачането трябва да е директно; след него дървото решава 3.3.18.

Само за времето на сглобяване, през `vite`/`vitest` - не стига до Worker-а, както и останалите закачания в този блок.

## Проверка

- `grep -c "nanoid@3.3.16" pnpm-lock.yaml` → 0
- наборът на `scripts`: 51 теста минават
