### PR TITLE
fix(ci): сверявай псевдонимите в сондата за колоните на анексите

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,12 +226,16 @@ jobs:
         if: steps.guard.outputs.ok == 'true'
         run: |
           node scripts/wrangler-render.mjs apps/web/wrangler.jsonc
+          # Each alias below MUST be the column name itself: read_flag looks the row up by the very string
+          # ensure_column is called with. An alias that merely describes the column (has_restated) makes
+          # `Object.hasOwn(row, key)` false for every column, which the probe treats as an unreadable answer
+          # and turns into a hard failure — so the step could never succeed, on any database.
           schema_json="$(pnpm --filter @sigma/web exec wrangler d1 execute "${SIGMA_D1_NAME:-sigma}" \
             --config wrangler.deploy.jsonc --remote --yes --json \
             --command "SELECT
-              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_restated') AS has_restated,
-              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_treatment') AS has_treatment,
-              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_suspect') AS has_suspect")"
+              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_restated') AS value_restated,
+              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_treatment') AS value_treatment,
+              (SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_suspect') AS value_suspect")"
 
           read_flag() {
             printf '%s' "$schema_json" | node -e '


### PR DESCRIPTION
Стъпката `Apply amendment restated/suspect columns` от #307 падна на първото си истинско пускане (`9999ad53`) и няма как да мине - нито на тази база, нито на никоя.

## Какво става

Заявката именува колоните `has_restated` / `has_treatment` / `has_suspect`:

```sql
(SELECT COUNT(*) FROM pragma_table_info('amendments') WHERE name = 'value_restated') AS has_restated,
```

а `read_flag` търси реда по низа, с който е извикана `ensure_column`:

```sh
ensure_column value_restated  "value_restated INTEGER NOT NULL DEFAULT 0"
```

`Object.hasOwn(row, 'value_restated')` е false, сондата чете това като нечетим отговор и излиза с 2, а `case`-ът го третира като фатално:

```
##[error]Could not determine whether amendments.value_restated exists.
```

## Какво е засегнато

Стъпката стои **преди** деплоя на Worker-а, тъй че деплоят спира на нея и стъпки 12-14 се прескачат. Самият сайт не е засегнат - нищо не е било разгърнато, stage връща 200 и работи с изданието отпреди #307. Кронът също върви със стария Worker, тъй че не търси новите колони. Няма повредени данни.

Ефектът е, че stage е замразен и редицата не може да продължи: #308 добавя своя стъпка след тази и никога не би стигнал до нея.

## Поправката

Псевдонимите стават самите имена на колоните, плюс коментар защо не могат да бъдат описателни.

Проверено срещу истинската база (само четене):

```
{ "value_restated": 0, "value_treatment": 0, "value_suspect": 0 }
```

и сондата върху този отговор дава статус **1** (добави) за трите, а върху отговор с единици - **0** (има ги). Никога 2.