### PR TITLE
docs(scripts): известието на wrangler е на stderr - подсигуряване, не поправка

### DIFF
--- a/scripts/ship-e2e.test.mjs
+++ b/scripts/ship-e2e.test.mjs
@@ -275,9 +275,14 @@ test('a bracketed notice on stdout does not corrupt the read-back', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'ship-e2e-noise-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
 
-  // The script slices from the first '[' to skip wrangler's preamble — a `[WARNING]` line would
-  // send that slice to the wrong offset. Real wrangler --json keeps notices on stderr, but the
-  // defensive slice exists precisely because that has not always been true.
+  // This is a HYPOTHETICAL, and saying so is the point. `wrangler d1 execute --json` was run against
+  // the real tool afterwards: the notice goes to stderr, stdout is clean JSON, and execFileSync
+  // returns stdout alone. So this models a stream layout wrangler does not currently produce.
+  //
+  // It stays as a cheap guard against a future release moving notices onto stdout — but the PR that
+  // added it billed the scan as fixing an observed failure, which it never was. A fake is a claim
+  // about the world; this one went unchecked, the suite was green, and the false claim shipped.
+  // Anything modelled here that has not been confirmed against the real binary gets labelled as such.
   const { res } = runShip(dir, { env: { SHIP_FAKE_NOISE: '1' } });
   assert.equal(res.status, 0, `a stdout notice broke the read-back:\n${res.stderr}`);
 });

--- a/scripts/ship-related-persons.mjs
+++ b/scripts/ship-related-persons.mjs
@@ -277,7 +277,8 @@ export function assertD1TargetAuthorized({ remote, shipEnv, d1Name, expectedId, 
  * fails — `assertShippedCounts` then reports every table as unanswered and fails the run, which is the
  * right way round: a verification step that cannot verify must not pass.
  */
-/** First bracket that actually parses — notices may contain '[' of their own. Exported for the test. */
+/** First bracket that actually parses — a notice on the same stream could contain one of its own.
+ *  Belt-and-braces: today wrangler keeps notices on stderr (see the call site). Exported for the test. */
 export function parseWranglerJson(out) {
   for (let i = out.indexOf('['); i >= 0; i = out.indexOf('[', i + 1)) {
     try {
@@ -303,10 +304,11 @@ function readShippedCounts(d1Name, remote, expected) {
       ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
       { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
     );
-    // wrangler prefixes its own notices before the JSON payload; take the document, not the whole
-    // stream. Slicing from the FIRST '[' is not enough — a notice can itself contain one („▲
-    // [WARNING] Processing wrangler.jsonc"), which sliced to the wrong offset and turned a perfectly
-    // healthy ship into a verification failure. Try each candidate and keep the first that parses.
+    // Defensive, NOT a fix for an observed failure — the earlier wording here claimed otherwise and
+    // was wrong. Checked against the real tool: `wrangler d1 execute --json` writes its notices
+    // („▲ [WARNING] Processing wrangler.jsonc") to STDERR and leaves stdout as clean JSON, and
+    // execFileSync returns stdout alone, so slicing from the first '[' is in fact safe today. The
+    // scan below survives a future release that changes that, and costs one failed parse if it does.
     const parsed = parseWranglerJson(out);
     const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
     // Only a real number counts as an answer. `Number(null)` is 0, which would let a null-valued cell pass


### PR DESCRIPTION
Поправка на невярно твърдение, което влезе с #283.

## Какво твърдеше

Коментарът в `readShippedCounts` казваше, че известието `▲ [WARNING]` идва преди JSON-а и „turned a perfectly healthy ship into a verification failure". Същото беше и в описанието на #283, като едно от три „реални дефекта".

## Какво показва истинският инструмент

```
$ wrangler d1 execute sigma --local --json --command "SELECT 1 AS n" > out 2> err
$ cat out
[
  {
    "results": [ { "n": 1 } ],
    "success": true,
$ head -1 err
▲ [WARNING] Processing wrangler.jsonc configuration:
```

Известието е на **stderr**, stdout е чист JSON, а `execFileSync` връща само stdout. Рязането от първата скоба е било безопасно през цялото време. Здраво качване никога не се е проваляло по тази причина.

## Откъде дойде грешката

Подставеният `wrangler` в `ship-e2e.test.mjs` печаташе известието на **stdout**. Тестът минаваше, защото проверяваше кода срещу мой собствен неверен модел на инструмента.

Това е клас грешка, който мутациите не хващат: те проверяват дали твърденията са вързани за кода, а не дали подставката прилича на истината. Тук кодът и тестът бяха вързани коректно - сгрешен беше моделът.

## Какво прави този PR

- коментарът казва вярното: подсигуряване срещу бъдещо издание, не поправка на наблюдаван провал;
- тестът казва изрично, че моделира поток, какъвто wrangler днес не произвежда, и че всяко непроверено срещу истинския двоичен файл поведение се обозначава като такова;
- `parseWranglerJson` **остава** - евтино е и покрива промяна нагоре по веригата. Само не се представя за друго.

Проверих и другите две твърдения от онзи списък - броячът за паузите по таблица и `Number(null) === 0`. И двете са срещу истинско поведение и стоят.

Само коментари; поведението не се променя. `scripts/`: 86 теста минават.