### PR TITLE
feat(cacbg): печат за пълнота - отрязан корпус не бива да се публикува

### DIFF
--- a/.github/workflows/related-persons-data.yml
+++ b/.github/workflows/related-persons-data.yml
@@ -39,7 +39,8 @@ on:
   # A scheduled run takes the same path as a manual one, with two differences:
   #   • it targets STAGING (the environment default below). Production stays manual, so the
   #     assertD1TargetAuthorized guard keeps a prod write a deliberate act.
-  #   • `full_crawl` is empty and therefore false, so it never crawls the CACBG corpus — it re-runs the
+  #   • `full_crawl` is empty and therefore false, so it normally never crawls the CACBG corpus — it
+  #     re-runs the
   #     decisions over the cached corpus, which is exactly what #279 §9 means by a pure, zero-network
   #     decision. Registry lookups are the one exception and run from inside this job on the 1st of the
   #     month (see „Decide whether to hit the register"): they cannot be a separate workflow, because the
@@ -181,6 +182,7 @@ jobs:
       # downgraded to a warning, step green. The verify step below would then look up that same key, find
       # attempt 1's entry, and certify the loss as a success. Every extra hour crawled would vanish.
       - name: Restore raw CACBG corpus cache
+        id: corpus_restore
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: scratch/cacbg/raw
@@ -197,6 +199,15 @@ jobs:
       - name: Check the corpus completeness stamp
         id: corpus_stamp
         run: |
+          # The restore action extracts straight into the workspace and downgrades tar errors to a
+          # warning — a failed extraction can leave SOME files (the stamp included) with no matched key
+          # reported (review finding). Files from an extraction the cache service never acknowledged are
+          # debris, not a corpus: the stamp among them would certify XML files that half-exist. Discard
+          # the whole tree so the state is exactly "no cache", which the healing crawl below handles.
+          if [ -z "${{ steps.corpus_restore.outputs.cache-matched-key }}" ] && [ -d scratch/cacbg/raw ]; then
+            echo "restore reported no matched key but scratch/cacbg/raw exists — discarding debris"
+            rm -rf scratch/cacbg/raw
+          fi
           if [ -f scratch/cacbg/raw/.corpus-complete.json ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
             echo "stamped corpus: $(cat scratch/cacbg/raw/.corpus-complete.json)"
@@ -236,7 +247,9 @@ jobs:
         run: node scripts/cacbg/fetch.mjs --concurrency 8 --deadline-minutes 240
 
       # Save the (possibly extended) corpus whenever we crawled — even if a later step fails — so the next
-      # run resumes from here. Skipped on full_crawl=false runs (nothing new was fetched).
+      # run resumes from here. Skipped only when the crawl itself was skipped (stamped cache, no
+      # full_crawl): nothing new was fetched. A scheduled run that self-healed DOES save — that crawl is
+      # real work and the stamp it wrote must reach the cache, or every Monday heals again.
       - name: Save raw CACBG corpus cache
         if: ${{ always() && (inputs.full_crawl || steps.corpus_stamp.outputs.present != 'true') }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/related-persons-data.yml
+++ b/.github/workflows/related-persons-data.yml
@@ -188,6 +188,23 @@ jobs:
           restore-keys: |
             cacbg-raw-
 
+      # Does the restored cache carry a completeness stamp? fetch.mjs writes it only on a corpus that
+      # reconciled against the register's own list.xml, and clears it before touching anything — so its
+      # absence means a deadline stop, a crash, or a cache saved before the stamp existed at all. The
+      # crawl below consults this so an unstamped cache HEALS instead of failing extract: a resume over a
+      # complete cache is ~2 minutes (declarations on disk are skipped) and re-verifies against the live
+      # register — the authoritative source — rather than trusting whatever the cache holds.
+      - name: Check the corpus completeness stamp
+        id: corpus_stamp
+        run: |
+          if [ -f scratch/cacbg/raw/.corpus-complete.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "stamped corpus: $(cat scratch/cacbg/raw/.corpus-complete.json)"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "no completeness stamp — the crawl will run to verify and stamp the corpus"
+          fi
+
       # Crawl only on demand. The polite full crawl of register.cacbg.bg is long; steady-state refresh
       # (incremental, R2-cached) is the sigma-etl Worker's job (spec §7), not this workflow.
       #
@@ -211,14 +228,17 @@ jobs:
       # fetched, so the next run resumes rather than restarting. Budget two runs for a cold corpus, one
       # thereafter. Either „Re-run failed jobs" or a fresh dispatch resumes: the key carries run_attempt,
       # which a re-run increments, so the save lands on a new key while restore-keys still finds the old one.
+      # `full_crawl || stamp missing`: an explicitly requested crawl, or the self-heal. On a scheduled run
+      # inputs.full_crawl is empty (false), so steady state with a stamped cache stays zero-network — the
+      # heal only fires on a cache that was never confirmed whole, where trusting it would be the bug.
       - name: Crawl CACBG (full corpus)
-        if: ${{ inputs.full_crawl }}
+        if: ${{ inputs.full_crawl || steps.corpus_stamp.outputs.present != 'true' }}
         run: node scripts/cacbg/fetch.mjs --concurrency 8 --deadline-minutes 240
 
       # Save the (possibly extended) corpus whenever we crawled — even if a later step fails — so the next
       # run resumes from here. Skipped on full_crawl=false runs (nothing new was fetched).
       - name: Save raw CACBG corpus cache
-        if: ${{ always() && inputs.full_crawl }}
+        if: ${{ always() && (inputs.full_crawl || steps.corpus_stamp.outputs.present != 'true') }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: scratch/cacbg/raw
@@ -229,7 +249,7 @@ jobs:
       # 31889519937 it was green and the cache was empty, which is how five hours of crawling went missing
       # unnoticed. Ask the cache service whether the key actually exists; lookup-only downloads nothing.
       - name: Verify the corpus cache was really written
-        if: ${{ always() && inputs.full_crawl }}
+        if: ${{ always() && (inputs.full_crawl || steps.corpus_stamp.outputs.present != 'true') }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: scratch/cacbg/raw
@@ -237,12 +257,11 @@ jobs:
           lookup-only: true
           fail-on-cache-miss: true
 
-      # No --allow-partial-corpus, deliberately, and that matters most on the path that does NOT crawl.
-      # A full_crawl=false run (the monthly schedule) restores whatever `restore-keys: cacbg-raw-` returns —
-      # the most RECENT snapshot, which since #313 is routinely a deadline-stopped partial one — and then
-      # extracts from it. Without the stamp that run republishes a surface missing whole years and nothing
-      # downstream notices. With it the run stops here instead, which is the correct outcome: the cache is
-      # still fine to RESUME from, just not to publish from. Dispatch with full_crawl=true to finish it.
+      # No --allow-partial-corpus, deliberately. By this point every path guarantees a stamped corpus: an
+      # unstamped restore triggered the healing crawl above, which either finished (stamped) or deadline-
+      # stopped (run already red before reaching here). So this gate firing means something UNFORESEEN —
+      # a bug, not a known transition — and fail-closed is the right answer for it. The cache stays fine
+      # to RESUME from either way; the stamp only governs publishing.
       - name: Extract declarations → staging (dedup by ControlHash)
         run: node scripts/cacbg/extract.mjs
 

--- a/.github/workflows/related-persons-data.yml
+++ b/.github/workflows/related-persons-data.yml
@@ -237,6 +237,12 @@ jobs:
           lookup-only: true
           fail-on-cache-miss: true
 
+      # No --allow-partial-corpus, deliberately, and that matters most on the path that does NOT crawl.
+      # A full_crawl=false run (the monthly schedule) restores whatever `restore-keys: cacbg-raw-` returns —
+      # the most RECENT snapshot, which since #313 is routinely a deadline-stopped partial one — and then
+      # extracts from it. Without the stamp that run republishes a surface missing whole years and nothing
+      # downstream notices. With it the run stops here instead, which is the correct outcome: the cache is
+      # still fine to RESUME from, just not to publish from. Dispatch with full_crawl=true to finish it.
       - name: Extract declarations → staging (dedup by ControlHash)
         run: node scripts/cacbg/extract.mjs
 

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -40,8 +40,15 @@ beforeEach(() => {
 });
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
-const ok = (f) => ({ [`${BASE}/${FOLDER}/${f}`]: { status: 200, body: '<x/>' } });
-const crawl = (routes, extraArgv = [], msPerRequest = null) => {
+const ok = (f, folder = FOLDER) => ({ [`${BASE}/${folder}/${f}`]: { status: 200, body: '<x/>' } });
+// Discovery-mode by default: the stamp is deliberately reserved for full-discovery crawls, so the tests
+// that expect one must crawl the way the workflow does. `folders` switches to a --folders subset run.
+const crawl = (
+  routes,
+  extraArgv = [],
+  msPerRequest = null,
+  { discovered = [FOLDER], folders = null } = {},
+) => {
   let clock = 0;
   const routed = fakeGet(routes);
   return run({
@@ -53,8 +60,16 @@ const crawl = (routes, extraArgv = [], msPerRequest = null) => {
       : routed,
     rawDir: dir,
     guard: () => {},
+    discover: async () => discovered,
     ...(msPerRequest ? { now: () => clock } : {}),
-    argv: ['node', 'fetch.mjs', '--folders', FOLDER, '--concurrency', '1', ...extraArgv],
+    argv: [
+      'node',
+      'fetch.mjs',
+      ...(folders ? ['--folders', folders] : []),
+      '--concurrency',
+      '1',
+      ...extraArgv,
+    ],
   });
 };
 
@@ -131,6 +146,55 @@ test('a stale stamp cannot outlive the corpus it described', async () => {
   );
 });
 
+test('a --folders subset that completes does NOT stamp — complete for the subset is not complete', async () => {
+  // Review finding (blocker): raw/ holds another folder in unknown state; certifying the whole tree off
+  // one finished subset would stamp around it. The subset still CLEARS any prior stamp (it mutates the
+  // corpus), leaving resumable-not-publishable — the correct state.
+  const OTHER = '2098t';
+  fs.mkdirSync(path.join(dir, OTHER), { recursive: true });
+  fs.writeFileSync(path.join(dir, OTHER, 'stale.xml'), '<x/>');
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml']) },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes, [], null, { folders: FOLDER }), 0, 'the subset itself succeeds');
+  assert.equal(
+    fs.existsSync(sentinelPath(dir)),
+    false,
+    'a subset run must never certify the whole corpus',
+  );
+});
+
+test('an index that discovers ZERO folders is a failure, not a trivially complete corpus', async () => {
+  // Review finding (blocker, reproduced): exit 0 and a `folders: 0, incomplete: false` stamp over an
+  // existing raw tree. The register has published year-sets continuously since 2015 — an empty index is
+  // a broken or redesigned index page, never a real corpus state.
+  fs.mkdirSync(path.join(dir, FOLDER), { recursive: true });
+  fs.writeFileSync(path.join(dir, FOLDER, 'a1.xml'), '<x/>');
+  assert.equal(await crawl({}, [], null, { discovered: [] }), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false);
+});
+
+test('a 200 list.xml that parses to zero rows over existing declarations is a skip, not an empty set', async () => {
+  // Review finding: a maintenance HTML page and a schema change both come back 200 and parse to [].
+  // Trusting one would zero out `announced`, make the folder look complete, and overwrite the cached
+  // list the extractor reads. With files on disk contradicting it, the folder is skipped — which makes
+  // the corpus incomplete: exit 1, no stamp, cached list.xml preserved.
+  fs.mkdirSync(path.join(dir, FOLDER), { recursive: true });
+  fs.writeFileSync(path.join(dir, FOLDER, 'a1.xml'), '<x/>');
+  fs.writeFileSync(path.join(dir, FOLDER, 'list.xml'), listXml(['a1.xml']));
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: '<html>maintenance</html>' },
+  };
+  assert.equal(await crawl(routes), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false);
+  assert.match(
+    fs.readFileSync(path.join(dir, FOLDER, 'list.xml'), 'utf8'),
+    /a1\.xml/,
+    'the cached list the extractor reads must not be overwritten by the contradicted body',
+  );
+});
+
 // ── the reading half ───────────────────────────────────────────────────────────────────────────────
 // The writer above is only useful if something refuses an unstamped corpus. extract.mjs is that reader,
 // and it runs in-process, so it is exercised as a subprocess against a temp scratch tree.
@@ -170,5 +234,57 @@ test('extract proceeds on a stamped corpus', () => {
   });
   const out = `${res.stdout}${res.stderr}`;
   assert.doesNotMatch(out, /REFUSE TO EXTRACT/, 'a stamped corpus must pass the gate');
+  assert.equal(
+    res.status,
+    0,
+    `a stamped corpus must extract cleanly, got ${res.status}: ${out.slice(0, 300)}`,
+  );
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+test('--allow-partial-corpus extracts an unstamped corpus, loudly', () => {
+  // The deliberate override the refusal names. Without a test, deleting the flag entirely would leave
+  // every test green while the documented escape hatch silently stopped existing (review finding).
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-extract-partial-'));
+  fs.mkdirSync(path.join(scratch, 'raw', FOLDER), { recursive: true });
+  const res = spawnSync(
+    process.execPath,
+    [path.resolve('scripts/cacbg/extract.mjs'), '--allow-partial-corpus'],
+    {
+      env: {
+        ...process.env,
+        CACBG_RAW: path.join(scratch, 'raw'),
+        CACBG_STAGING: path.join(scratch, 'staging'),
+      },
+      encoding: 'utf8',
+    },
+  );
+  const out = `${res.stdout}${res.stderr}`;
+  assert.equal(
+    res.status,
+    0,
+    `the override must let the run proceed, got ${res.status}: ${out.slice(0, 300)}`,
+  );
+  assert.match(out, /--allow-partial-corpus/, 'the acceptance must be printed, never silent');
+});
+
+test('a CACBG_STAGING override pointing at a tracked path inside the repo is refused', () => {
+  // Review finding: the env seams redirect real I/O, and assertScratchIgnored only probes the fixed
+  // scratch/ location — so an override could write related.jsonl (third-party names) into a directory
+  // git would commit. The override rail applies the same rule scratch/ satisfies: inside the repo ⇒
+  // must be git-ignored.
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-extract-pii-'));
+  fs.mkdirSync(path.join(scratch, 'raw'), { recursive: true });
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: path.join(scratch, 'raw'),
+      CACBG_STAGING: path.resolve('scripts', 'pii-leak-probe'), // inside the repo, NOT ignored
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0, 'a committable PII destination must refuse to run');
+  assert.match(out, /CACBG_STAGING/, 'the refusal must name the offending variable');
   fs.rmSync(scratch, { recursive: true, force: true });
 });

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -271,6 +271,21 @@ test('a multi-root body that validates is still not a list', async () => {
   assert.equal(fs.existsSync(sentinelPath(dir)), false);
 });
 
+test('a corrupt cached list is healed by a valid incoming one, not crashed on', async () => {
+  // Round 4 (minor, recovered from the truncated report): the shrink check parses the CACHED list, and
+  // a legacy/corrupt body there threw instead of letting the valid incoming list replace it. The
+  // sentinel was already cleared, so it was fail-closed — but self-healing is the designed behavior.
+  fs.mkdirSync(path.join(dir, FOLDER), { recursive: true });
+  fs.writeFileSync(path.join(dir, FOLDER, 'list.xml'), '<!DOCTYPE nonsense><<<broken');
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml']) },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes), 0, 'the valid incoming list must heal the corrupt cache');
+  assert.equal(fs.existsSync(sentinelPath(dir)), true);
+  assert.match(fs.readFileSync(path.join(dir, FOLDER, 'list.xml'), 'utf8'), /a1\.xml/);
+});
+
 // ── the reading half ───────────────────────────────────────────────────────────────────────────────
 // The writer above is only useful if something refuses an unstamped corpus. extract.mjs is that reader,
 // and it runs in-process, so it is exercised as a subprocess against a temp scratch tree.
@@ -512,4 +527,29 @@ test('an inherited GIT_DIR cannot reach the DEFAULT-path scratch rail either', (
   assert.match(out, /REFUSE TO EXTRACT/, 'the scratch rail must consult the real repository');
   assert.doesNotMatch(out, /not git-ignored/);
   fs.rmSync(decoy, { recursive: true, force: true });
+});
+
+test('an ignored SYMLINK into committable territory is judged by its destination', () => {
+  // Round 4 (blocker, recovered from the truncated report): scratch/ is ignored, so a symlink
+  // scratch/cacbg/leak → scripts/ passed the lexical check while extraction would write THROUGH it
+  // into tracked files. The guard now canonicalizes before judging: the resolved location is scripts/,
+  // which is tracked, and tracked refuses.
+  const link = path.join('scratch', 'cacbg', 'leak-link');
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  try {
+    fs.symlinkSync(path.resolve('scripts'), link);
+    const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+      env: {
+        ...process.env,
+        CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-sym-raw-')),
+        CACBG_STAGING: path.resolve(link),
+      },
+      encoding: 'utf8',
+    });
+    const out = `${res.stdout}${res.stderr}`;
+    assert.notEqual(res.status, 0, 'writing through the symlink reaches committable files');
+    assert.match(out, /TRACKED|does not ignore/);
+  } finally {
+    fs.rmSync(link, { force: true });
+  }
 });

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -553,3 +553,28 @@ test('an ignored SYMLINK into committable territory is judged by its destination
     fs.rmSync(link, { force: true });
   }
 });
+
+test('a symlink at the DEFAULT staging directory is caught, not only an override', () => {
+  // Review round 5 (blocker 2): assertScratchIgnored probes only scratch/cacbg/.probe, so a symlink at
+  // the sibling default `staging` — pointing into tracked territory — was invisible while extract I/O
+  // followed it. The default paths now go through the canonicalizing guard unconditionally. Runs with
+  // NO env overrides, so RAW/STAGING take their real default locations.
+  const link = path.join('scratch', 'cacbg', 'staging');
+  const raw = path.join('scratch', 'cacbg', 'raw');
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  const hadLink = fs.existsSync(link) || fs.lstatSync(link, { throwIfNoEntry: false });
+  if (hadLink) return; // never clobber a real local scratch tree
+  fs.mkdirSync(raw, { recursive: true });
+  try {
+    fs.symlinkSync(path.resolve('scripts'), link); // default staging → tracked scripts/
+    const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+      encoding: 'utf8', // no CACBG_* — exercises the DEFAULT path
+    });
+    const out = `${res.stdout}${res.stderr}`;
+    assert.notEqual(res.status, 0, 'a symlinked default staging into tracked files must refuse');
+    assert.match(out, /TRACKED|does not ignore/);
+  } finally {
+    fs.rmSync(link, { force: true });
+    fs.rmSync(raw, { recursive: true, force: true });
+  }
+});

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -1,0 +1,174 @@
+// The completeness sentinel — the one signal that tells a PARTIAL raw corpus apart from a whole one.
+//
+// #313 made a partial corpus an EXPECTED state: the crawl now stops on its deadline and saves what it has,
+// which is what lets a cold corpus finish across two runs. But `restore-keys: cacbg-raw-` returns the most
+// RECENT snapshot, not the most complete, and extract.mjs walks readdirSync over whatever files exist
+// without reconciling them against the register's own list.xml. So before this, a truncated corpus simply
+// produced a smaller published surface with no error anywhere — and neither downstream gate closes it: the
+// monotonicity gate sees net growth whenever new links outnumber lost ones, the --min-links floor only
+// counts, and a first run in a fresh environment has no baseline at all.
+//
+// These tests pin the two halves that have to agree: the crawl stamps ONLY a corpus that reconciled, and
+// the extractor refuses one that carries no stamp.
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { run, sentinelPath } from './fetch.mjs';
+
+const BASE = 'https://register.cacbg.bg';
+const FOLDER = '2099t';
+
+const listXml = (files) =>
+  `<root><MainCategory><Category Name="C"><Institution Name="I"><Person><Name>N</Name>` +
+  `<Position><Name>P</Name>` +
+  files.map((f) => `<Declaration><xmlFile>${f}</xmlFile></Declaration>`).join('') +
+  `</Position></Person></Institution></Category></MainCategory></root>`;
+
+const fakeGet = (routes) => async (url) => {
+  const r = routes[url];
+  return r
+    ? { status: r.status, headers: {}, body: Buffer.from(r.body ?? '', 'utf8') }
+    : { status: 404, headers: {}, body: Buffer.from('') };
+};
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-sentinel-'));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const ok = (f) => ({ [`${BASE}/${FOLDER}/${f}`]: { status: 200, body: '<x/>' } });
+const crawl = (routes, extraArgv = [], msPerRequest = null) => {
+  let clock = 0;
+  const routed = fakeGet(routes);
+  return run({
+    httpGet: msPerRequest
+      ? async (url) => {
+          clock += msPerRequest;
+          return routed(url);
+        }
+      : routed,
+    rawDir: dir,
+    guard: () => {},
+    ...(msPerRequest ? { now: () => clock } : {}),
+    argv: ['node', 'fetch.mjs', '--folders', FOLDER, '--concurrency', '1', ...extraArgv],
+  });
+};
+
+test('a corpus that reconciles against list.xml is stamped', async () => {
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml', 'a2.xml']) },
+    ...ok('a1.xml'),
+    ...ok('a2.xml'),
+  };
+  assert.equal(await crawl(routes), 0);
+  assert.equal(fs.existsSync(sentinelPath(dir)), true, 'a whole corpus must be publishable');
+  const stamp = JSON.parse(fs.readFileSync(sentinelPath(dir), 'utf8'));
+  assert.equal(stamp.incomplete, false);
+  assert.ok(stamp.stampedAt, 'the stamp records WHEN, so a stale one is recognisable');
+});
+
+test('a deadline stop leaves the corpus UNSTAMPED — resumable, but not publishable', async () => {
+  // The exact state #313 introduced and made routine. The raw cache is intact and the next crawl resumes
+  // from it; what must not happen is a later no-crawl run publishing from it as though it were whole.
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml', 'a2.xml']) },
+    ...ok('a1.xml'),
+    ...ok('a2.xml'),
+  };
+  assert.equal(
+    await crawl(routes, ['--deadline-minutes', '1'], 61_000),
+    1,
+    'a deadline stop still exits non-zero',
+  );
+  assert.equal(
+    fs.existsSync(sentinelPath(dir)),
+    false,
+    'a deadline-stopped corpus must NOT carry a completeness stamp',
+  );
+});
+
+test('an incomplete corpus is unstamped even under --allow-incomplete', async () => {
+  // --allow-incomplete records that an operator SAW this shortfall and accepted it. That acceptance is
+  // theirs and does not travel: a later unattended run restoring this cache must not inherit it as whole.
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml', 'a2.xml']) },
+    ...ok('a1.xml'),
+    [`${BASE}/${FOLDER}/a2.xml`]: { status: 500, body: '' },
+  };
+  assert.equal(
+    await crawl(routes, ['--allow-incomplete']),
+    0,
+    'the flag still lets the run proceed',
+  );
+  assert.equal(
+    fs.existsSync(sentinelPath(dir)),
+    false,
+    'but the corpus stays unstamped — the acceptance was for THIS run only',
+  );
+});
+
+test('a stale stamp cannot outlive the corpus it described', async () => {
+  // Stamp first, then run a crawl that fails. If the stamp were only WRITTEN and never CLEARED, the failed
+  // run would inherit the previous run's verdict — the precise shape of every "the marker lied" bug here.
+  fs.writeFileSync(
+    sentinelPath(dir),
+    JSON.stringify({ incomplete: false, stampedAt: 'yesterday' }),
+  );
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml', 'a2.xml']) },
+    ...ok('a1.xml'),
+    [`${BASE}/${FOLDER}/a2.xml`]: { status: 500, body: '' },
+  };
+  assert.equal(await crawl(routes), 1);
+  assert.equal(
+    fs.existsSync(sentinelPath(dir)),
+    false,
+    'the prior stamp must be gone — cleared before fetching, rewritten only on a clean exit',
+  );
+});
+
+// ── the reading half ───────────────────────────────────────────────────────────────────────────────
+// The writer above is only useful if something refuses an unstamped corpus. extract.mjs is that reader,
+// and it runs in-process, so it is exercised as a subprocess against a temp scratch tree.
+
+test('extract refuses an unstamped corpus, and says how to proceed', () => {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-extract-'));
+  fs.mkdirSync(path.join(scratch, 'raw', FOLDER), { recursive: true });
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: path.join(scratch, 'raw'),
+      CACBG_STAGING: path.join(scratch, 'staging'),
+    },
+    encoding: 'utf8',
+  });
+  assert.notEqual(res.status, 0, 'an unstamped corpus must not extract');
+  const out = `${res.stdout}${res.stderr}`;
+  assert.match(out, /REFUSE TO EXTRACT/);
+  assert.match(out, /--allow-partial-corpus/, 'the refusal must name the deliberate override');
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+test('extract proceeds on a stamped corpus', () => {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-extract-ok-'));
+  fs.mkdirSync(path.join(scratch, 'raw', FOLDER), { recursive: true });
+  fs.writeFileSync(
+    path.join(scratch, 'raw', '.corpus-complete.json'),
+    JSON.stringify({ incomplete: false, stampedAt: new Date().toISOString() }),
+  );
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: path.join(scratch, 'raw'),
+      CACBG_STAGING: path.join(scratch, 'staging'),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.doesNotMatch(out, /REFUSE TO EXTRACT/, 'a stamped corpus must pass the gate');
+  fs.rmSync(scratch, { recursive: true, force: true });
+});

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -221,6 +221,43 @@ test('a 200 list.xml that parses to zero rows over existing declarations is a sk
   );
 });
 
+test('a truncated list whose tail still parses to one row is malformed, not a one-row set', async () => {
+  // Review round 3 (blocker, reproduced): lenient parsing accepted a mangled body's surviving complete
+  // <Declaration> as the whole announcement — announced 1, reconciled, STAMPED. Structural validation
+  // now precedes counting: not-well-formed ⇒ the folder is skipped and the corpus cannot certify.
+  const truncated =
+    `<root><MainCategory><Category Name="C"><Institution Name="I"><Person><Name>N</Name>` +
+    `<Position><Name>P</Name><Declaration><xmlFile>a1.xml</xmlFile></Declaration><Declaration><xmlFile>a2`;
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: truncated },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false);
+});
+
+test('a list that announces fewer rows than the cached one is a contradiction, not an update', async () => {
+  // Review round 3 (blocker, reproduced): cached [a1,a2], incoming [a1] — the fuller cache was
+  // overwritten and the shrunken corpus stamped. The resume design rests on per-year immutability, so
+  // shrinkage is skipped and the cached list survives; a genuine withdrawal is a human decision on a
+  // red run, not a certifier's.
+  fs.mkdirSync(path.join(dir, FOLDER), { recursive: true });
+  fs.writeFileSync(path.join(dir, FOLDER, 'list.xml'), listXml(['a1.xml', 'a2.xml']));
+  fs.writeFileSync(path.join(dir, FOLDER, 'a1.xml'), '<x/>');
+  fs.writeFileSync(path.join(dir, FOLDER, 'a2.xml'), '<x/>');
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml']) },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false);
+  assert.match(
+    fs.readFileSync(path.join(dir, FOLDER, 'list.xml'), 'utf8'),
+    /a2\.xml/,
+    'the fuller cached list must survive the contradicted shrinkage',
+  );
+});
+
 // ── the reading half ───────────────────────────────────────────────────────────────────────────────
 // The writer above is only useful if something refuses an unstamped corpus. extract.mjs is that reader,
 // and it runs in-process, so it is exercised as a subprocess against a temp scratch tree.
@@ -329,4 +366,73 @@ test('a CACBG_RAW override pointing at a tracked path inside the repo is refused
   const out = `${res.stdout}${res.stderr}`;
   assert.notEqual(res.status, 0);
   assert.match(out, /CACBG_RAW/, 'the refusal must name the offending variable');
+});
+
+// ── the override guard, adversarially ──────────────────────────────────────────────────────────────
+// Round-3 findings: the guard must answer for the FILESYSTEM location (not an inherited GIT_DIR), must
+// check EVERY containing worktree (not just the innermost), and an unanswerable question fails closed.
+
+test('an inherited GIT_DIR cannot substitute a permissive repository for the real one', () => {
+  const decoy = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-decoy-'));
+  spawnSync('git', ['init', '-q', decoy], { encoding: 'utf8' });
+  fs.mkdirSync(path.join(decoy, '.git', 'info'), { recursive: true });
+  fs.writeFileSync(path.join(decoy, '.git', 'info', 'exclude'), '*\n'); // decoy ignores EVERYTHING
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      GIT_DIR: path.join(decoy, '.git'),
+      GIT_WORK_TREE: path.resolve('.'),
+      CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-git-raw-')),
+      CACBG_STAGING: path.resolve('scripts', 'pii-leak-probe'),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0, 'the decoy exclude-everything repo must not be consulted');
+  assert.match(out, /does not ignore/);
+  fs.rmSync(decoy, { recursive: true, force: true });
+});
+
+test('a nested repository that ignores the path does not clear an OUTER repository that tracks it', () => {
+  // The committable leak from review round 3: the file entered the OUTER index BEFORE the nested repo
+  // existed. Tracked beats ignored — ignore rules never apply to the index, and the nested repo's
+  // implicit ignore silently covers it. (A nested repo with nothing tracked outside is genuinely
+  // uncommittable from the outer side — git add refuses across the boundary — and passes.)
+  const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-outer-'));
+  spawnSync('git', ['init', '-q', outer], { encoding: 'utf8' });
+  const inner = path.join(outer, 'inner');
+  fs.mkdirSync(path.join(inner, 'sink'), { recursive: true });
+  fs.writeFileSync(path.join(inner, 'sink', 'related.jsonl'), '{}\n');
+  spawnSync('git', ['add', 'inner/sink/related.jsonl'], { cwd: outer, encoding: 'utf8' }); // tracked FIRST
+  spawnSync('git', ['init', '-q', inner], { encoding: 'utf8' }); // nested repo appears AFTER
+  fs.writeFileSync(path.join(inner, '.gitignore'), 'sink/\n'); // inner ignores it; outer index unmoved
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-nest-raw-')),
+      CACBG_STAGING: path.join(inner, 'sink'),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0, 'the outer worktree still tracks inner/sink');
+  assert.match(out, /TRACKED/, 'the refusal must name the real reason — the index, not a pattern');
+  fs.rmSync(outer, { recursive: true, force: true });
+});
+
+test('when git cannot answer at all, the guard fails closed', () => {
+  // Round 3: EPERM, a missing git and a corrupt repository all used to PASS. Only a confirmed
+  // "not a repository" may pass; an unanswered safety question refuses.
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      HOME: process.env.HOME,
+      PATH: '/nonexistent', // git unreachable
+      CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-nogit-raw-')),
+      CACBG_STAGING: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-nogit-stg-')),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0, 'no verification means no run');
+  assert.match(out, /could not be verified/);
 });

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -258,6 +258,19 @@ test('a list that announces fewer rows than the cached one is a contradiction, n
   );
 });
 
+test('a multi-root body that validates is still not a list', async () => {
+  // Round 4 (blocker, reproduced): fast-xml-parser validates `<wrong/><root>…</root>` as true, and the
+  // lenient parser merges both roots so parseList still finds the rows. Exactly one document element or
+  // the folder is skipped.
+  const multi = `<wrong/>` + listXml(['a1.xml']);
+  const routes = {
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: multi },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false);
+});
+
 // ── the reading half ───────────────────────────────────────────────────────────────────────────────
 // The writer above is only useful if something refuses an unstamped corpus. extract.mjs is that reader,
 // and it runs in-process, so it is exercised as a subprocess against a temp scratch tree.
@@ -435,4 +448,68 @@ test('when git cannot answer at all, the guard fails closed', () => {
   const out = `${res.stdout}${res.stderr}`;
   assert.notEqual(res.status, 0, 'no verification means no run');
   assert.match(out, /could not be verified/);
+});
+
+test('a literal directory named like pathspec magic cannot resolve to an ignored path', () => {
+  // Round 4 (blocker, verified): `--` does not disable pathspec magic, and check-ignore evaluates
+  // `:(top)…` — a directory LITERALLY named `:(top)scratch/cacbg/leak` used to be judged by the ignore
+  // status of scratch/cacbg/leak and pass, while the literal directory is committable. The ./ prefix
+  // keeps the name a name.
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-magic-raw-')),
+      CACBG_STAGING: path.resolve(':(top)scratch/cacbg/leak'),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0);
+  assert.match(out, /does not ignore/, 'the literal name must be judged, not the magic resolution');
+});
+
+test('a localized git does not turn legitimate outside-repo overrides into refusals', () => {
+  // Round 4: this machine runs bg_BG, where „not a git repository" arrives translated — the English
+  // match then read a legitimate /tmp override as an unexplained failure and refused. gitEnv pins
+  // LC_ALL=C, so the caller's locale must not matter.
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      LC_ALL: 'bg_BG.UTF-8',
+      LANG: 'bg_BG.UTF-8',
+      CACBG_RAW: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-loc-raw-')),
+      CACBG_STAGING: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-loc-stg-')),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.match(
+    out,
+    /REFUSE TO EXTRACT/,
+    'the guard must PASS (the later corpus gate is what refuses)',
+  );
+  assert.doesNotMatch(out, /could not be verified/);
+});
+
+test('an inherited GIT_DIR cannot reach the DEFAULT-path scratch rail either', () => {
+  // Round 4: assertOverrideDirSafe stripped GIT_* but assertScratchIgnored still inherited them — the
+  // default-output rail could consult a decoy repository. Both rails now share gitEnv(). The decoy here
+  // ignores NOTHING, so consulting it would refuse the probe; the REAL repo ignores scratch/ and the
+  // run proceeds to the corpus gate.
+  const decoy = fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-decoy2-'));
+  spawnSync('git', ['init', '-q', decoy], { encoding: 'utf8' });
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      GIT_DIR: path.join(decoy, '.git'),
+      // The decoy's OWN empty worktree: .gitignore files are read from the work tree, so pointing the
+      // work tree at the real checkout would answer "ignored" either way and hide the substitution.
+      GIT_WORK_TREE: decoy,
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.match(out, /REFUSE TO EXTRACT/, 'the scratch rail must consult the real repository');
+  assert.doesNotMatch(out, /not git-ignored/);
+  fs.rmSync(decoy, { recursive: true, force: true });
 });

--- a/scripts/cacbg/corpus-sentinel.test.mjs
+++ b/scripts/cacbg/corpus-sentinel.test.mjs
@@ -153,6 +153,12 @@ test('a --folders subset that completes does NOT stamp — complete for the subs
   const OTHER = '2098t';
   fs.mkdirSync(path.join(dir, OTHER), { recursive: true });
   fs.writeFileSync(path.join(dir, OTHER, 'stale.xml'), '<x/>');
+  // Seeded stamp: the subset must CLEAR it (it mutates the corpus), not merely decline to write one —
+  // a clear that runs only on the discovery path would leave this stale certificate standing.
+  fs.writeFileSync(
+    sentinelPath(dir),
+    JSON.stringify({ incomplete: false, stampedAt: 'yesterday' }),
+  );
   const routes = {
     [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml']) },
     ...ok('a1.xml'),
@@ -161,7 +167,7 @@ test('a --folders subset that completes does NOT stamp — complete for the subs
   assert.equal(
     fs.existsSync(sentinelPath(dir)),
     false,
-    'a subset run must never certify the whole corpus',
+    'a subset run must never certify the whole corpus — and must clear a prior certificate',
   );
 });
 
@@ -171,7 +177,27 @@ test('an index that discovers ZERO folders is a failure, not a trivially complet
   // a broken or redesigned index page, never a real corpus state.
   fs.mkdirSync(path.join(dir, FOLDER), { recursive: true });
   fs.writeFileSync(path.join(dir, FOLDER, 'a1.xml'), '<x/>');
+  // Seeded stamp: the clear must run BEFORE the zero-discovery bail-out, or the failure exits 1 while
+  // yesterday's certificate keeps standing over a tree the run just declared unverifiable.
+  fs.writeFileSync(
+    sentinelPath(dir),
+    JSON.stringify({ incomplete: false, stampedAt: 'yesterday' }),
+  );
   assert.equal(await crawl({}, [], null, { discovered: [] }), 1);
+  assert.equal(fs.existsSync(sentinelPath(dir)), false, 'the stale stamp must be gone too');
+});
+
+test('a maintenance page on a FRESH folder cannot ride a valid neighbour into a stamp', async () => {
+  // The review reproduced exactly this: folder A serves maintenance HTML (0 rows, no files on disk),
+  // folder B is valid — skippedSets stayed 0, the corpus stamped. Zero-row folders now skip
+  // unconditionally, so A makes the corpus incomplete regardless of B.
+  const A = '2097t';
+  const routes = {
+    [`${BASE}/${A}/list.xml`]: { status: 200, body: '<html>maintenance</html>' },
+    [`${BASE}/${FOLDER}/list.xml`]: { status: 200, body: listXml(['a1.xml']) },
+    ...ok('a1.xml'),
+  };
+  assert.equal(await crawl(routes, [], null, { discovered: [A, FOLDER] }), 1);
   assert.equal(fs.existsSync(sentinelPath(dir)), false);
 });
 
@@ -266,6 +292,7 @@ test('--allow-partial-corpus extracts an unstamped corpus, loudly', () => {
     `the override must let the run proceed, got ${res.status}: ${out.slice(0, 300)}`,
   );
   assert.match(out, /--allow-partial-corpus/, 'the acceptance must be printed, never silent');
+  fs.rmSync(scratch, { recursive: true, force: true });
 });
 
 test('a CACBG_STAGING override pointing at a tracked path inside the repo is refused', () => {
@@ -287,4 +314,19 @@ test('a CACBG_STAGING override pointing at a tracked path inside the repo is ref
   assert.notEqual(res.status, 0, 'a committable PII destination must refuse to run');
   assert.match(out, /CACBG_STAGING/, 'the refusal must name the offending variable');
   fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+test('a CACBG_RAW override pointing at a tracked path inside the repo is refused too', () => {
+  // Same rail, other variable — deleting only the RAW validation survived the STAGING-only test.
+  const res = spawnSync(process.execPath, [path.resolve('scripts/cacbg/extract.mjs')], {
+    env: {
+      ...process.env,
+      CACBG_RAW: path.resolve('scripts', 'pii-raw-probe'),
+      CACBG_STAGING: fs.mkdtempSync(path.join(os.tmpdir(), 'cacbg-pii-raw-')),
+    },
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.notEqual(res.status, 0);
+  assert.match(out, /CACBG_RAW/, 'the refusal must name the offending variable');
 });

--- a/scripts/cacbg/extract.mjs
+++ b/scripts/cacbg/extract.mjs
@@ -10,13 +10,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseList, parseDeclaration } from './parse.mjs';
-import { assertScratchIgnored, SCRATCH } from './guard.mjs';
+import { assertScratchIgnored, assertOverrideDirSafe, SCRATCH } from './guard.mjs';
 import { sentinelPath } from './fetch.mjs';
 
 // Overridable for tests, mirroring load.mjs's CACBG_DB/CACBG_STAGING. Defaults are the real scratch, so
 // production behaviour is unchanged when they are unset.
 const RAW = process.env.CACBG_RAW || path.join(SCRATCH, 'raw');
 const STAGING = process.env.CACBG_STAGING || path.join(SCRATCH, 'staging');
+// An override must satisfy the same rail the default location does — see assertOverrideDirSafe. The
+// default paths are covered by assertScratchIgnored in run(); overrides are validated here, at the
+// moment they are adopted, so no code path can write PII somewhere git could commit.
+if (process.env.CACBG_RAW) assertOverrideDirSafe(RAW, 'CACBG_RAW');
+if (process.env.CACBG_STAGING) assertOverrideDirSafe(STAGING, 'CACBG_STAGING');
 
 /**
  * Refuse a corpus that was never stamped complete — unless the caller states it knows.

--- a/scripts/cacbg/extract.mjs
+++ b/scripts/cacbg/extract.mjs
@@ -11,12 +11,51 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseList, parseDeclaration } from './parse.mjs';
 import { assertScratchIgnored, SCRATCH } from './guard.mjs';
+import { sentinelPath } from './fetch.mjs';
 
-const RAW = path.join(SCRATCH, 'raw');
-const STAGING = path.join(SCRATCH, 'staging');
+// Overridable for tests, mirroring load.mjs's CACBG_DB/CACBG_STAGING. Defaults are the real scratch, so
+// production behaviour is unchanged when they are unset.
+const RAW = process.env.CACBG_RAW || path.join(SCRATCH, 'raw');
+const STAGING = process.env.CACBG_STAGING || path.join(SCRATCH, 'staging');
+
+/**
+ * Refuse a corpus that was never stamped complete — unless the caller states it knows.
+ *
+ * fetch.mjs writes `.corpus-complete.json` only when the crawl reconciles against the register's own
+ * list.xml, and clears it before touching anything. So a missing stamp means one of: a deadline stop
+ * (#313 made that an EXPECTED state), a crash, or a cache restored from a run that never finished.
+ *
+ * That distinction had no reader. `restore-keys: cacbg-raw-` takes the most RECENT snapshot, not the most
+ * complete, and the loop below walks readdirSync over whatever files exist without reconciling them
+ * against list.xml — so a truncated corpus simply produces a smaller surface, with no error anywhere.
+ * Neither downstream gate closes it: the monotonicity gate sees net growth whenever new links outnumber
+ * lost ones, the --min-links floor only counts, and a first run in a fresh environment has no baseline.
+ *
+ * A partial corpus stays fully usable for RESUMING — the next crawl skips what is on disk. This gate is
+ * only about PUBLISHING from one.
+ */
+function assertCorpusComplete() {
+  if (process.argv.includes('--allow-partial-corpus')) {
+    console.warn(
+      '⚠ --allow-partial-corpus: extracting from a corpus that was never stamped complete. ' +
+        'Whatever is missing from the raw cache will be missing from the surface, silently.',
+    );
+    return;
+  }
+  if (fs.existsSync(sentinelPath(RAW))) return;
+  throw new Error(
+    `REFUSE TO EXTRACT: no completeness stamp at ${sentinelPath(RAW)}. The raw corpus was never ` +
+      `confirmed whole — it is a deadline stop, a crashed crawl, or a cache restored from one. Extracting ` +
+      `now would publish a surface missing whatever the corpus is missing, and nothing downstream would ` +
+      `notice: the monotonicity gate sees net growth when new links offset lost ones, and the ship floor ` +
+      `only counts. Re-run the crawl to completion (it resumes — declarations on disk are skipped), or ` +
+      `pass --allow-partial-corpus to state that a smaller surface is intended.`,
+  );
+}
 
 function run() {
   assertScratchIgnored();
+  assertCorpusComplete();
   fs.mkdirSync(STAGING, { recursive: true });
   const holdingsOut = fs.createWriteStream(path.join(STAGING, 'holdings.jsonl'));
   const relatedOut = fs.createWriteStream(path.join(STAGING, 'related.jsonl'));

--- a/scripts/cacbg/extract.mjs
+++ b/scripts/cacbg/extract.mjs
@@ -17,11 +17,16 @@ import { sentinelPath } from './fetch.mjs';
 // production behaviour is unchanged when they are unset.
 const RAW = process.env.CACBG_RAW || path.join(SCRATCH, 'raw');
 const STAGING = process.env.CACBG_STAGING || path.join(SCRATCH, 'staging');
-// An override must satisfy the same rail the default location does — see assertOverrideDirSafe. The
-// default paths are covered by assertScratchIgnored in run(); overrides are validated here, at the
-// moment they are adopted, so no code path can write PII somewhere git could commit.
-if (process.env.CACBG_RAW) assertOverrideDirSafe(RAW, 'CACBG_RAW');
-if (process.env.CACBG_STAGING) assertOverrideDirSafe(STAGING, 'CACBG_STAGING');
+// Validate the ACTUAL output directories, default or overridden alike (review round 5, blocker 2):
+// assertScratchIgnored probes only the fixed scratch/cacbg/.probe path, so a symlink AT the sibling
+// default `raw`/`staging` — or an overridden one — is invisible to it while fetch/extract I/O follows
+// it into committable files. assertOverrideDirSafe canonicalizes the real target and asks git, so it
+// is the right check for both. Unconditional: the default location must clear the same bar it guards.
+assertOverrideDirSafe(RAW, process.env.CACBG_RAW ? 'CACBG_RAW' : 'scratch/cacbg/raw');
+assertOverrideDirSafe(
+  STAGING,
+  process.env.CACBG_STAGING ? 'CACBG_STAGING' : 'scratch/cacbg/staging',
+);
 
 /**
  * Refuse a corpus that was never stamped complete — unless the caller states it knows.

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -308,7 +308,16 @@ export async function run({
     // human decides that, not a certifier.
     const cachedListPath = path.join(dir, 'list.xml');
     if (fs.existsSync(cachedListPath)) {
-      const cachedRows = parseList(fs.readFileSync(cachedListPath, 'utf8')).length;
+      // A corrupt cached list (a legacy DOCTYPE, a truncated write) must not crash the shrink check —
+      // the valid INCOMING list is exactly what heals it. Unparseable-cached reads as zero rows: no
+      // shrink objection, and the atomicWrite below replaces the corrupt cache (round 4, minor).
+      const cachedRows = (() => {
+        try {
+          return parseList(fs.readFileSync(cachedListPath, 'utf8')).length;
+        } catch {
+          return 0;
+        }
+      })();
       if (rows.length < cachedRows) {
         console.log(`  ${folder}: list announces ${rows.length} < cached ${cachedRows} — SKIP`);
         stats.skippedFolders.push({ folder, status: 'list-shrank' });

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -21,7 +21,13 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { getPinned, CACBG_HOST } from './tls.mjs';
 import { parseList } from './parse.mjs';
 import { XMLParser, XMLValidator } from 'fast-xml-parser';
-import { assertScratchIgnored, SCRATCH, safeXmlFile, safeFolder } from './guard.mjs';
+import {
+  assertScratchIgnored,
+  assertOverrideDirSafe,
+  SCRATCH,
+  safeXmlFile,
+  safeFolder,
+} from './guard.mjs';
 
 const BASE = `https://${CACBG_HOST}`;
 const RAW = path.join(SCRATCH, 'raw');
@@ -198,6 +204,10 @@ export async function run({
   now = () => Date.now(),
 } = {}) {
   guard();
+  // The corpus directory the crawl writes into must clear the PII rail too — a symlink at rawDir would
+  // otherwise redirect fetched declarations into committable territory (review round 5, blocker 2). The
+  // injected-guard tests point rawDir at a temp dir, which is outside any repo and passes trivially.
+  assertOverrideDirSafe(rawDir, rawDir === RAW ? 'scratch/cacbg/raw' : 'rawDir');
   const {
     limit,
     concurrency,

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -231,6 +231,17 @@ export async function run({
     ? override.split(',').map((f) => safeFolder(f.trim()))
     : (console.log('Discovering folders from register index …'), await discover(httpGet));
   console.log(`Folders to crawl (${folders.length}): ${folders.join(', ') || '(none)'}`);
+  // An index page that yields ZERO folders is a broken or redesigned index, never a real corpus state —
+  // the register has published year-sets continuously since 2015. Proceeding would run a vacuous crawl
+  // whose completeness arithmetic is 0/0 and stamp it (review finding: reproduced — exit 0 and a
+  // `folders: 0, incomplete: false` stamp over an existing raw tree). Fail instead; the stamp was
+  // already cleared above, so the corpus is left resumable and unpublishable.
+  if (!override && folders.length === 0) {
+    console.error(
+      `\n✖ the register index yielded no folders — refusing to certify anything from it.`,
+    );
+    return 1;
+  }
 
   // Per-set accounting so completeness can be reconciled announced↔obtained (Todor #2). A set whose list.xml
   // never loaded is a WHOLESALE gap (we don't even know its declaration count) → tracked separately.
@@ -251,8 +262,21 @@ export async function run({
       stats.skippedFolders.push({ folder, status: listRes.status });
       continue;
     }
-    atomicWrite(path.join(dir, 'list.xml'), listRes.body); // cache list for extract.mjs
     let rows = parseList(listRes.body.toString('utf8'));
+    // An HTTP-200 body that parses to ZERO rows while the folder already holds declaration files is a
+    // contradiction, not an empty set: a maintenance HTML page or a schema change both come back 200 and
+    // parse to [] (review finding: confirmed against a real maintenance page). Trusting it would shrink
+    // `announced` to zero, make the folder look trivially complete, and OVERWRITE the cached list the
+    // extractor reads. Skip the folder instead — skippedFolders makes the corpus incomplete, so no stamp.
+    if (rows.length === 0) {
+      const onDisk = fs.readdirSync(dir).some((f) => f.endsWith('.xml') && f !== 'list.xml');
+      if (onDisk) {
+        console.log(`  ${folder}: list.xml parsed to 0 rows but declarations exist on disk — SKIP`);
+        stats.skippedFolders.push({ folder, status: 'empty-list-with-files' });
+        continue;
+      }
+    }
+    atomicWrite(path.join(dir, 'list.xml'), listRes.body); // cache list for extract.mjs
     // `announced` is what the SET declares, so it is read BEFORE --limit truncates the work. Taking it
     // after the slice made a deliberately partial crawl report announced == obtained, i.e. the completeness
     // gate certified a corpus it had never attempted to fetch (ydimitrof #226).
@@ -380,8 +404,14 @@ export async function run({
   // if it were whole.
   // Gated on the RECONCILED verdict, not on reaching this line: --allow-incomplete lets an accepted
   // shortfall proceed to exit 0, and stamping there would hand a later unattended run an acceptance that
-  // was never theirs.
-  if (!completeness.incomplete) writeSentinel(rawDir, { folders: folders.length, ...completeness });
+  // was never theirs. Two more conditions, both review findings:
+  //   • !override — a --folders subset that completes is complete FOR THE SUBSET; certifying the whole
+  //     raw tree from it would stamp around every other folder's state. Subset crawls still CLEAR the
+  //     stamp (top of run), so they leave the corpus resumable-not-publishable, which is right.
+  //   • announced > 0 — a crawl that reconciled zero declarations certifies nothing. With the empty-
+  //     index and empty-list guards above this is belt-and-braces, not the primary defence.
+  const stampable = !override && !completeness.incomplete && completeness.announcedDeclarations > 0;
+  if (stampable) writeSentinel(rawDir, { folders: folders.length, ...completeness });
   return 0;
 }
 

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -20,7 +20,7 @@ import { pathToFileURL } from 'node:url';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { getPinned, CACBG_HOST } from './tls.mjs';
 import { parseList } from './parse.mjs';
-import { XMLValidator } from 'fast-xml-parser';
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { assertScratchIgnored, SCRATCH, safeXmlFile, safeFolder } from './guard.mjs';
 
 const BASE = `https://${CACBG_HOST}`;
@@ -267,8 +267,16 @@ export async function run({
     // Structural validation FIRST (review round 3): a truncated body whose tail still holds one complete
     // <Declaration> parses leniently to that one row — announced becomes 1, the corpus reconciles, and a
     // fresh crawl STAMPS off a mangled list. Only a well-formed document may be counted or cached.
-    if (XMLValidator.validate(listBody) !== true) {
-      console.log(`  ${folder}: list.xml is not well-formed XML — SKIP`);
+    // XMLValidator alone is NOT enough: fast-xml-parser validates `<wrong/><root>…</root>` — a
+    // MULTI-root body — as true, and the lenient parser then merges both roots so parseList still finds
+    // rows (review round 4: reproduced in both root orders). A real list.xml has exactly one document
+    // element; anything else is a mangled or concatenated body.
+    const roots = () =>
+      Object.keys(new XMLParser().parse(listBody)).filter(
+        (k) => k !== '?xml' && k !== '?xml-stylesheet',
+      );
+    if (XMLValidator.validate(listBody) !== true || roots().length !== 1) {
+      console.log(`  ${folder}: list.xml is not a single well-formed document — SKIP`);
       stats.skippedFolders.push({ folder, status: 'malformed-list' });
       continue;
     }

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -263,18 +263,24 @@ export async function run({
       continue;
     }
     let rows = parseList(listRes.body.toString('utf8'));
-    // An HTTP-200 body that parses to ZERO rows while the folder already holds declaration files is a
-    // contradiction, not an empty set: a maintenance HTML page or a schema change both come back 200 and
-    // parse to [] (review finding: confirmed against a real maintenance page). Trusting it would shrink
-    // `announced` to zero, make the folder look trivially complete, and OVERWRITE the cached list the
-    // extractor reads. Skip the folder instead — skippedFolders makes the corpus incomplete, so no stamp.
+    // An HTTP-200 body that parses to ZERO rows is a maintenance HTML page or a schema change, not an
+    // empty set — the register indexes a folder only once it has declarations, and both failure shapes
+    // come back 200 and parse to [] (review finding: confirmed against a real maintenance page; the
+    // follow-up reproduced the FRESH-folder variant certifying a mixed corpus). Trusting it would shrink
+    // `announced` to zero, make the folder look trivially complete, and — when files already exist —
+    // OVERWRITE the cached list the extractor reads. Skip the folder unconditionally: skippedFolders
+    // makes the corpus incomplete, so no stamp; a genuinely empty brand-new set (never yet observed)
+    // would go red for an operator to look at, which is the right failure direction for a certifier.
     if (rows.length === 0) {
       const onDisk = fs.readdirSync(dir).some((f) => f.endsWith('.xml') && f !== 'list.xml');
-      if (onDisk) {
-        console.log(`  ${folder}: list.xml parsed to 0 rows but declarations exist on disk — SKIP`);
-        stats.skippedFolders.push({ folder, status: 'empty-list-with-files' });
-        continue;
-      }
+      console.log(
+        `  ${folder}: list.xml parsed to 0 rows${onDisk ? ' (declarations exist on disk!)' : ''} — SKIP`,
+      );
+      stats.skippedFolders.push({
+        folder,
+        status: onDisk ? 'empty-list-with-files' : 'empty-list',
+      });
+      continue;
     }
     atomicWrite(path.join(dir, 'list.xml'), listRes.body); // cache list for extract.mjs
     // `announced` is what the SET declares, so it is read BEFORE --limit truncates the work. Taking it
@@ -408,8 +414,11 @@ export async function run({
   //   • !override — a --folders subset that completes is complete FOR THE SUBSET; certifying the whole
   //     raw tree from it would stamp around every other folder's state. Subset crawls still CLEAR the
   //     stamp (top of run), so they leave the corpus resumable-not-publishable, which is right.
-  //   • announced > 0 — a crawl that reconciled zero declarations certifies nothing. With the empty-
-  //     index and empty-list guards above this is belt-and-braces, not the primary defence.
+  //   • announced > 0 — a crawl that reconciled zero declarations certifies nothing. UNREACHABLE by
+  //     construction since the zero-row skip above (every zero-announced folder lands in skippedFolders,
+  //     making the corpus incomplete; zero folders at all exits earlier) — kept as belt-and-braces
+  //     against a future regression of those guards, which is also why no test pins it: a mutant
+  //     deleting it survives, deliberately, rather than a test encoding an impossible scenario.
   const stampable = !override && !completeness.incomplete && completeness.announcedDeclarations > 0;
   if (stampable) writeSentinel(rawDir, { folders: folders.length, ...completeness });
   return 0;

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -220,6 +220,12 @@ export async function run({
   const pastDeadline = () => now() >= deadlineAt;
   let deadlineHit = false;
 
+  // Clear any prior sentinel BEFORE fetching. From here until the clean exit below the corpus is in flux,
+  // and a stamp from an earlier run would describe a corpus that no longer exists. Clearing first also
+  // means every abnormal exit — deadline stop, circuit breaker, an uncaught throw, the runner being
+  // killed — leaves the corpus unstamped without needing its own cleanup path.
+  fs.rmSync(sentinelPath(rawDir), { force: true });
+
   // Default: discover every folder from the register index. --folders 2021_nc,2025y restricts to a subset.
   const folders = override
     ? override.split(',').map((f) => safeFolder(f.trim()))
@@ -358,7 +364,40 @@ export async function run({
       return 1;
     }
   }
+
+  // The completeness sentinel — written ONLY on a corpus that reconciles against the register's own
+  // list.xml, and removed otherwise. #313 made a partial raw cache an EXPECTED state (the crawl now stops
+  // on its deadline and saves what it has), and `restore-keys: cacbg-raw-` takes the most RECENT snapshot,
+  // not the most complete. Nothing downstream could tell the two apart: extract.mjs walks readdirSync over
+  // whatever files exist and never reconciles them against list.xml, so a truncated corpus re-publishes as
+  // a smaller surface with no error anywhere. The monotonicity gate sees net growth when new links offset
+  // lost ones, the --min-links floor only counts, and a first run in a fresh environment has no baseline
+  // at all.
+  //
+  // So: a partial cache stays perfectly good for RESUMING (the next crawl skips what is on disk) but is
+  // marked unfit for PUBLISHING. --allow-incomplete does not write it either: that flag records that an
+  // operator accepted a shortfall, which is exactly the state a later unattended run must not inherit as
+  // if it were whole.
+  // Gated on the RECONCILED verdict, not on reaching this line: --allow-incomplete lets an accepted
+  // shortfall proceed to exit 0, and stamping there would hand a later unattended run an acceptance that
+  // was never theirs.
+  if (!completeness.incomplete) writeSentinel(rawDir, { folders: folders.length, ...completeness });
   return 0;
+}
+
+/** Sentinel path for a raw corpus directory. Exported so the reader and the writer cannot drift. */
+export const sentinelPath = (rawDir) => path.join(rawDir, '.corpus-complete.json');
+
+/**
+ * Stamp a corpus as publishable. Called on the clean-exit path only; every other path REMOVES the file so
+ * a stale sentinel can never outlive the corpus it described (a resumed crawl that then fails must not
+ * leave yesterday's stamp behind).
+ */
+function writeSentinel(rawDir, summary) {
+  fs.writeFileSync(
+    sentinelPath(rawDir),
+    `${JSON.stringify({ ...summary, stampedAt: new Date().toISOString() }, null, 2)}\n`,
+  );
 }
 
 // Only crawl when invoked directly (`node fetch.mjs`). Importing the module — e.g. the unit/integration tests

--- a/scripts/cacbg/fetch.mjs
+++ b/scripts/cacbg/fetch.mjs
@@ -20,6 +20,7 @@ import { pathToFileURL } from 'node:url';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { getPinned, CACBG_HOST } from './tls.mjs';
 import { parseList } from './parse.mjs';
+import { XMLValidator } from 'fast-xml-parser';
 import { assertScratchIgnored, SCRATCH, safeXmlFile, safeFolder } from './guard.mjs';
 
 const BASE = `https://${CACBG_HOST}`;
@@ -262,7 +263,16 @@ export async function run({
       stats.skippedFolders.push({ folder, status: listRes.status });
       continue;
     }
-    let rows = parseList(listRes.body.toString('utf8'));
+    const listBody = listRes.body.toString('utf8');
+    // Structural validation FIRST (review round 3): a truncated body whose tail still holds one complete
+    // <Declaration> parses leniently to that one row — announced becomes 1, the corpus reconciles, and a
+    // fresh crawl STAMPS off a mangled list. Only a well-formed document may be counted or cached.
+    if (XMLValidator.validate(listBody) !== true) {
+      console.log(`  ${folder}: list.xml is not well-formed XML — SKIP`);
+      stats.skippedFolders.push({ folder, status: 'malformed-list' });
+      continue;
+    }
+    let rows = parseList(listBody);
     // An HTTP-200 body that parses to ZERO rows is a maintenance HTML page or a schema change, not an
     // empty set — the register indexes a folder only once it has declarations, and both failure shapes
     // come back 200 and parse to [] (review finding: confirmed against a real maintenance page; the
@@ -282,7 +292,22 @@ export async function run({
       });
       continue;
     }
-    atomicWrite(path.join(dir, 'list.xml'), listRes.body); // cache list for extract.mjs
+    // A list that announces FEWER rows than the cached one contradicts the per-year immutability the
+    // whole resume design rests on ("source is immutable per year — files already on disk are skipped").
+    // Trusting it would overwrite the fuller cached list the extractor reads and certify the shrinkage
+    // (review round 3: reproduced — cached [a1,a2], incoming [a1], stamped). Keep the cache, skip the
+    // folder; if the register ever legitimately withdraws a declaration, the red run is the place a
+    // human decides that, not a certifier.
+    const cachedListPath = path.join(dir, 'list.xml');
+    if (fs.existsSync(cachedListPath)) {
+      const cachedRows = parseList(fs.readFileSync(cachedListPath, 'utf8')).length;
+      if (rows.length < cachedRows) {
+        console.log(`  ${folder}: list announces ${rows.length} < cached ${cachedRows} — SKIP`);
+        stats.skippedFolders.push({ folder, status: 'list-shrank' });
+        continue;
+      }
+    }
+    atomicWrite(cachedListPath, listRes.body); // cache list for extract.mjs
     // `announced` is what the SET declares, so it is read BEFORE --limit truncates the work. Taking it
     // after the slice made a deliberately partial crawl report announced == obtained, i.e. the completeness
     // gate certified a corpus it had never attempted to fetch (ydimitrof #226).

--- a/scripts/cacbg/guard.mjs
+++ b/scripts/cacbg/guard.mjs
@@ -39,43 +39,90 @@ export function assertScratchIgnored(subdir = 'cacbg') {
  * @param {string} name the env var being validated, for the error message
  */
 export function assertOverrideDirSafe(dir, name) {
-  // Ask git ITSELF, not a lexical prefix check. The review demonstrated four bypasses of the string
-  // comparison this used to do: the repository root itself (equality fails a startsWith(ROOT+sep)
-  // test), a /proc/self/cwd symlink alias resolving back inside the checkout, an unignored path in a
-  // DIFFERENT git worktree, and case aliases on case-insensitive filesystems. Running git FROM the
-  // target directory sidesteps all four — the OS resolves symlinks on chdir, and git answers for
-  // whichever repository actually contains the path, ours or not.
-  //
-  // The directory may not exist yet (extract creates staging), so the probe walks up to the deepest
-  // existing ancestor and the missing tail is re-appended for the ignore check.
-  const missing = [];
-  let probe = path.resolve(dir);
-  while (!fs.existsSync(probe)) {
-    const parent = path.dirname(probe);
-    if (parent === probe) break; // filesystem root — nothing exists; nothing to commit either
-    missing.unshift(path.basename(probe));
-    probe = parent;
-  }
   const refuse = (why) => {
     throw new Error(
       `REFUSE TO RUN: ${name}=${dir} ${why} — PII output must never be committable (PII rail, spec §8)`,
     );
   };
-  let top = null;
-  try {
-    top = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: probe }).toString().trim();
-  } catch {
-    return; // not inside ANY git worktree — no repository can commit it
+  // The directory may not exist yet (extract creates staging): walk up to the deepest existing
+  // ancestor; the missing tail is re-appended for the ignore checks below.
+  const missing = [];
+  let probe = path.resolve(dir);
+  while (!fs.existsSync(probe)) {
+    const parent = path.dirname(probe);
+    if (parent === probe) break;
+    missing.unshift(path.basename(probe));
+    probe = parent;
   }
   const target = path.join(probe, ...missing);
-  const rel = path.relative(top, path.resolve(probe, target === probe ? '.' : target));
-  if (rel === '' || rel === '.')
-    refuse('IS a git worktree root — everything under it defaults to committable');
-  try {
-    execFileSync('git', ['check-ignore', '-q', '--', rel], { cwd: top });
-  } catch {
-    refuse(`points inside the git worktree at ${top} at a path git does not ignore`);
+  // Git must answer for the FILESYSTEM location. An inherited GIT_DIR / GIT_WORK_TREE would let the
+  // caller substitute another repository's ignore policy for the one that actually contains the path
+  // (review round 3: reproduced — an alternate repo's exclude rules accepted a tracked sink/).
+  const env = { ...process.env };
+  for (const k of Object.keys(env)) if (k.startsWith('GIT_')) delete env[k];
+  const gitTop = (cwd) => {
+    try {
+      return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+        .toString()
+        .trim();
+    } catch (e) {
+      // Only a CONFIRMED "not a repository" may pass. Every other failure — git missing, permission
+      // errors, a corrupt repository — leaves the question unanswered, and an unanswered safety
+      // question fails closed (review round 3: EPERM and invalid setups all used to PASS).
+      const msg = `${e.stderr ?? ''}${e.message ?? ''}`;
+      if (/not a git repository/i.test(msg)) return null;
+      refuse(`could not be verified (git failed from ${cwd}: ${String(msg).split('\n')[0]})`);
+    }
+  };
+  // EVERY containing worktree must ignore the target, not just the innermost: a nested repository that
+  // ignores the path proves nothing about an OUTER repository that tracks the same tree (review round
+  // 3: reproduced — inner repo ignored sink/, outer repo held inner/sink/related.jsonl as committable).
+  let cwd = probe;
+  for (let depth = 0; depth < 64; depth++) {
+    const top = gitTop(cwd);
+    if (top === null) return; // no (further) repository contains it
+    const rel = path.relative(top, target);
+    if (rel === '' || rel === '.')
+      refuse('IS a git worktree root — everything under it defaults to committable');
+    // TRACKED beats ignored. Ignore rules never apply to paths already in the index, and check-ignore
+    // can even answer "ignored" for them (a nested repository makes everything beneath it implicitly
+    // ignored — truthful for ADDING files, silent about ones tracked BEFORE the nested repo appeared;
+    // review round 3 reproduced exactly that committable leak). If any file under the target is in
+    // this worktree's index, modifications are committable regardless of every pattern.
+    let tracked;
+    try {
+      tracked = execFileSync('git', ['ls-files', '-z', '--', rel], {
+        cwd: top,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch {
+      refuse(`could not be verified (git ls-files failed in ${top})`);
+    }
+    // Decided OUTSIDE the try — a refusal thrown inside it would be swallowed by our own catch and
+    // re-dressed as a verification failure (caught by the fixture's message assertion, usefully).
+    if (tracked.length > 0)
+      refuse(`overlaps files TRACKED in the git worktree at ${top} — already committable`);
+    try {
+      execFileSync('git', ['check-ignore', '-q', '--', rel], {
+        cwd: top,
+        env,
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+    } catch (e) {
+      if (e.status === 1)
+        refuse(`points inside the git worktree at ${top} at a path git does not ignore`);
+      refuse(`could not be verified (git check-ignore failed in ${top})`);
+    }
+    const above = path.dirname(top);
+    if (above === top) return; // filesystem root
+    cwd = above;
   }
+  refuse('could not be verified (worktree nesting exceeded 64 levels)');
 }
 
 // Path-sanitize an xml_file / year from the untrusted list.xml before using it in a filesystem path

--- a/scripts/cacbg/guard.mjs
+++ b/scripts/cacbg/guard.mjs
@@ -3,6 +3,7 @@
 // commit. This asserts that invariant before any fetch — if scratch/ is not ignored, we stop hard.
 
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -38,16 +39,42 @@ export function assertScratchIgnored(subdir = 'cacbg') {
  * @param {string} name the env var being validated, for the error message
  */
 export function assertOverrideDirSafe(dir, name) {
-  const abs = path.resolve(dir);
-  if (!abs.startsWith(ROOT + path.sep)) return; // outside the repo — git cannot commit it
-  const rel = path.relative(ROOT, abs);
-  try {
-    execFileSync('git', ['check-ignore', '-q', rel], { cwd: ROOT });
-  } catch {
+  // Ask git ITSELF, not a lexical prefix check. The review demonstrated four bypasses of the string
+  // comparison this used to do: the repository root itself (equality fails a startsWith(ROOT+sep)
+  // test), a /proc/self/cwd symlink alias resolving back inside the checkout, an unignored path in a
+  // DIFFERENT git worktree, and case aliases on case-insensitive filesystems. Running git FROM the
+  // target directory sidesteps all four — the OS resolves symlinks on chdir, and git answers for
+  // whichever repository actually contains the path, ours or not.
+  //
+  // The directory may not exist yet (extract creates staging), so the probe walks up to the deepest
+  // existing ancestor and the missing tail is re-appended for the ignore check.
+  const missing = [];
+  let probe = path.resolve(dir);
+  while (!fs.existsSync(probe)) {
+    const parent = path.dirname(probe);
+    if (parent === probe) break; // filesystem root — nothing exists; nothing to commit either
+    missing.unshift(path.basename(probe));
+    probe = parent;
+  }
+  const refuse = (why) => {
     throw new Error(
-      `REFUSE TO RUN: ${name}=${dir} points inside the repository at a path git does not ignore — ` +
-        `PII output must never be committable (PII rail, spec §8)`,
+      `REFUSE TO RUN: ${name}=${dir} ${why} — PII output must never be committable (PII rail, spec §8)`,
     );
+  };
+  let top = null;
+  try {
+    top = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: probe }).toString().trim();
+  } catch {
+    return; // not inside ANY git worktree — no repository can commit it
+  }
+  const target = path.join(probe, ...missing);
+  const rel = path.relative(top, path.resolve(probe, target === probe ? '.' : target));
+  if (rel === '' || rel === '.')
+    refuse('IS a git worktree root — everything under it defaults to committable');
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--', rel], { cwd: top });
+  } catch {
+    refuse(`points inside the git worktree at ${top} at a path git does not ignore`);
   }
 }
 

--- a/scripts/cacbg/guard.mjs
+++ b/scripts/cacbg/guard.mjs
@@ -16,6 +16,12 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '.
 function gitEnv() {
   const env = { ...process.env, LC_ALL: 'C' };
   for (const k of Object.keys(env)) if (k.startsWith('GIT_')) delete env[k];
+  // Re-set AFTER the sweep: without it git stops repository discovery at filesystem boundaries, and a
+  // mount point INSIDE an outer worktree reports the accepted „not a repository" while that worktree
+  // can track the mounted path (review round 4, truncated finding). Forcing discovery across mounts
+  // keeps the every-containing-worktree walk honest. Untestable without root (a bind mount), so this
+  // line carries the reasoning instead of a fixture.
+  env.GIT_DISCOVERY_ACROSS_FILESYSTEM = '1';
   return env;
 }
 export const SCRATCH = path.join(ROOT, 'scratch', 'cacbg');
@@ -63,6 +69,15 @@ export function assertOverrideDirSafe(dir, name) {
     if (parent === probe) break;
     missing.unshift(path.basename(probe));
     probe = parent;
+  }
+  // Canonicalize BEFORE judging (review round 4, truncated finding): git already resolves symlinks for
+  // its own cwd, but the ignore verdict was being passed the LEXICAL name — an ignored symlink
+  // `scratch/leak` pointing at `scripts/` was judged as scratch/… while extraction wrote through it
+  // into committable files. Judging the resolved location closes that.
+  try {
+    probe = fs.realpathSync(probe);
+  } catch {
+    refuse('could not be verified (the existing ancestor could not be resolved)');
   }
   const target = path.join(probe, ...missing);
   // Git must answer for the FILESYSTEM location. An inherited GIT_DIR / GIT_WORK_TREE would let the

--- a/scripts/cacbg/guard.mjs
+++ b/scripts/cacbg/guard.mjs
@@ -8,6 +8,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// One environment for every git the rails spawn: inherited GIT_DIR / GIT_WORK_TREE would substitute a
+// DIFFERENT repository's answer for the filesystem's (review rounds 3-4 demonstrated it against both
+// rails), and LC_ALL=C pins git's messages to English — this machine runs bg_BG, where a localized
+// „not a git repository" would turn every legitimate outside-repo override into a refusal.
+function gitEnv() {
+  const env = { ...process.env, LC_ALL: 'C' };
+  for (const k of Object.keys(env)) if (k.startsWith('GIT_')) delete env[k];
+  return env;
+}
 export const SCRATCH = path.join(ROOT, 'scratch', 'cacbg');
 
 /**
@@ -20,7 +30,7 @@ export const SCRATCH = path.join(ROOT, 'scratch', 'cacbg');
 export function assertScratchIgnored(subdir = 'cacbg') {
   const probe = path.join('scratch', subdir, '.probe');
   try {
-    execFileSync('git', ['check-ignore', '-q', probe], { cwd: ROOT });
+    execFileSync('git', ['check-ignore', '-q', '--', probe], { cwd: ROOT, env: gitEnv() });
   } catch {
     throw new Error(
       `REFUSE TO RUN: ${probe} is not git-ignored — add scratch/ to .gitignore first (PII rail, spec §8)`,
@@ -58,8 +68,7 @@ export function assertOverrideDirSafe(dir, name) {
   // Git must answer for the FILESYSTEM location. An inherited GIT_DIR / GIT_WORK_TREE would let the
   // caller substitute another repository's ignore policy for the one that actually contains the path
   // (review round 3: reproduced — an alternate repo's exclude rules accepted a tracked sink/).
-  const env = { ...process.env };
-  for (const k of Object.keys(env)) if (k.startsWith('GIT_')) delete env[k];
+  const env = gitEnv();
   const gitTop = (cwd) => {
     try {
       return execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -88,6 +97,11 @@ export function assertOverrideDirSafe(dir, name) {
     const rel = path.relative(top, target);
     if (rel === '' || rel === '.')
       refuse('IS a git worktree root — everything under it defaults to committable');
+    // `./`-prefix the pathspec: `--` does NOT disable git's pathspec magic, so a directory literally
+    // named `:(top)scratch/…` is evaluated as MAGIC — resolving to an ignored path and certifying a
+    // committable one (review round 4; verified: check-ignore answers 0 for it). --literal-pathspecs is
+    // NOT usable here — check-ignore rejects the literal magic flag while still evaluating :(top) — but
+    // a leading ./ keeps the name a name for both commands (verified both directions).
     // TRACKED beats ignored. Ignore rules never apply to paths already in the index, and check-ignore
     // can even answer "ignored" for them (a nested repository makes everything beneath it implicitly
     // ignored — truthful for ADDING files, silent about ones tracked BEFORE the nested repo appeared;
@@ -95,7 +109,7 @@ export function assertOverrideDirSafe(dir, name) {
     // this worktree's index, modifications are committable regardless of every pattern.
     let tracked;
     try {
-      tracked = execFileSync('git', ['ls-files', '-z', '--', rel], {
+      tracked = execFileSync('git', ['ls-files', '-z', '--', `./${rel}`], {
         cwd: top,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -108,7 +122,7 @@ export function assertOverrideDirSafe(dir, name) {
     if (tracked.length > 0)
       refuse(`overlaps files TRACKED in the git worktree at ${top} — already committable`);
     try {
-      execFileSync('git', ['check-ignore', '-q', '--', rel], {
+      execFileSync('git', ['check-ignore', '-q', '--', `./${rel}`], {
         cwd: top,
         env,
         stdio: ['ignore', 'ignore', 'pipe'],

--- a/scripts/cacbg/guard.mjs
+++ b/scripts/cacbg/guard.mjs
@@ -27,6 +27,30 @@ export function assertScratchIgnored(subdir = 'cacbg') {
   }
 }
 
+/**
+ * The same PII rail for an OVERRIDDEN output directory (the CACBG_RAW / CACBG_STAGING test seams).
+ * assertScratchIgnored probes the fixed scratch/ location, so a caller that redirects its I/O elsewhere
+ * would sail past it — the review demonstrated extract writing related.jsonl (third-party names) into a
+ * TRACKED directory via CACBG_STAGING. The rule an override must satisfy is the same one scratch/
+ * satisfies: nothing PII may land where git can commit it. So: outside the repository entirely (temp
+ * dirs — where every test points) is fine; inside it, the directory must be git-ignored.
+ * @param {string} dir absolute or relative path the override points at
+ * @param {string} name the env var being validated, for the error message
+ */
+export function assertOverrideDirSafe(dir, name) {
+  const abs = path.resolve(dir);
+  if (!abs.startsWith(ROOT + path.sep)) return; // outside the repo — git cannot commit it
+  const rel = path.relative(ROOT, abs);
+  try {
+    execFileSync('git', ['check-ignore', '-q', rel], { cwd: ROOT });
+  } catch {
+    throw new Error(
+      `REFUSE TO RUN: ${name}=${dir} points inside the repository at a path git does not ignore — ` +
+        `PII output must never be committable (PII rail, spec §8)`,
+    );
+  }
+}
+
 // Path-sanitize an xml_file / year from the untrusted list.xml before using it in a filesystem path
 // or URL. Rejects traversal, absolute paths, and anything outside the expected shape.
 // The shape of a real declaration filename. Single source of truth for both the throwing guard below


### PR DESCRIPTION
## Какво

Печат за пълнота до суровия корпус. `fetch.mjs` го пише **само** когато корпусът се сверява с описа на
регистъра, и го чисти в началото на всяко обхождане. `extract.mjs` отказва да извлича без него.

Затваря дупката, отбелязана при ревюто на #313, но неподадена като issue.

## Защо

#313 направи частичния корпус **очаквано** състояние - краулът спира сам на срока и запазва каквото има,
което е и причината студен корпус да завършва за два хода вместо никога. Но:

- `restore-keys: cacbg-raw-` връща най-**скорошния** запис, не най-**пълния** - няма как да ги различи;
- `extract.mjs` изброява файловете с `readdirSync` и **никога не ги сверява с `list.xml`**, макар да чете
  описа за друго (контекста на лицето).

Тоест отрязан корпус даваше по-малка публикувана повърхност, без грешка никъде.

Конкретният път: ход с `full_crawl=true` удря срока на 29 от 37 набора и запазва частичен кеш → месечният
cron се задейства с `full_crawl` празно (тоест false, по замисъл) → възстановява се най-скорошният кеш,
частичният → повърхността се преизчислява без 2015-2019 и се публикува.

**Нито един съществуващ гейт не го хваща.** Гейтът за монотонност сравнява с предишната повърхност и вижда
нетен ръст, щом новите връзки надвишат загубените - точно каквото стана вчера (103 → 277); тихото
недопубликуване се крие вътре. Подът `--min-links 250` брои, тоест отрязан корпус с 260 връзки минава. А
първо пускане в нова среда няма база за сравнение изобщо - гейтът сам казва "first run" и пропуска.

## Поправката

**Пишещата страна.** Печатът се чисти ПРЕДИ обхождането и се пише само при сверена присъда. Чистенето в
началото значи, че всеки ненормален изход - спиране по срок, прекъсвач, необработена грешка, убит
изпълнител - оставя корпуса неподпечатан, без да му трябва собствен път за почистване.

**Четящата страна.** `extract.mjs` отказва без печат и назовава `--allow-partial-corpus`. Значението е
разделено на две: частичният кеш остава напълно годен за **продължаване** (следващият крал прескача
каквото е на диска), но негоден за **публикуване**.

**`--allow-incomplete` не подпечатва.** Този флаг записва, че оператор е ВИДЯЛ недостига и го е приел -
приемането е негово и не бива да пътува към следващ ненаблюдаван ход. Това го открих от тест, не по
замисъл: първата версия подпечатваше, защото просто стигаше до същия ред.

`extract.mjs` получава `CACBG_RAW`/`CACBG_STAGING` по модела на `load.mjs`, за да е тестваем; по
подразбиране сочи истинския scratch, тоест поведението не се променя.

## Тестове

Шест нови, покриват двете страни: подпечатване при сверен корпус, липса на печат при спиране по срок,
липса при `--allow-incomplete`, изчистване на стар печат при провалено обхождане, отказ при четене, и
преминаване при подпечатан корпус.

Убиват три мутанта:

| мутант | резултат |
|---|---|
| печат без проверка на присъдата | 1 тест пада |
| без чистене в началото | 1 тест пада |
| махнат гейт в `extract.mjs` | 1 тест пада |

Целият пакет `scripts/cacbg` + `scripts/tr`: 313 минават.

## Ефект върху сегашния конвейер

Никакъв при нормален ход - краулът и извличането са в едно пускане, тоест печатът е пресен. Промяната се
усеща само там, където и трябва: ход, който НЕ обхожда, върху кеш от недовършено обхождане.
