### PR TITLE
fix(tr): бумни правилата на tr-rules-2 - режимът се смени, версията не

### DIFF
--- a/scripts/cacbg/audit.test.mjs
+++ b/scripts/cacbg/audit.test.mjs
@@ -11,6 +11,7 @@
 // (name-based) colliding link STILL fails A_multi_eik — the relaxation must not weaken the name gate.
 // Run: node --import ./scripts/cacbg/register-ts.mjs --test scripts/cacbg/audit.test.mjs
 import { test, after } from 'node:test';
+import { RULES_VERSION } from '../tr/evidence.mjs';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import { execFileSync } from 'node:child_process';
@@ -278,7 +279,7 @@ test('a well-formed seal passes every C axis (positive control)', () => {
 // A one-for-one swap — one link lost, one gained — leaves the count identical and the floor silent
 // while a true published link is dropped. Only a per-key comparison sees it.
 const SEALED = [
-  `'p1|100000001','document','owner','role:owner:CR_F_19_L','2026-08-05','tr-rules-1','live'`,
+  `'p1|100000001','document','owner','role:owner:CR_F_19_L','2026-08-05','${RULES_VERSION}','live'`,
 ];
 const ONE_LINK = {
   bidders: [`'b1','УНИК ТЕХ 7 ЕООД','100000001',1`, `'b2','ВТОРА ФИРМА ЕООД','200000002',1`],
@@ -292,8 +293,8 @@ test('D — a previously published link that vanished under an UNCHANGED rules_v
   const { threw, out } = buildAndAudit({
     ...ONE_LINK,
     snapshot: [
-      { link_key: 'p1|100000001', rules_version: 'tr-rules-1' },
-      { link_key: 'p9|200000002', rules_version: 'tr-rules-1' }, // published last run, gone now
+      { link_key: 'p1|100000001', rules_version: RULES_VERSION },
+      { link_key: 'p9|200000002', rules_version: RULES_VERSION }, // published last run, gone now
     ],
   });
   assert.equal(threw, true, 'a silent recall regression must fail the build');
@@ -331,8 +332,8 @@ test('D — a link taken down through the ADR-0031 suppression path is a declare
       `'il2','p9|200000002','p9','200000002','${K('ВТОРА ФИРМА ЕООД')}','exact_name_key','document','b2','owns',0,1000,'suppressed'`,
     ],
     snapshot: [
-      { link_key: 'p1|100000001', rules_version: 'tr-rules-1' },
-      { link_key: 'p9|200000002', rules_version: 'tr-rules-1' },
+      { link_key: 'p1|100000001', rules_version: RULES_VERSION },
+      { link_key: 'p9|200000002', rules_version: RULES_VERSION },
     ],
   });
   assert.equal(threw, false, 'the sanctioned takedown path must not fail the build');
@@ -347,8 +348,8 @@ test('D — a snapshot entry acknowledged as a corrected input is a declared rem
   const { threw, out } = buildAndAudit({
     ...ONE_LINK,
     snapshot: [
-      { link_key: 'p1|100000001', rules_version: 'tr-rules-1' },
-      { link_key: 'p9|200000002', rules_version: 'tr-rules-1', corrected: true },
+      { link_key: 'p1|100000001', rules_version: RULES_VERSION },
+      { link_key: 'p9|200000002', rules_version: RULES_VERSION, corrected: true },
     ],
   });
   assert.equal(threw, false, 'an acknowledged correction must not fail the build');
@@ -365,8 +366,8 @@ test('D — neither escape hatch fires on its own: an unacknowledged, unsuppress
       `'il2','p9|200000002','p9','200000002','${K('ВТОРА ФИРМА ЕООД')}','exact_name_key','document','b2','owns',0,1000,'held'`,
     ],
     snapshot: [
-      { link_key: 'p1|100000001', rules_version: 'tr-rules-1' },
-      { link_key: 'p9|200000002', rules_version: 'tr-rules-1' },
+      { link_key: 'p1|100000001', rules_version: RULES_VERSION },
+      { link_key: 'p9|200000002', rules_version: RULES_VERSION },
     ],
   });
   assert.equal(
@@ -380,7 +381,7 @@ test('D positive control — an unchanged published set produces no monotonicity
   // Without this, a gate that never fires would pass both negatives above.
   const { threw, out } = buildAndAudit({
     ...ONE_LINK,
-    snapshot: [{ link_key: 'p1|100000001', rules_version: 'tr-rules-1' }],
+    snapshot: [{ link_key: 'p1|100000001', rules_version: RULES_VERSION }],
   });
   assert.equal(threw, false);
   assert.doesNotMatch(out, /D_monotonicity/);

--- a/scripts/tr/evidence.mjs
+++ b/scripts/tr/evidence.mjs
@@ -34,8 +34,15 @@ import {
  * Version of the RULES, not of the code. §8's monotonicity gate keys on this: a previously published
  * link disappearing under an UNCHANGED rules version is a hard finding; under a changed one it is an
  * expected diff. Bump it whenever a rung's meaning changes.
+ *
+ * `tr-rules-2` records the evidence regime that #309 and ADR-0035 introduced and that `tr-rules-1`
+ * never described. Under `tr-rules-1` a link could publish with NO registry evidence at all — the
+ * `interest_link_evidence` table did not yet exist. Publishing now requires a seal, and rung 2 also
+ * requires something beyond the company name to establish the company. Both change what a rung means,
+ * which is exactly what this constant is for; leaving it at `tr-rules-1` made the monotonicity gate
+ * compare two incompatible regimes and report the tightening as 37 silent regressions.
  */
-export const RULES_VERSION = 'tr-rules-1';
+export const RULES_VERSION = 'tr-rules-2';
 
 /** Rung 2 needs a real three-part Bulgarian name (ЗГР чл. 9). Two tokens is the homonym risk itself. */
 const MIN_NAME_TOKENS = 3;


### PR DESCRIPTION
## Какво

`RULES_VERSION` става `tr-rules-2`, а фикстурите в `audit.test.mjs`, които значеха "текущата версия",
вече сочат константата вместо низа.

## Защо

Константата версионира **правилата**, не кода, и гейтът за монотонност виси точно на нея: изчезнала
връзка при непроменена версия е твърда находка, при сменена - очаквана разлика. Собственият ѝ коментар
казва да се бумва, щом смисълът на стъпало се промени.

Смени се два пъти, без версията да го отрази:

- **#309** въведе изискването изобщо да има регистърно доказателство. Дотогава връзка се публикуваше
  **без никакво** - таблицата `interest_link_evidence` не съществуваше.
- **ADR-0035** затегна стъпало 2: освен фирменото наименование трябва и нещо друго да установи, че
  дружеството е декларираното.

## Как се прояви

Първото пускане с пълен регистърен обход (`32670990181`, 731/731 присъди, 100%) стигна до одита и спря:

```
## monotonicity — 103 published last run, 277 now; 37 regression(s), 0 declared removal(s)
```

Гейтът сравняваше повърхност, публикувана на **2026-08-04 - преди #309 да съществува** - със сегашната,
и виждаше законното затягане като тиха загуба. Сред 37-те се повтарят и псевдо-институции като
"ВСТЪПИТЕЛНИ И ФИНАЛНИ ДЕКЛАРАЦИИ", тоест отпадат и дублирания, а не същински връзки.

Под `tr-rules-2` същите 37 стават отпечатана разлика за преглед - каквито са - вместо провал на хода.

## Тестовете

`audit.test.mjs` зашиваше `'tr-rules-1'` на седем места, където значеше "текущата версия". Тоест тестът
**"изчезнала връзка при НЕПРОМЕНЕНА версия е твърда находка"** щеше да се обърне при всяко бумване и да
мери точно обратното на замисленото. Вече сочат `RULES_VERSION`. `'tr-rules-0'` остава литерал, защото
там нарочно значи "стара версия".

Минават: `audit.test.mjs` 23, `evidence.test.mjs` 42, всички `scripts/cacbg` + `scripts/tr` - 305.

## Какво НЕ прави

Не отписва нищо самоволно: 37-те продължават да се отпечатват при всеки одит, само че като декларирана
разлика, а не като спиране. Прегледът им си остава човешка работа.
