### PR TITLE
fix(web): improve totals strip semantics

### DIFF
--- a/apps/web/app/components/TotalsStrip.tsx
+++ b/apps/web/app/components/TotalsStrip.tsx
@@ -9,8 +9,8 @@ export function TotalsStrip({ totals, label }: { totals: Total[]; label?: string
     <dl className="totals" aria-label={label}>
       {totals.map((t) => (
         <div className="cell" key={t.label}>
-          <span className="num">{t.num}</span>
-          <span className="label">{t.label}</span>
+          <dt className="label">{t.label}</dt>
+          <dd className="num">{t.num}</dd>
         </div>
       ))}
     </dl>

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -48,6 +48,8 @@
   margin: var(--s-7) 0;
 }
 .totals .cell {
+  display: flex;
+  flex-direction: column;
   padding: var(--s-6) var(--s-6) var(--s-6) 0;
   border-right: 1px solid var(--rule);
   min-width: 0;
@@ -61,6 +63,8 @@
 }
 .totals .num {
   display: block;
+  order: -1;
+  margin: 0;
   /* Scale down on narrower viewports so the widest value ("51,6 млрд.") never overruns its cell. */
   font: 400 clamp(26px, 2.8vw, 36px) / 1 var(--font-serif);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Какво и защо

Този PR подобрява семантиката на статистическия компонент `TotalsStrip`.

До момента компонентът използваше `<dl>`, но отделните стойности и техните описания бяха представени чрез обикновени `<span>` елементи. Така връзката между етикета и стойността не беше изразена чрез подходящ семантичен HTML.

Промяната използва `<dt>` за описанието и `<dd>` за стойността на всяка статистика.

След feedback от предишния review визуалното оформление остава изцяло в CSS - без inline стилове. Съществуващият визуален ред и дизайн се запазват.

## Свързан issue

Няма свързан issue - промяната е малко и самостоятелно подобрение на семантичния HTML и достъпността.

## Вид промяна

- [x] `fix` - поправка на бъг
- [ ] `feat` - нова функционалност
- [ ] `docs` - документация
- [ ] `refactor` / `perf` / `style` - без промяна в поведението
- [ ] `test` / `ci` / `build` / `chore` - поддръжка

## Как е тествано

Проверено е, че:

- всяка статистика използва семантична двойка `<dt>` / `<dd>`;
- стойността остава визуално над описанието;
- оформлението се управлява чрез съществуващите CSS класове;
- `margin: 0` премахва браузърния default margin на `<dd>`;
- промяната не засяга данните или поведението на компонента.

## Чеклист

- [x] Комитите следват [conventional commits](https://www.conventionalcommits.org) и **нямат** `Co-Authored-By:` trailer, който сочи към агент (Claude Code, Codex, Cursor, Copilot)
- [x] PR-ът е с **един логически обхват** и е от форк към `midt-bg/sigma:main`
- [ ] `pnpm typecheck` минава
- [ ] `pnpm test` (поне за засегнатите пакети) минава
- [ ] `pnpm lint` е чисто
- [x] Няма комитнати тайни, `.env*` или `.dev.vars`
- [x] Документацията в `docs/` е обновена, ако промяната го налага

## Discord

`dr.necrotix`