### PR TITLE
fix(cacbg): ретрай на четенето на броевете след ship, не фалшив провал

### DIFF
--- a/scripts/ship-related-persons.mjs
+++ b/scripts/ship-related-persons.mjs
@@ -300,30 +300,39 @@ export function parseWranglerJson(out) {
 // shipped — and skipped the reindex behind it (observed on runs 32775600033 and 33207492181). The guard
 // is right to fail closed; the READ under it must not turn one flaky call into a false verdict.
 //
-// The distinction the retry rests on: `attempt()` throwing, or returning an answer missing any expected
-// table, is a TRANSIENT read failure — retry it. A complete answer whose numbers disagree is a REAL
-// drift — return it unchanged so assertShippedCounts catches it. A genuinely empty table counts as 0
-// (a number), so a real partial ship is never mistaken for a transient miss. Pure; `attempt`/`sleep`
-// injected, so the retry logic is unit-tested without touching wrangler.
-export function readCountsWithRetry(attempt, tables, { attempts = 4, sleep = () => {} } = {}) {
+// The distinction the retry rests on: `attempt()` throwing, or returning an answer where any expected
+// table is not a non-negative integer (missing, NaN, string, null), is a TRANSIENT read failure — retry
+// it. A complete answer whose numbers disagree is a REAL drift — return it unchanged so
+// assertShippedCounts catches it. A genuinely empty table counts as 0 (a non-negative integer), so a real
+// partial ship is never mistaken for a transient miss. Pure; `attempt`/`sleep` injected, so the retry
+// logic is unit-tested without touching wrangler. `sleep` defaults to the REAL synchronous sleeper — the
+// backoff must fire in production, where the whole point is to ride out a transient outage; a degenerate
+// `attempts` (0, negative, NaN, fractional, Infinity) falls back to the default 4 rather than making zero
+// attempts or looping forever.
+export function readCountsWithRetry(attempt, tables, { attempts = 4, sleep = sleepSync } = {}) {
+  const budget = Number.isInteger(attempts) && attempts > 0 ? attempts : 4;
   let lastErr;
-  for (let i = 0; i < attempts; i++) {
+  for (let i = 0; i < budget; i++) {
     if (i > 0) sleep(2000 * i);
     try {
       const counts = attempt();
-      if (tables.every((t) => typeof counts[t] === 'number')) return counts;
+      if (tables.every((t) => Number.isInteger(counts[t]) && counts[t] >= 0)) return counts;
       lastErr = new Error('readback returned an incomplete answer');
     } catch (err) {
       lastErr = err instanceof Error ? err : new Error(String(err));
     }
   }
   console.error(
-    `ship: could not read back row counts after ${attempts} attempts — ${lastErr?.message ?? lastErr}`,
+    `ship: could not read back row counts after ${budget} attempts — ${lastErr?.message ?? lastErr}`,
   );
   return {};
 }
 
-function readShippedCounts(d1Name, remote, expected) {
+// `deps` is a TEST SEAM: prod passes nothing, so `readOnce` is the live wrangler read, `sleep` falls
+// through to the helper's real `sleepSync`, and `attempts` to its default 4. Tests inject a fake reader,
+// a recording sleep, and a small budget to pin the retry WIRING — that readShippedCounts actually wraps
+// the read in readCountsWithRetry with a real backoff, and not a one-shot — without touching wrangler.
+export function readShippedCounts(d1Name, remote, expected, deps = {}) {
   const tables = Object.entries(expected)
     .filter(([, n]) => typeof n === 'number')
     .map(([t]) => t);
@@ -331,23 +340,28 @@ function readShippedCounts(d1Name, remote, expected) {
   const sql = tables
     .map((t) => `SELECT ${sqlLiteral(t)} AS t, COUNT(*) AS n FROM ${sqlIdent(t)}`)
     .join(' UNION ALL ');
-  return readCountsWithRetry(() => {
-    const out = execFileSync(
-      'wrangler',
-      ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
-      { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
-    );
-    // `wrangler d1 execute --json` writes its notices („▲ [WARNING] Processing wrangler.jsonc") to
-    // STDERR and leaves stdout as clean JSON, and execFileSync returns stdout alone, so slicing from
-    // the first '[' is safe today. The scan survives a future release that changes that, at one failed
-    // parse if it does.
-    const parsed = parseWranglerJson(out);
-    const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
-    // Only a real number counts as an answer. `Number(null)` is 0, which would let a null-valued cell
-    // pass for „the table is empty"; anything non-numeric lands as NaN so the retry treats it as an
-    // incomplete answer and assertShippedCounts fails closed if it is the final one.
-    return Object.fromEntries(rows.map((r) => [r.t, typeof r.n === 'number' ? r.n : Number.NaN]));
-  }, tables);
+  const readOnce =
+    deps.readOnce ??
+    (() => {
+      const out = execFileSync(
+        'wrangler',
+        ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
+        { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+      );
+      // `wrangler d1 execute --json` writes its notices („▲ [WARNING] Processing wrangler.jsonc") to
+      // STDERR and leaves stdout as clean JSON, and execFileSync returns stdout alone, so slicing from
+      // the first '[' is safe today. The scan survives a future release that changes that, at one failed
+      // parse if it does.
+      const parsed = parseWranglerJson(out);
+      const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
+      // Only a non-negative integer counts as an answer. `Number(null)` is 0, which would let a
+      // null-valued cell pass for „the table is empty"; anything non-numeric lands as NaN so the retry
+      // treats it as an incomplete answer and assertShippedCounts fails closed if it is the final one.
+      return Object.fromEntries(rows.map((r) => [r.t, typeof r.n === 'number' ? r.n : Number.NaN]));
+    });
+  // Pass `sleep`/`attempts` through only when a test overrides them; undefined lets the helper defaults
+  // (the real sleepSync, 4 attempts) apply — so production always gets the backoff.
+  return readCountsWithRetry(readOnce, tables, { sleep: deps.sleep, attempts: deps.attempts });
 }
 
 function resolveD1Id(d1Name) {

--- a/scripts/ship-related-persons.mjs
+++ b/scripts/ship-related-persons.mjs
@@ -294,6 +294,35 @@ export function parseWranglerJson(out) {
   return JSON.parse(out); // no usable bracket: let the original parse error surface
 }
 
+// Retry the readback around a single-attempt reader. `wrangler d1 execute --remote --json` is a live
+// network call that intermittently times out or errors transiently; when it did, readShippedCounts
+// returned {} and assertShippedCounts then failed the WHOLE run — falsely, over data that had actually
+// shipped — and skipped the reindex behind it (observed on runs 32775600033 and 33207492181). The guard
+// is right to fail closed; the READ under it must not turn one flaky call into a false verdict.
+//
+// The distinction the retry rests on: `attempt()` throwing, or returning an answer missing any expected
+// table, is a TRANSIENT read failure — retry it. A complete answer whose numbers disagree is a REAL
+// drift — return it unchanged so assertShippedCounts catches it. A genuinely empty table counts as 0
+// (a number), so a real partial ship is never mistaken for a transient miss. Pure; `attempt`/`sleep`
+// injected, so the retry logic is unit-tested without touching wrangler.
+export function readCountsWithRetry(attempt, tables, { attempts = 4, sleep = () => {} } = {}) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    if (i > 0) sleep(2000 * i);
+    try {
+      const counts = attempt();
+      if (tables.every((t) => typeof counts[t] === 'number')) return counts;
+      lastErr = new Error('readback returned an incomplete answer');
+    } catch (err) {
+      lastErr = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  console.error(
+    `ship: could not read back row counts after ${attempts} attempts — ${lastErr?.message ?? lastErr}`,
+  );
+  return {};
+}
+
 function readShippedCounts(d1Name, remote, expected) {
   const tables = Object.entries(expected)
     .filter(([, n]) => typeof n === 'number')
@@ -302,28 +331,23 @@ function readShippedCounts(d1Name, remote, expected) {
   const sql = tables
     .map((t) => `SELECT ${sqlLiteral(t)} AS t, COUNT(*) AS n FROM ${sqlIdent(t)}`)
     .join(' UNION ALL ');
-  try {
+  return readCountsWithRetry(() => {
     const out = execFileSync(
       'wrangler',
       ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
       { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
     );
-    // Defensive, NOT a fix for an observed failure — the earlier wording here claimed otherwise and
-    // was wrong. Checked against the real tool: `wrangler d1 execute --json` writes its notices
-    // („▲ [WARNING] Processing wrangler.jsonc") to STDERR and leaves stdout as clean JSON, and
-    // execFileSync returns stdout alone, so slicing from the first '[' is in fact safe today. The
-    // scan below survives a future release that changes that, and costs one failed parse if it does.
+    // `wrangler d1 execute --json` writes its notices („▲ [WARNING] Processing wrangler.jsonc") to
+    // STDERR and leaves stdout as clean JSON, and execFileSync returns stdout alone, so slicing from
+    // the first '[' is safe today. The scan survives a future release that changes that, at one failed
+    // parse if it does.
     const parsed = parseWranglerJson(out);
     const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
-    // Only a real number counts as an answer. `Number(null)` is 0, which would let a null-valued cell pass
-    // for „the table is empty"; anything non-numeric must land as NaN so assertShippedCounts fails closed.
+    // Only a real number counts as an answer. `Number(null)` is 0, which would let a null-valued cell
+    // pass for „the table is empty"; anything non-numeric lands as NaN so the retry treats it as an
+    // incomplete answer and assertShippedCounts fails closed if it is the final one.
     return Object.fromEntries(rows.map((r) => [r.t, typeof r.n === 'number' ? r.n : Number.NaN]));
-  } catch (err) {
-    console.error(
-      `ship: could not read back row counts — ${err instanceof Error ? err.message : err}`,
-    );
-    return {};
-  }
+  }, tables);
 }
 
 function resolveD1Id(d1Name) {

--- a/scripts/ship-related-persons.test.mjs
+++ b/scripts/ship-related-persons.test.mjs
@@ -11,6 +11,7 @@ import {
   runShip,
   assertShippedCounts,
   readCountsWithRetry,
+  readShippedCounts,
   sqlLiteral,
   sqlIdent,
   TABLES,
@@ -301,6 +302,129 @@ test('readCountsWithRetry backs off between attempts', () => {
     [2000, 4000],
     'linear backoff before attempts 2 and 3, none before the first',
   );
+});
+
+test('readCountsWithRetry does NOT back off after the FINAL failed attempt', () => {
+  // The exhaustion path: 3 attempts, all failing, must sleep only BETWEEN them (before 2 and 3), never
+  // after the last — a trailing sleep burns 6s before returning {} for nothing. The success-path backoff
+  // test above cannot see this; only a fully-failing run does.
+  const waits = [];
+  const attempt = () => {
+    throw new Error('sustained failure');
+  };
+  readCountsWithRetry(attempt, RC_TABLES, { attempts: 3, sleep: (ms) => waits.push(ms) });
+  assert.deepEqual(waits, [2000, 4000], 'two sleeps for three attempts, none trailing the last');
+});
+
+test('readCountsWithRetry retries a NON-FINITE cell (NaN / string / null), not just a missing table', () => {
+  // A present-but-malformed cell is what `typeof x === "number"` let slip: `typeof NaN === "number"` is
+  // true, so a NaN (from a non-numeric wrangler cell) was accepted as an answer instead of retried. Each
+  // of these must be treated as an incomplete answer — a row count is a non-negative integer or nothing.
+  for (const bad of [Number.NaN, '2', null, 2.5, -1, Infinity]) {
+    let calls = 0;
+    const attempt = () => {
+      calls += 1;
+      return calls < 2 ? { persons: 3, interest_links: bad } : { persons: 3, interest_links: 2 };
+    };
+    const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: 3, sleep: () => {} });
+    assert.deepEqual(out, { persons: 3, interest_links: 2 }, `retried past ${String(bad)}`);
+    assert.equal(calls, 2, `a non-finite ${String(bad)} must not count as an answer`);
+  }
+});
+
+test('readCountsWithRetry defaults to 4 attempts (not 1) when none is given', () => {
+  // Pins the default budget: a mutant lowering it to 1 would give up after the first throw and return {}.
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    if (calls < 4) throw new Error('transient');
+    return { persons: 1, interest_links: 1 };
+  };
+  const out = readCountsWithRetry(attempt, RC_TABLES, { sleep: () => {} }); // no `attempts`
+  assert.deepEqual(out, { persons: 1, interest_links: 1 });
+  assert.equal(calls, 4, 'the default budget must be 4, so it recovers on the fourth try');
+});
+
+test('readCountsWithRetry treats a degenerate `attempts` as the default 4, never 0 or forever', () => {
+  // 0 / negative / NaN / fraction would make ZERO attempts (return {} having never read); Infinity would
+  // loop forever. All must fall back to 4 — so a persistent failure terminates at exactly 4 reads.
+  for (const bad of [0, -3, Number.NaN, 2.5, Infinity]) {
+    let calls = 0;
+    const attempt = () => {
+      calls += 1;
+      throw new Error('sustained failure');
+    };
+    const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: bad, sleep: () => {} });
+    assert.deepEqual(out, {}, `degenerate ${String(bad)} still fails closed`);
+    assert.equal(calls, 4, `degenerate ${String(bad)} must run exactly the default 4 attempts`);
+  }
+});
+
+test('readCountsWithRetry uses a REAL sleep by default — the backoff must fire in production', () => {
+  // Finding 1's regression guard. Every other test injects a no-op sleep, so a mutant reverting the
+  // default `sleep = sleepSync` back to `() => {}` would slip past them all. With no sleep injected, one
+  // transient failure must cost a real ~2s backoff before the recovering read — proof the default blocks.
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    if (calls < 2) throw new Error('transient');
+    return { persons: 1, interest_links: 1 };
+  };
+  const started = Date.now();
+  const out = readCountsWithRetry(attempt, RC_TABLES); // no options at all → real sleepSync, 4 attempts
+  const elapsed = Date.now() - started;
+  assert.deepEqual(out, { persons: 1, interest_links: 1 });
+  assert.ok(elapsed >= 1900, `expected a real ~2s backoff, waited only ${elapsed}ms`);
+});
+
+// ── readShippedCounts — the PRODUCTION wiring, not just the helper in isolation ──────────────────────
+// Codex flagged that the tests exercised readCountsWithRetry directly but nothing pinned that
+// readShippedCounts actually wraps its wrangler read in that retry with a real backoff. The `deps` seam
+// injects a fake reader + recording sleep so these run without touching wrangler.
+const RS_EXPECTED = { persons: 3, interest_links: 2 };
+
+test('readShippedCounts wraps the read in a retry with real backoff — not a one-shot', () => {
+  // Kills the mutant that reverts readShippedCounts to a single wrangler call: a one-shot would return the
+  // first (failing) read; the wiring must retry past two transient failures and forward the 2s/4s schedule.
+  const waits = [];
+  let calls = 0;
+  const readOnce = () => {
+    calls += 1;
+    if (calls < 3) throw new Error('Command failed: wrangler d1 execute (timeout)');
+    return { persons: 3, interest_links: 2 };
+  };
+  const out = readShippedCounts('sigma-db', true, RS_EXPECTED, {
+    readOnce,
+    sleep: (ms) => waits.push(ms),
+  });
+  assert.deepEqual(out, { persons: 3, interest_links: 2 });
+  assert.equal(calls, 3, 'readShippedCounts must retry the read, not call it once');
+  assert.deepEqual(waits, [2000, 4000], 'and forward the real linear backoff');
+});
+
+test('readShippedCounts inherits the default 4-attempt budget', () => {
+  // No `attempts` in deps → the helper default (4) must apply through the wiring, so it recovers on the 4th.
+  let calls = 0;
+  const readOnce = () => {
+    calls += 1;
+    if (calls < 4) throw new Error('transient');
+    return { persons: 3, interest_links: 2 };
+  };
+  const out = readShippedCounts('sigma-db', true, RS_EXPECTED, { readOnce, sleep: () => {} });
+  assert.deepEqual(out, { persons: 3, interest_links: 2 });
+  assert.equal(calls, 4);
+});
+
+test('readShippedCounts short-circuits to {} when nothing was expected', () => {
+  // No numeric expectations → no tables to read → no wrangler call at all.
+  let calls = 0;
+  const readOnce = () => {
+    calls += 1;
+    return {};
+  };
+  const out = readShippedCounts('sigma-db', true, {}, { readOnce, sleep: () => {} });
+  assert.deepEqual(out, {});
+  assert.equal(calls, 0, 'an empty expectation must never touch the reader');
 });
 
 test('assertShippedCounts fails on a short table and names the numbers', () => {

--- a/scripts/ship-related-persons.test.mjs
+++ b/scripts/ship-related-persons.test.mjs
@@ -10,6 +10,7 @@ import {
   chunkStatements,
   runShip,
   assertShippedCounts,
+  readCountsWithRetry,
   sqlLiteral,
   sqlIdent,
   TABLES,
@@ -232,6 +233,73 @@ test('chunkStatements refuses a non-positive size rather than looping forever', 
 test('assertShippedCounts passes when the target holds exactly what was shipped', () => {
   assert.doesNotThrow(() =>
     assertShippedCounts({ persons: 3, interest_links: 2 }, { persons: 3, interest_links: 2 }),
+  );
+});
+
+// ── readCountsWithRetry — a flaky live readback must not become a false verdict ──────────────────────
+// The readback is `wrangler d1 execute --remote --json`, a network call that intermittently times out.
+// When it did, the run FAILED over data that had actually shipped, and skipped the reindex behind it
+// (runs 32775600033, 33207492181). These pin: transient failures retry, real drift passes through.
+const RC_TABLES = ['persons', 'interest_links'];
+
+test('readCountsWithRetry returns the answer once a transient failure clears', () => {
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    if (calls < 3) throw new Error('Command failed: wrangler d1 execute (timeout)');
+    return { persons: 3, interest_links: 2 };
+  };
+  const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: 4, sleep: () => {} });
+  assert.deepEqual(out, { persons: 3, interest_links: 2 });
+  assert.equal(calls, 3, 'it must keep trying, not give up on the first throw');
+});
+
+test('readCountsWithRetry retries an INCOMPLETE answer (a table missing), not just a throw', () => {
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    return calls < 2 ? { persons: 3 } : { persons: 3, interest_links: 2 }; // interest_links missing first
+  };
+  const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: 3, sleep: () => {} });
+  assert.deepEqual(out, { persons: 3, interest_links: 2 });
+  assert.equal(calls, 2);
+});
+
+test('readCountsWithRetry returns {} after exhausting attempts — the guard still fails closed', () => {
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    throw new Error('sustained failure');
+  };
+  const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: 3, sleep: () => {} });
+  assert.deepEqual(out, {}, 'a genuinely unreadable target yields {} so assertShippedCounts fails');
+  assert.equal(calls, 3, 'it must exhaust exactly the budget');
+});
+
+test('readCountsWithRetry does NOT retry a COMPLETE answer that disagrees — real drift passes through', () => {
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    return { persons: 3, interest_links: 0 }; // a real partial ship: 0 is a number, a complete answer
+  };
+  const out = readCountsWithRetry(attempt, RC_TABLES, { attempts: 4, sleep: () => {} });
+  assert.deepEqual(out, { persons: 3, interest_links: 0 });
+  assert.equal(calls, 1, 'a complete answer must be returned immediately, drift or not');
+});
+
+test('readCountsWithRetry backs off between attempts', () => {
+  const waits = [];
+  let calls = 0;
+  const attempt = () => {
+    calls += 1;
+    if (calls < 3) throw new Error('transient');
+    return { persons: 1, interest_links: 1 };
+  };
+  readCountsWithRetry(attempt, RC_TABLES, { attempts: 4, sleep: (ms) => waits.push(ms) });
+  assert.deepEqual(
+    waits,
+    [2000, 4000],
+    'linear backoff before attempts 2 and 3, none before the first',
   );
 });
 


### PR DESCRIPTION
## Какво

`assertShippedCounts` е прав да пада затворено при частичен ship. Но четенето под него -
`wrangler d1 execute --remote --json` - е жива мрежова заявка, която понякога изтича. `readCountsWithRetry`
обгражда единичния опит с ретрай.

## Защо

Наблюдавано на **два** пълни хода към staging (`32775600033`, `33207492181`): и двата записаха
повърхността успешно (staging държи данните - проверено), одитът мина чисто, но браузящата стъпка след
ship гръмна с:

```
ship: could not read back row counts — Command failed: wrangler d1 execute ...
Error: ship verification FAILED — the target does not hold what was shipped:
  persons: shipped 14703, target has no answer
  ...
```

`wrangler` изтече, `readShippedCounts` върна `{}`, и `assertShippedCounts` отчете „target has no answer"
за всяка таблица. Резултат: ходът става **червен върху успешно записани данни** и прескача `Reindex`-а зад
него - тоест `search_index.official` остава изостанал. Всеки път се налага ръчно доизкарване.

## Поправката

Заздравява четенето, не разхлабва guard-а. Разграничението:

- хвърлен опит, или отговор без някоя очаквана таблица → **преходен** провал → ретрай (линеен backoff)
- пълен отговор, чиито числа не съвпадат → **реален** drift → връща се непроменен, `assertShippedCounts`
  го хваща
- празна таблица е `0` (число) → истински частичен ship никога не се бърка с преходна липса
- изтощят ли се опитите → `{}`, guard-ът пак пада затворено

## Тестове

5 нови в `ship-related-persons.test.mjs`: преходен провал се изчиства, непълен отговор ретрайва, реален
drift минава без ретрай, изтощени опити дават `{}`, backoff-ът е линеен. `attempt`/`sleep` се инжектират,
тоест ретрай логиката е покрита без да се докосва wrangler. Убиват два мутанта (изключен ретрай,
изпусната проверка за пълнота). Целият ship пакет: 40.

Нулева промяна в поведението на успешния път (един опит, успява веднага) и в строгостта на guard-а.
