### PR TITLE
fix(etl): обезсили маркера за срез в началото, не го оставяй да лъже

### DIFF
--- a/packages/ingest/src/refresh-freshness-marker.test.ts
+++ b/packages/ingest/src/refresh-freshness-marker.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { refreshSliceStatementGroups } from './refresh';
+
+// The slice refresh runs its groups as SEPARATE batches — `runRefreshSliceBatches` in scripts/import.mjs
+// shells out once per group, and the Worker path calls db.batch() once per group. Nothing is
+// transactional ACROSS groups, so a group that throws leaves every earlier group applied and every later
+// one unrun. That is not hypothetical: a catch-up on 2026-08-23 died in `amendments` with SQLITE_NOMEM,
+// leaving contracts and tenders advanced by four days while `data_freshness` and `home_totals` still
+// advertised the previous slice. A reader was told a date that was confidently wrong rather than unknown.
+//
+// The fix is ordering, not atomicity: nulling `as_of` in the FIRST group means an interrupted refresh
+// reads as „unknown slice", and `@refresh-batch globals` writes the true values back at the end. These
+// tests hold that ordering, because the property is invisible on a successful run — it only shows up on
+// the failure nobody is watching.
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const refreshSlice = readFileSync(resolve(root, 'scripts/refresh-slice.sql'), 'utf8');
+const groups = refreshSliceStatementGroups(refreshSlice);
+
+const indexOfGroupWhere = (pred: (sql: string) => boolean) =>
+  groups.findIndex((g) => g.statements.some((s) => pred(s)));
+
+describe('freshness markers survive an interrupted slice refresh', () => {
+  it('nulls both markers in the very first group', () => {
+    // First, not merely early: any group that runs before the invalidation can fail and strand a stale
+    // marker, which is exactly the state this guards against.
+    const first = groups[0]!;
+    const sql = first.statements.join('\n');
+    expect(first.name).toBe('setup');
+    expect(sql).toMatch(/UPDATE\s+data_freshness\s+SET\s+as_of\s*=\s*NULL/i);
+    expect(sql).toMatch(/UPDATE\s+home_totals\s+SET\s+as_of\s*=\s*NULL/i);
+  });
+
+  it('writes the true values only in a LATER group', () => {
+    // If the write ever moves into (or before) the invalidating group, the invalidation stops meaning
+    // anything — the marker would be restored before the work it describes has happened.
+    const invalidates = indexOfGroupWhere((s) =>
+      /UPDATE\s+data_freshness\s+SET\s+as_of\s*=\s*NULL/i.test(s),
+    );
+    const writes = indexOfGroupWhere((s) => /INSERT\s+INTO\s+data_freshness/i.test(s));
+    expect(invalidates).toBe(0);
+    expect(writes).toBeGreaterThan(invalidates);
+  });
+
+  it('keeps both markers written in the same group, so they cannot disagree', () => {
+    // data_freshness feeds the ETL catch-up planner; home_totals feeds the public „as of" date and the
+    // CSV export. Splitting them across groups would let a failure land between the two and leave the
+    // site and the planner describing different slices.
+    const freshness = indexOfGroupWhere((s) => /INSERT\s+INTO\s+data_freshness/i.test(s));
+    const totals = indexOfGroupWhere((s) => /INSERT\s+INTO\s+home_totals/i.test(s));
+    expect(freshness).toBe(totals);
+  });
+
+  it('leaves refreshed_at alone, which is NOT NULL in the schema', () => {
+    // Nulling refreshed_at instead would throw on the UPDATE and turn a resilience fix into an outage.
+    const first = groups[0]!.statements.join('\n');
+    expect(first).not.toMatch(/SET[^;]*refreshed_at\s*=\s*NULL/i);
+  });
+});

--- a/scripts/refresh-slice.sql
+++ b/scripts/refresh-slice.sql
@@ -9,6 +9,16 @@
 -- precompute.sql, scoped.
 
 -- @refresh-batch setup
+-- Invalidate the freshness markers BEFORE anything is rebuilt; `@refresh-batch globals` writes the true
+-- values back at the end. The groups below run as separate batches with nothing transactional spanning
+-- them, so a failure part-way through leaves the domain tables advanced while `data_freshness` and
+-- `home_totals` still advertise the PREVIOUS slice — a reader is then told a date that is confidently
+-- wrong rather than unknown. Nulling `as_of` first makes an interrupted refresh read as „unknown slice":
+-- getCoverageMeta already coalesces a missing as_of to null, and the ETL catch-up planner falls back to
+-- raw_contracts. Only `as_of` is touched: `refreshed_at` is NOT NULL, and the row counts stay readable.
+UPDATE data_freshness SET as_of = NULL;
+UPDATE home_totals SET as_of = NULL;
+
 -- The base-wins dedup probes contracts by АОП document number — index it (no-op if already present).
 CREATE INDEX IF NOT EXISTS idx_contracts_cnum ON contracts(contract_number);
 CREATE INDEX IF NOT EXISTS idx_contracts_tender_id ON contracts(tender_id);


### PR DESCRIPTION
## Какво

Първата група на частичното обновяване вече обезсилва `as_of` на `data_freshness` и `home_totals`, а
`@refresh-batch globals` записва истинските стойности накрая, както досега. Прекъснато обновяване
тогава се чете като "неизвестен срез", вместо да рекламира предишния като валиден.

## Защо

Групите се изпълняват като **отделни партиди** - `runRefreshSliceBatches` в `scripts/import.mjs` пуска
по едно `wrangler d1 execute` на група, а Worker-ът (`packages/ingest/src/refresh.ts:179`) по едно
`db.batch`. Нищо не е транзакционно между групите: група, която се провали, оставя всички преди нея
приложени и всички след нея непуснати.

Наблюдавано, не предположено. Догонване на 2026-08-23 умря в групата `amendments` с
`out of memory: SQLITE_NOMEM`:

| | преди | след провала |
|---|---|---|
| contracts | 198 795 | 199 228 |
| tenders | 157 803 | 158 405 |
| amendments | 27 032 | 27 032 |
| `data_freshness.as_of` | 2026-08-17 | **2026-08-17** |

Договорите и поръчките бяха придвижени с четири дни, анексите не, а маркерът стоеше на старото - защото
се пише чак в групата `globals`, петнайсета по ред. Който прочете базата в този момент, получава дата,
която е уверено грешна, а не "не знам".

Засегнати са и двата пътя. `home_totals` захранва публичната дата "към" (`app/lib/coverage.ts`) и
CSV износа; `data_freshness` захранва планировчика на догонването (`apps/etl/src/eop.ts`). Тоест същият
сценарий важи и за месечния cron срещу обслужваната база.

## Поправката

Ред, не атомарност - атомарност между отделни `d1 execute` така или иначе няма.

Пипа се само `as_of`. `refreshed_at` е `NOT NULL`, зануляването му би превърнало поправка по устойчивост
в авария. Броячите остават четими. `getCoverageMeta` вече свежда липсващо `as_of` до `null`, а
планировчикът пада обратно към `raw_contracts` - никой потребител не се чупи.

## Тестове

Четири, върху истинския `refresh-slice.sql`. Свойството е невидимо при успешно пускане - проличава
единствено при провала, който никой не гледа - затова тестовете държат подредбата, а не резултата.

Убиват два мутанта:

| мутант | резултат |
|---|---|
| махнато обезсилване от `setup` | 2 теста падат |
| записът преместен в първата група | 2 теста падат |

Целият пакет `ingest`: 88 минават.

## Извън обхвата

`SQLITE_NOMEM` е отделен въпрос - ограничение на локалния workerd, не на заявките: същият
`amendments.sql` мина за 1,2 секунди през `sqlite3`. Не влиза в този PR.
