### PR TITLE
test(db): закови gate-а за близнаци при анексите (#302)

### DIFF
--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -237,9 +237,12 @@ describe('reconciliation gate — injected violations', () => {
   // dedup behaviourally; these cases pin the GATE — without them an `ok: n === 0` → `ok: true` edit
   // leaves every package green while the gate is inert.
   //
-  // Sources are the real staged shapes (`eop:annexes:<day>`, `ocds:<day>`), and the offending pairs
-  // deliberately span two different years: the gate matches by source PREFIX, so a narrowed pattern
-  // (`ocds:2026%`) has to drop one of them and blow the count.
+  // Sources are the real staged partition shapes: `eop:annexes:<day>` spanning 2020-05-08..2026-08-11 on
+  // the live corpus, `ocds:<day>` only 2026 (the OCDS feed is go-forward). The gate matches by source
+  // PREFIX, so the fixtures below use both ends of the real EOP range — a pattern pinned to one year
+  // drops an arm and blows the count. The OCDS side cannot be spread the same way without inventing a
+  // partition that does not exist, so an `ocds:2026%` narrowing stays out of reach of honest fixtures;
+  // it is latent-in-2027, not a present regression.
   it('amendment-twin-dedup catches an EOP and an OCDS amendment on the same (unp, contract_number)', async () => {
     const db = track(freshDb());
     sqlite(
@@ -252,7 +255,9 @@ describe('reconciliation gate — injected violations', () => {
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);
     expect(result.skipped).toBe(false);
-    expect(result.detail).toMatch(/^1 \(unp, contract_number\) carry both/);
+    // Anchor the COUNT (so `11` cannot satisfy `1`) but keep the prose match to the stable half of the
+    // message, not the whole sentence.
+    expect(result.detail).toMatch(/^1\b/);
     expect(result.detail).toMatch(/prefer-EOP dedup regressed/);
   });
 
@@ -266,14 +271,14 @@ describe('reconciliation gate — injected violations', () => {
          ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
          ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-06-01','E2','eop:annexes:2022-06-01'),
          -- a genuinely OCDS-only annex on a DIFFERENT contract: what the dedup deliberately keeps
-         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2026-02-01','ocds-e82gsb-1','ocds:2026-02-01'),
+         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2026-02-03','ocds-e82gsb-1','ocds:2026-02-03'),
          -- an OCDS row the bridge refused (still keyed by its OCID) next to an EOP annex on the same
          -- contract number: an honest residual, NOT double counting, because every consumer keys on
          -- (unp, contract_number) and this row's unp matches no contract
-         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-01','ocds-e82gsb-2','ocds:2026-04-01'),
+         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-07','ocds-e82gsb-2','ocds:2026-04-07'),
          -- NULL contract_number on both sides: cannot roll onto a contract, so it cannot double count
-         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2026-05-01','E3','eop:annexes:2026-05-01'),
-         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-01','ocds-e82gsb-4','ocds:2026-05-01');`,
+         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2026-05-06','E3','eop:annexes:2026-05-06'),
+         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-06','ocds-e82gsb-4','ocds:2026-05-06');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(true);
@@ -281,25 +286,28 @@ describe('reconciliation gate — injected violations', () => {
     expect(result.detail).toMatch(/prefer-EOP dedup intact/);
   });
 
-  // Two offending pairs, one per YEAR on both sides. Any source pattern narrower than the prefix the
-  // gate is meant to match (say `ocds:2026%` or `eop:annexes:2026%`) sees only one of them, so the
-  // count drops to 1 and this fails — a year-blind gate cannot masquerade as a working one.
-  it('amendment-twin-dedup counts each offending pair once, not each row', async () => {
+  // THREE offending pairs that deliberately share a value along each axis — (U1,C1), (U1,C2), (U2,C1) —
+  // so the grouping key itself is pinned: collapsing it to `unp` alone counts 2, to `contract_number`
+  // alone counts 2, and only the real composite key counts 3. One pair also carries two EOP rows, so
+  // counting rows instead of pairs overshoots. The EOP sources sit at both ends of the real partition
+  // range (2020 and 2026), which is what kills a year-pinned pattern.
+  it('amendment-twin-dedup counts each offending pair once, keyed on BOTH columns', async () => {
     const db = track(freshDb());
     sqlite(
       db,
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2026-03-05','E1','eop:annexes:2026-03-05'),
-         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-04-09','E2','eop:annexes:2026-04-09'),
-         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-03-05','ocds-e82gsb-1','ocds:2026-03-05'),
-         ('am:ocds:2','am:UNP-1:C-1:ocds-2','C-1','UNP-1','2026-04-09','ocds-e82gsb-2','ocds:2026-04-09'),
-         ('am:eop:3','am:UNP-2:C-2:E3','C-2','UNP-2','2025-11-04','E3','eop:annexes:2025-11-04'),
-         ('am:ocds:3','am:UNP-2:C-2:ocds-3','C-2','UNP-2','2025-11-04','ocds-e82gsb-3','ocds:2025-11-04');`,
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2020-05-08','E1','eop:annexes:2020-05-08'),
+         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-08-11','E2','eop:annexes:2026-08-11'),
+         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-01-04','ocds-e82gsb-1','ocds:2026-01-04'),
+         ('am:eop:3','am:UNP-1:C-2:E3','C-2','UNP-1','2023-09-12','E3','eop:annexes:2023-09-12'),
+         ('am:ocds:2','am:UNP-1:C-2:ocds-2','C-2','UNP-1','2026-05-20','ocds-e82gsb-2','ocds:2026-05-20'),
+         ('am:eop:4','am:UNP-2:C-1:E4','C-1','UNP-2','2026-08-11','E4','eop:annexes:2026-08-11'),
+         ('am:ocds:3','am:UNP-2:C-1:ocds-3','C-1','UNP-2','2026-08-11','ocds-e82gsb-3','ocds:2026-08-11');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);
-    expect(result.detail).toMatch(/^2 \(unp, contract_number\) carry both/);
+    expect(result.detail).toMatch(/^3\b/);
   });
 
   it('amendment-twin-dedup self-skips when the amendments table is absent (staging-only DB)', async () => {

--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -236,19 +236,24 @@ describe('reconciliation gate — injected violations', () => {
   // `amendments` is unconditional. This gate is that dedup's post-condition. The suite already pins the
   // dedup behaviourally; these cases pin the GATE — without them an `ok: n === 0` → `ok: true` edit
   // leaves every package green while the gate is inert.
+  //
+  // Sources are the real staged shapes (`eop:annexes:<day>`, `ocds:<day>`), and the offending pairs
+  // deliberately span two different years: the gate matches by source PREFIX, so a narrowed pattern
+  // (`ocds:2026%`) has to drop one of them and blow the count.
   it('amendment-twin-dedup catches an EOP and an OCDS amendment on the same (unp, contract_number)', async () => {
     const db = track(freshDb());
     sqlite(
       db,
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
-         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2022-03-01','ocds-e82gsb-1','ocds:2022-03-01');`,
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2026-03-05','E1','eop:annexes:2026-03-05'),
+         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-03-05','ocds-e82gsb-1','ocds:2026-03-05');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);
     expect(result.skipped).toBe(false);
-    expect(result.detail).toMatch(/1 \(unp, contract_number\).*prefer-EOP dedup regressed/);
+    expect(result.detail).toMatch(/^1 \(unp, contract_number\) carry both/);
+    expect(result.detail).toMatch(/prefer-EOP dedup regressed/);
   });
 
   it('amendment-twin-dedup stays green on the shapes a working dedup actually leaves behind', async () => {
@@ -261,13 +266,14 @@ describe('reconciliation gate — injected violations', () => {
          ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
          ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-06-01','E2','eop:annexes:2022-06-01'),
          -- a genuinely OCDS-only annex on a DIFFERENT contract: what the dedup deliberately keeps
-         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2023-02-01','ocds-e82gsb-1','ocds:2023-02-01'),
+         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2026-02-01','ocds-e82gsb-1','ocds:2026-02-01'),
          -- an OCDS row the bridge refused (still keyed by its OCID) next to an EOP annex on the same
-         -- contract number: an honest residual, NOT double counting, because it joins no contract
-         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2022-04-01','ocds-e82gsb-2','ocds:2022-04-01'),
+         -- contract number: an honest residual, NOT double counting, because every consumer keys on
+         -- (unp, contract_number) and this row's unp matches no contract
+         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-01','ocds-e82gsb-2','ocds:2026-04-01'),
          -- NULL contract_number on both sides: cannot roll onto a contract, so it cannot double count
-         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2022-05-01','E3','eop:annexes:2022-05-01'),
-         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2022-05-01','ocds-e82gsb-4','ocds:2022-05-01');`,
+         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2026-05-01','E3','eop:annexes:2026-05-01'),
+         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-01','ocds-e82gsb-4','ocds:2026-05-01');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(true);
@@ -275,22 +281,25 @@ describe('reconciliation gate — injected violations', () => {
     expect(result.detail).toMatch(/prefer-EOP dedup intact/);
   });
 
+  // Two offending pairs, one per YEAR on both sides. Any source pattern narrower than the prefix the
+  // gate is meant to match (say `ocds:2026%` or `eop:annexes:2026%`) sees only one of them, so the
+  // count drops to 1 and this fails — a year-blind gate cannot masquerade as a working one.
   it('amendment-twin-dedup counts each offending pair once, not each row', async () => {
     const db = track(freshDb());
     sqlite(
       db,
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
-         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-04-01','E2','eop:annexes:2022-04-01'),
-         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2022-03-01','ocds-e82gsb-1','ocds:2022-03-01'),
-         ('am:ocds:2','am:UNP-1:C-1:ocds-2','C-1','UNP-1','2022-04-01','ocds-e82gsb-2','ocds:2022-04-01'),
-         ('am:eop:3','am:UNP-2:C-2:E3','C-2','UNP-2','2022-05-01','E3','eop:annexes:2022-05-01'),
-         ('am:ocds:3','am:UNP-2:C-2:ocds-3','C-2','UNP-2','2022-05-01','ocds-e82gsb-3','ocds:2022-05-01');`,
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2026-03-05','E1','eop:annexes:2026-03-05'),
+         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-04-09','E2','eop:annexes:2026-04-09'),
+         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-03-05','ocds-e82gsb-1','ocds:2026-03-05'),
+         ('am:ocds:2','am:UNP-1:C-1:ocds-2','C-1','UNP-1','2026-04-09','ocds-e82gsb-2','ocds:2026-04-09'),
+         ('am:eop:3','am:UNP-2:C-2:E3','C-2','UNP-2','2025-11-04','E3','eop:annexes:2025-11-04'),
+         ('am:ocds:3','am:UNP-2:C-2:ocds-3','C-2','UNP-2','2025-11-04','ocds-e82gsb-3','ocds:2025-11-04');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);
-    expect(result.detail).toMatch(/^2 \(unp, contract_number\)/);
+    expect(result.detail).toMatch(/^2 \(unp, contract_number\) carry both/);
   });
 
   it('amendment-twin-dedup self-skips when the amendments table is absent (staging-only DB)', async () => {

--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -249,8 +249,8 @@ describe('reconciliation gate — injected violations', () => {
       db,
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2026-03-05','E1','eop:annexes:2026-03-05'),
-         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-03-05','ocds-e82gsb-1','ocds:2026-03-05');`,
+         ('am:UNP-1:C-1:E1','am:UNP-1:C-1:E1','C-1','UNP-1','2026-03-05','E1','eop:annexes:2026-03-05'),
+         ('am:UNP-1:C-1:ocds-1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-03-05','ocds-e82gsb-1','ocds:2026-03-05');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);
@@ -268,21 +268,21 @@ describe('reconciliation gate — injected violations', () => {
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
          -- two EOP annexes on one contract: the normal case, not a twin
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
-         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-06-01','E2','eop:annexes:2022-06-01'),
+         ('am:UNP-1:C-1:E1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
+         ('am:UNP-1:C-1:E2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-06-01','E2','eop:annexes:2022-06-01'),
          -- a genuinely OCDS-only annex on a DIFFERENT contract: what the dedup deliberately keeps
-         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2026-02-03','ocds-e82gsb-1','ocds:2026-02-03'),
+         ('am:UNP-2:C-2:ocds-1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2026-02-03','ocds-e82gsb-1','ocds:2026-02-03'),
          -- an OCDS row the bridge refused (still keyed by its OCID) next to an EOP annex on the same
          -- contract number: an honest residual, NOT double counting, because every consumer keys on
          -- (unp, contract_number) and this row's unp matches no contract
-         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-07','ocds-e82gsb-2','ocds:2026-04-07'),
+         ('am:ocds-3:C-1:ocds-2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-07','ocds-e82gsb-2','ocds:2026-04-07'),
          -- NULL contract_number on both sides: cannot roll onto a contract, so it cannot double count
-         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2026-05-06','E3','eop:annexes:2026-05-06'),
-         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-06','ocds-e82gsb-4','ocds:2026-05-06'),
+         ('am:UNP-3::E3','am:UNP-3::E3',NULL,'UNP-3','2026-05-06','E3','eop:annexes:2026-05-06'),
+         ('am:UNP-3::ocds-3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-06','ocds-e82gsb-4','ocds:2026-05-06'),
          -- NULL unp on both sides, same contract number: amendments.unp is nullable and both mappers
          -- can leave it empty, but such a row joins no contract either, so it must stay green too
-         ('am:eop:4','am:C-9:E4','C-9',NULL,'2026-07-02','E4','eop:annexes:2026-07-02'),
-         ('am:ocds:5','am:C-9:ocds-5','C-9',NULL,'2026-07-02','ocds-e82gsb-5','ocds:2026-07-02');`,
+         ('am:C-9:E4','am:C-9:E4','C-9',NULL,'2026-07-02','E4','eop:annexes:2026-07-02'),
+         ('am:C-9:ocds-5','am:C-9:ocds-5','C-9',NULL,'2026-07-02','ocds-e82gsb-5','ocds:2026-07-02');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(true);
@@ -301,16 +301,16 @@ describe('reconciliation gate — injected violations', () => {
       db,
       `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
        VALUES
-         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2020-05-08','E1','eop:annexes:2020-05-08'),
-         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-08-11','E2','eop:annexes:2026-08-11'),
-         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-01-04','ocds-e82gsb-1','ocds:2026-01-04'),
+         ('am:UNP-1:C-1:E1','am:UNP-1:C-1:E1','C-1','UNP-1','2020-05-08','E1','eop:annexes:2020-05-08'),
+         ('am:UNP-1:C-1:E2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-08-11','E2','eop:annexes:2026-08-11'),
+         ('am:UNP-1:C-1:ocds-1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-01-04','ocds-e82gsb-1','ocds:2026-01-04'),
          -- ...and TWO OCDS rows, which the dedup would drop together: a gate that demanded exactly one
          -- row per side would walk straight past this pair
-         ('am:ocds:4','am:UNP-1:C-1:ocds-4','C-1','UNP-1','2026-06-15','ocds-e82gsb-4','ocds:2026-06-15'),
-         ('am:eop:3','am:UNP-1:C-2:E3','C-2','UNP-1','2023-09-12','E3','eop:annexes:2023-09-12'),
-         ('am:ocds:2','am:UNP-1:C-2:ocds-2','C-2','UNP-1','2026-05-20','ocds-e82gsb-2','ocds:2026-05-20'),
-         ('am:eop:4','am:UNP-2:C-1:E4','C-1','UNP-2','2026-08-11','E4','eop:annexes:2026-08-11'),
-         ('am:ocds:3','am:UNP-2:C-1:ocds-3','C-1','UNP-2','2026-08-11','ocds-e82gsb-3','ocds:2026-08-11');`,
+         ('am:UNP-1:C-1:ocds-4','am:UNP-1:C-1:ocds-4','C-1','UNP-1','2026-06-15','ocds-e82gsb-4','ocds:2026-06-15'),
+         ('am:UNP-1:C-2:E3','am:UNP-1:C-2:E3','C-2','UNP-1','2023-09-12','E3','eop:annexes:2023-09-12'),
+         ('am:UNP-1:C-2:ocds-2','am:UNP-1:C-2:ocds-2','C-2','UNP-1','2026-05-20','ocds-e82gsb-2','ocds:2026-05-20'),
+         ('am:UNP-2:C-1:E4','am:UNP-2:C-1:E4','C-1','UNP-2','2026-08-11','E4','eop:annexes:2026-08-11'),
+         ('am:UNP-2:C-1:ocds-3','am:UNP-2:C-1:ocds-3','C-1','UNP-2','2026-08-11','ocds-e82gsb-3','ocds:2026-08-11');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(false);

--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   assertIntegrity,
+  checkAmendmentTwins,
   checkCurrentAmountParity,
   checkDateSanity,
   checkEikValidity,
@@ -117,6 +118,7 @@ describe('reconciliation gate — clean corpus', () => {
       'eik-validity',
       'date-sanity',
       'staging-reconciliation',
+      'amendment-twin-dedup',
     ])
       expect(results.find((r) => r.name === nm)?.skipped, `${nm} must not skip`).toBe(false);
   });
@@ -227,6 +229,76 @@ describe('reconciliation gate — injected violations', () => {
     expect(result.ok).toBe(false);
     expect(result.skipped).toBe(false);
     expect(result.detail).toMatch(/EMPTY corpus/);
+  });
+
+  // #286/#302: the OCDS→EOP bridge lets an OCDS amendment reach the same contract as its EOP twin, and
+  // the prefer-EOP dedup (a DELETE two scripts earlier) is the SOLE guard, since promotion into
+  // `amendments` is unconditional. This gate is that dedup's post-condition. The suite already pins the
+  // dedup behaviourally; these cases pin the GATE — without them an `ok: n === 0` → `ok: true` edit
+  // leaves every package green while the gate is inert.
+  it('amendment-twin-dedup catches an EOP and an OCDS amendment on the same (unp, contract_number)', async () => {
+    const db = track(freshDb());
+    sqlite(
+      db,
+      `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
+       VALUES
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
+         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2022-03-01','ocds-e82gsb-1','ocds:2022-03-01');`,
+    );
+    const result = await checkAmendmentTwins(runner(db));
+    expect(result.ok).toBe(false);
+    expect(result.skipped).toBe(false);
+    expect(result.detail).toMatch(/1 \(unp, contract_number\).*prefer-EOP dedup regressed/);
+  });
+
+  it('amendment-twin-dedup stays green on the shapes a working dedup actually leaves behind', async () => {
+    const db = track(freshDb());
+    sqlite(
+      db,
+      `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
+       VALUES
+         -- two EOP annexes on one contract: the normal case, not a twin
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
+         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-06-01','E2','eop:annexes:2022-06-01'),
+         -- a genuinely OCDS-only annex on a DIFFERENT contract: what the dedup deliberately keeps
+         ('am:ocds:1','am:UNP-2:C-2:ocds-1','C-2','UNP-2','2023-02-01','ocds-e82gsb-1','ocds:2023-02-01'),
+         -- an OCDS row the bridge refused (still keyed by its OCID) next to an EOP annex on the same
+         -- contract number: an honest residual, NOT double counting, because it joins no contract
+         ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2022-04-01','ocds-e82gsb-2','ocds:2022-04-01'),
+         -- NULL contract_number on both sides: cannot roll onto a contract, so it cannot double count
+         ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2022-05-01','E3','eop:annexes:2022-05-01'),
+         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2022-05-01','ocds-e82gsb-4','ocds:2022-05-01');`,
+    );
+    const result = await checkAmendmentTwins(runner(db));
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(result.detail).toMatch(/prefer-EOP dedup intact/);
+  });
+
+  it('amendment-twin-dedup counts each offending pair once, not each row', async () => {
+    const db = track(freshDb());
+    sqlite(
+      db,
+      `INSERT INTO amendments (id, natural_key, contract_number, unp, published_at, document_number, source)
+       VALUES
+         ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2022-03-01','E1','eop:annexes:2022-03-01'),
+         ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2022-04-01','E2','eop:annexes:2022-04-01'),
+         ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2022-03-01','ocds-e82gsb-1','ocds:2022-03-01'),
+         ('am:ocds:2','am:UNP-1:C-1:ocds-2','C-1','UNP-1','2022-04-01','ocds-e82gsb-2','ocds:2022-04-01'),
+         ('am:eop:3','am:UNP-2:C-2:E3','C-2','UNP-2','2022-05-01','E3','eop:annexes:2022-05-01'),
+         ('am:ocds:3','am:UNP-2:C-2:ocds-3','C-2','UNP-2','2022-05-01','ocds-e82gsb-3','ocds:2022-05-01');`,
+    );
+    const result = await checkAmendmentTwins(runner(db));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toMatch(/^2 \(unp, contract_number\)/);
+  });
+
+  it('amendment-twin-dedup self-skips when the amendments table is absent (staging-only DB)', async () => {
+    const db = track(freshDb());
+    sqlite(db, 'DROP TABLE amendments;');
+    const result = await checkAmendmentTwins(runner(db));
+    expect(result.skipped).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it('eik-validity catches eik_valid=1 with a non-numeric eik_normalized', async () => {

--- a/packages/db/src/integrity-checks.test.ts
+++ b/packages/db/src/integrity-checks.test.ts
@@ -278,7 +278,11 @@ describe('reconciliation gate — injected violations', () => {
          ('am:ocds:2','am:ocds-3:C-1:ocds-2','C-1','ocds-e82gsb-3','2026-04-07','ocds-e82gsb-2','ocds:2026-04-07'),
          -- NULL contract_number on both sides: cannot roll onto a contract, so it cannot double count
          ('am:eop:3','am:UNP-3::E3',NULL,'UNP-3','2026-05-06','E3','eop:annexes:2026-05-06'),
-         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-06','ocds-e82gsb-4','ocds:2026-05-06');`,
+         ('am:ocds:3','am:UNP-3::ocds-3',NULL,'UNP-3','2026-05-06','ocds-e82gsb-4','ocds:2026-05-06'),
+         -- NULL unp on both sides, same contract number: amendments.unp is nullable and both mappers
+         -- can leave it empty, but such a row joins no contract either, so it must stay green too
+         ('am:eop:4','am:C-9:E4','C-9',NULL,'2026-07-02','E4','eop:annexes:2026-07-02'),
+         ('am:ocds:5','am:C-9:ocds-5','C-9',NULL,'2026-07-02','ocds-e82gsb-5','ocds:2026-07-02');`,
     );
     const result = await checkAmendmentTwins(runner(db));
     expect(result.ok).toBe(true);
@@ -300,6 +304,9 @@ describe('reconciliation gate — injected violations', () => {
          ('am:eop:1','am:UNP-1:C-1:E1','C-1','UNP-1','2020-05-08','E1','eop:annexes:2020-05-08'),
          ('am:eop:2','am:UNP-1:C-1:E2','C-1','UNP-1','2026-08-11','E2','eop:annexes:2026-08-11'),
          ('am:ocds:1','am:UNP-1:C-1:ocds-1','C-1','UNP-1','2026-01-04','ocds-e82gsb-1','ocds:2026-01-04'),
+         -- ...and TWO OCDS rows, which the dedup would drop together: a gate that demanded exactly one
+         -- row per side would walk straight past this pair
+         ('am:ocds:4','am:UNP-1:C-1:ocds-4','C-1','UNP-1','2026-06-15','ocds-e82gsb-4','ocds:2026-06-15'),
          ('am:eop:3','am:UNP-1:C-2:E3','C-2','UNP-1','2023-09-12','E3','eop:annexes:2023-09-12'),
          ('am:ocds:2','am:UNP-1:C-2:ocds-2','C-2','UNP-1','2026-05-20','ocds-e82gsb-2','ocds:2026-05-20'),
          ('am:eop:4','am:UNP-2:C-1:E4','C-1','UNP-2','2026-08-11','E4','eop:annexes:2026-08-11'),

--- a/scripts/integrity-checks.d.mts
+++ b/scripts/integrity-checks.d.mts
@@ -30,6 +30,7 @@ export function checkNoNegativeValues(runner: IntegrityRunner): Promise<Integrit
 export function checkEikValidity(runner: IntegrityRunner): Promise<IntegrityResult>;
 export function checkDateSanity(runner: IntegrityRunner): Promise<IntegrityResult>;
 export function checkStagingReconciliation(runner: IntegrityRunner): Promise<IntegrityResult>;
+export function checkAmendmentTwins(runner: IntegrityRunner): Promise<IntegrityResult>;
 
 export const CHECKS: Array<(runner: IntegrityRunner) => Promise<IntegrityResult>>;
 export function runIntegrityChecks(runner: IntegrityRunner): Promise<IntegrityResult[]>;


### PR DESCRIPTION
Последващо на #302.

## Защо

Новата integrity проверка `amendment-twin-dedup` влезе в `CHECKS`, но нищо не доказваше, че може да се провали. Мутация `ok: n === 0` -> `ok: true` - тоест напълно обезсилен гейт - оцеляваше целия суит: `packages/db` 367, `apps/etl` 20, `scripts/` 89, всичките зелени.

Самата проверка не е сгрешена: ръчно засята двойка EOP+OCDS върху едно и също `(unp, contract_number)` я кара да върне `ok: false` с верния текст, а срещу реалните данни днес дава 0 нарушения. Липсваше тестът, който да закове това поведение, тъй че бъдеща редакция можеше да я обезсили тихо. Точно това е класът „проверка, за която не сме доказали, че може да падне".

## Какво

Четири случая в `packages/db/src/integrity-checks.test.ts`, по идиома на файла (чист корпус минава, по едно засято нарушение на инвариант):

1. **засято нарушение** - EOP и OCDS ред върху едно и също `(unp, contract_number)`: `ok: false` с очаквания текст;
2. **близките, но чисти форми, които работещият dedup наистина оставя** и които НЕ бива да палят гейта: два EOP анекса на един договор; само-OCDS анекс на друг договор; отказан от моста ред, който още носи своя OCID, до EOP анекс със същия номер на договор; и NULL номер на договор от двете страни;
3. **броене на двойки, не на редове** - две нарушени двойки с по два реда всяка дават 2, не 4;
4. **самопропускане**, когато таблицата `amendments` липсва (staging-only база).

`amendment-twin-dedup` е добавена и в списъка „не бива да пропуска" на теста за чистия корпус, тъй че махането ѝ от `CHECKS` също вали тест.

## Проверка

Мутации срещу `scripts/integrity-checks.mjs`, всяка върху чисто копие:

| мутация | резултат |
| --- | --- |
| `ok: n === 0` -> `ok: true` (гейтът винаги минава) | 2 теста падат |
| махане на `checkAmendmentTwins` от `CHECKS` | 1 тест пада |
| броене на редове вместо на двойки | 2 теста падат |
| махане на филтъра за NULL `contract_number` | 1 тест пада |

`packages/db` 371 минават (единственото падане е предсъществуващ артефакт на средата - `ship-domain.test.ts` не намира глобалния wrangler; файлът не е пипан). Само тестов файл, без промяна в производствен код.
