### PR TITLE
chore(devcontainer): Codex идва инсталиран и настроен

### DIFF
--- a/.devcontainer/codex-defaults.toml
+++ b/.devcontainer/codex-defaults.toml
@@ -1,0 +1,6 @@
+approval_policy = "never"
+default_permissions = ":danger-full-access"
+model_reasoning_effort = "ultra"
+
+[agents]
+default_subagent_reasoning_effort = "max"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,6 +16,27 @@ else
   pnpm install
 fi
 
+# Codex CLI. Installed here rather than in the Dockerfile because /home/node/.pnpm-store
+# is a named volume: a build-time install lands in the image layer and the volume then
+# mounts over it, leaving the shim pointing at whatever stale version the volume holds.
+#
+# The global-bin-dir pin is what keeps `codex update` working afterwards. PATH lists both
+# $PNPM_HOME/bin and $PNPM_HOME (bin first), and the two pnpm majors disagree about which
+# is the global bin dir -- corepack serves pnpm 10 inside this repo (packageManager) and
+# pnpm 11 outside it. So an update run from the repo wrote the shim PATH never resolved,
+# and codex silently stayed pinned at an old version. Pinning the dir makes both majors
+# write the same shim, whatever the cwd.
+echo "==> Installing/updating Codex CLI"
+pnpm config set global-bin-dir "${PNPM_HOME:-$HOME/.local/share/pnpm}/bin"
+rm -f "${PNPM_HOME:-$HOME/.local/share/pnpm}/codex"   # drop a pre-pin duplicate, if any
+pnpm add -g @openai/codex@latest
+
+# Recreate only the desired global Codex defaults on each new container. Codex auth,
+# history, trust decisions, and other state intentionally remain container-local.
+echo "==> Applying Codex defaults"
+install -d -m 700 "$HOME/.codex"
+install -m 600 /workspaces/sigma/.devcontainer/codex-defaults.toml "$HOME/.codex/config.toml"
+
 if [ ! -f .dev.vars ] && [ -f .dev.vars.example ]; then
   cp .dev.vars.example .dev.vars
   echo "==> Copied .dev.vars.example → .dev.vars (fill in real keys before pnpm dev)"


### PR DESCRIPTION
Codex се инсталираше на ръка във всеки нов контейнер, а настройките му живееха само в `~/.codex/config.toml`, който е вътрешен за контейнера и изчезва при пресъздаване. И двете се повтаряха при всяко вдигане на средата. След това PR средата ги носи.

## Защо инсталацията е в post-create, а не в Dockerfile

По същата причина, поради която е там и всичко останало около pnpm: `/home/node/.pnpm-store` е именуван том и се монтира върху слоя на образа. Инсталирано при строеж остава скрито зад това, което томът вече носи, и командата сочи към каквато стара версия той държи.

## Закованата папка за глобални команди

Това е поправка на нещо, което мълчеше. PATH изброява и `$PNPM_HOME/bin`, и `$PNPM_HOME`, а pnpm 10 и pnpm 11 не са съгласни коя от двете е глобалната - в това хранилище corepack сервира 10, извън него 11. Затова `codex update`, пуснат от хранилището, пишеше команда, до която PATH не стигаше, и Codex оставаше на стара версия, без да се оплаче. Закованата папка кара и двете версии да пишат на едно място, независимо от текущата директория.

## Две неща за решаване при ревюто

**1. Колко широки да са настройките по подразбиране.** `codex-defaults.toml` дава `approval_policy = "never"` и `default_permissions = ":danger-full-access"`, тоест Codex върви без пясъчник и без питане в контейнера на всеки. Контейнерът е за еднократна употреба, но `~/.claude` е bind-нат от хоста (виж `mounts` в devcontainer.json), така че „пълен достъп" стига и до файлове на машината през тази папка. Ако това е твърде широко за общо хранилище, по-предпазливата двойка е `on-request` и `workspace-write`.

**2. Презаписването на личен config.** `install -m 600 ... "$HOME/.codex/config.toml"` презаписва без да пита при всяко създаване на контейнер. Днес там няма какво да се загуби, защото файлът е вътрешен за контейнера, но ако някой ден `~/.codex` тръгне да се bind-ва като `~/.claude`, това ще трие лична настройка. Да сложим ли запазване настрани преди презаписа, или да остане просто?

## Проверено

Настройките са сверени със справочника за конфигурация на Codex. Самата инсталация е тази, която върви в тази среда от няколко седмици; образът не е строен наново за този PR, защото промяната е в post-create, а не в Dockerfile.
