### PR TITLE
fix(cacbg): преходът от режима преди #309 е декларирано оттегляне, не находка

### DIFF
--- a/scripts/cacbg/audit.mjs
+++ b/scripts/cacbg/audit.mjs
@@ -258,11 +258,13 @@ if (priorPublished === null) {
   // "removed" alone would flatten a court annulment, a corrected parse and a rules bump into one line.
   for (const p of declared) {
     const ground =
-      p.rules_version !== RULES_VERSION
-        ? `a rules change (${p.rules_version} → ${RULES_VERSION})`
-        : statusNow.get(p.link_key) === 'suppressed'
-          ? 'a suppression (ADR-0031 takedown path)'
-          : 'an acknowledged input correction';
+      p.rules_version == null
+        ? `the pre-evidence regime — predates §8 and #309, now under ${RULES_VERSION}`
+        : p.rules_version !== RULES_VERSION
+          ? `a rules change (${p.rules_version} → ${RULES_VERSION})`
+          : statusNow.get(p.link_key) === 'suppressed'
+            ? 'a suppression (ADR-0031 takedown path)'
+            : 'an acknowledged input correction';
     console.log(`  - ${p.link_key} removed under ${ground}`);
   }
   if (declared.length) console.log('');

--- a/scripts/cacbg/audit.test.mjs
+++ b/scripts/cacbg/audit.test.mjs
@@ -302,6 +302,22 @@ test('D — a previously published link that vanished under an UNCHANGED rules_v
   assert.match(out, /p9\|200000002/);
 });
 
+test('D — a pre-evidence-regime link (null rules_version) that vanished is a declared removal, not a finding', () => {
+  // The transition case #309 introduced and no test covered: links published BEFORE
+  // interest_link_evidence existed carry no evidence row, so load.mjs's LEFT JOIN leaves their
+  // snapshot rules_version null. The pre-#309 regime is gone, so their disappearance under the current
+  // regime is intentional by definition — not a silent recall. Before this test the fallback
+  // `?? RULES_VERSION` masked the missing rows and turned the whole legacy set into hard findings on
+  // the first post-#309 staging run (32736025202: 37 regressions, 0 declared removals).
+  const { threw, out } = buildAndAudit({
+    ...ONE_LINK,
+    snapshot: [{ link_key: 'p9|200000002', rules_version: null }],
+  });
+  assert.equal(threw, false, 'a pre-evidence-regime removal must not fail the build');
+  assert.match(out, /p9\|200000002/, 'but it must still be reported');
+  assert.match(out, /pre-evidence regime/, 'the ground must name the transition, not print "null"');
+});
+
 test('D — the same disappearance under a CHANGED rules_version is a printed diff, not a finding', () => {
   // Removal stays an intentional event: bumping the rules version is how you declare one.
   const { threw, out } = buildAndAudit({

--- a/scripts/cacbg/load.mjs
+++ b/scripts/cacbg/load.mjs
@@ -142,15 +142,24 @@ const usedSuppressions = new Set();
 // set — written, not skipped, so a missing file means „the loader never ran", not „nothing published".
 const priorPublished = (() => {
   try {
-    return db
-      .prepare(
-        `SELECT il.link_key AS link_key, e.rules_version AS rules_version
+    return (
+      db
+        .prepare(
+          `SELECT il.link_key AS link_key, e.rules_version AS rules_version
            FROM interest_links il
            LEFT JOIN interest_link_evidence e ON e.link_key = il.link_key
           WHERE il.status = 'published'`,
-      )
-      .all()
-      .map((r) => ({ link_key: r.link_key, rules_version: r.rules_version ?? RULES_VERSION }));
+        )
+        .all()
+        // rules_version is NOT NULL in interest_link_evidence, so a null here means the LEFT JOIN
+        // missed — the link was published under a regime that had no evidence table at all (before
+        // #309 introduced it). That is exactly the case §8's gate must treat as a rules bump: the
+        // regime that licensed it is gone, so its vanishing under the current regime is intentional,
+        // not a silent recall. Defaulting to RULES_VERSION here erased that distinction and turned a
+        // legitimate one-way transition into 37 hard findings on the first post-#309 staging run
+        // (32736025202). Keep the null; audit.mjs's declaredRemoval reads null !== RULES_VERSION.
+        .map((r) => ({ link_key: r.link_key, rules_version: r.rules_version }))
+    );
   } catch (e) {
     // A first run: interest_links does not exist yet. Any OTHER failure must surface — swallowing it
     // would turn a broken export into a permanently silent gate.

--- a/scripts/cacbg/load.test.mjs
+++ b/scripts/cacbg/load.test.mjs
@@ -1490,6 +1490,40 @@ test('a bootstrap pass leaves the REAL work DB untouched — it runs on a throwa
   assert.equal(fs.existsSync(`${DB}.bootstrap`), false, 'the throwaway copy must be cleaned up');
 });
 
+test('a published link with no evidence row (pre-#309 regime) carries null rules_version, not a masking fallback', () => {
+  // The one-way transition #309 introduced. interest_links pre-dates interest_link_evidence: any
+  // link published before ADR-0033 landed has no evidence row and no rules_version to travel with.
+  // Defaulting the LEFT JOIN miss to RULES_VERSION erased that distinction and made the audit see 37
+  // legitimate regime-transition removals as silent recalls on the first post-#309 staging run
+  // (32736025202). The snapshot has to carry null through so declaredRemoval can read it.
+  const SNAP = path.join(STAGING, 'published-snapshot.json');
+  runLoad();
+  // Read-only lookup, then a writable connection to simulate the pre-#309 state.
+  const rdb = open();
+  const preExistingKey = rdb
+    .prepare("SELECT link_key FROM interest_links WHERE status='published' LIMIT 1")
+    .get().link_key;
+  rdb.close();
+  const wdb = new DatabaseSync(DB);
+  // Simulate the pre-#309 state: this key was published before the evidence table existed, so its
+  // evidence row is gone. The current run's REBUILD would resurface it, but the snapshot export
+  // reads what stands BEFORE the wipe — which on staging on 2026-08-24 was 103 such orphaned rows.
+  wdb.prepare('DELETE FROM interest_link_evidence WHERE link_key = ?').run(preExistingKey);
+  wdb.close();
+  runLoad();
+  const snap = JSON.parse(fs.readFileSync(SNAP, 'utf8'));
+  const orphan = snap.find((s) => s.link_key === preExistingKey);
+  assert.ok(
+    orphan,
+    'the pre-evidence link must still appear in the snapshot — the gate needs to see it',
+  );
+  assert.equal(
+    orphan.rules_version,
+    null,
+    'a missing evidence row must surface as null, not as the current RULES_VERSION',
+  );
+});
+
 test('the monotonicity gate still sees a prior surface AFTER a bootstrap pass', () => {
   // The end-to-end shape of the merged workflow: real run → bootstrap (to produce the crawl list) →
   // real run. If the bootstrap emptied interest_links, the second real run would export an EMPTY


### PR DESCRIPTION
## Какво

Snapshot заявката в `load.mjs` вече оставя `null` за връзка без ред в `interest_link_evidence`, вместо
да я маскира с текущата `RULES_VERSION`. Гейтът за монотонност в `audit.mjs` вече чете това като
декларирано оттегляне и отпечатва точно основанието "the pre-evidence regime — predates §8 and #309".

## Защо

`interest_link_evidence` е добавена от #309 (`acfcdcef`). Връзки, публикувани преди това, нямат ред в
нея - на staging това са всички 103. Snapshot заявката прави LEFT JOIN и мапваше липсата с
`r.rules_version ?? RULES_VERSION`. Схемата държи `rules_version TEXT NOT NULL`, значи fallback-ът се
задейства САМО при LEFT JOIN пропуск, тоест точно на прехода.

Ефектът: първото пълно пускане към staging след бумването (`32736025202`) стигна до одита с 731/731
присъди и 277 публикувани, но гейтът отчете:

```
## monotonicity — 103 published last run, 277 now; 37 regression(s), 0 declared removal(s)
```

Режимът, който беше публикувал тези 103, вече не съществува. `tr-rules-2` изисква регистърно
доказателство, а те нямат такова, защото таблицата не е съществувала. Но fallback-ът вкарваше
`tr-rules-2` за всичките - гейтът виждаше "изчезнала при непроменена версия" вместо "изчезнала при
смяна на режима".

## Поправката

Три части, всяка обяснена в коментарите:

1. `load.mjs`: премахнат `?? RULES_VERSION`. `rules_version` е NOT NULL в схемата, така че липсата
   винаги означава "няма ред", което е точно преходният случай. Пази null и предава семантиката.
2. `audit.mjs`: `declaredRemoval` вече чете `null !== RULES_VERSION` → true. Изричен клон в
   съобщението назовава основанието с думи ("the pre-evidence regime"), вместо да отпечатва "rules
   change (null → tr-rules-2)".
3. Тестове (два): в `audit.test.mjs` - snapshot с `rules_version: null` → декларирано оттегляне и
   думите се появяват. В `load.test.mjs` - симулира преходния случай (изтрива реда за евидиране
   между две пускания) и чака null в експортирания snapshot. Убива връщането на fallback-а.

Всичко: 46 минават. Работният път (връзка с ред за евидиране) не се променя - fallback-ът е бил
неактивен при него от NOT NULL нататък.

## Какво следва

При пускането след сливането: гейтът вижда 103-те стари като декларирани оттегляния, минава, а
пътят продължава към `Apply schema → Ship → Reindex`. `sigma-stage.midt.bg/conflicts` се напълва.

## Извън обхвата

Дали 37-те стари връзки трябва пак да се публикуват под `tr-rules-2` е отделен въпрос за
методологията, не за гейта. Ако да - от следващото пускане ще имат ред за евидиране и ще се държат
нормално.
