### PR TITLE
fix(cacbg): четенето след ship да се дели под лимита на локалния engine

### DIFF
--- a/scripts/ship-e2e.test.mjs
+++ b/scripts/ship-e2e.test.mjs
@@ -21,6 +21,7 @@ import {
   MAX_BATCH_ROWS,
   MAX_STATEMENTS_PER_REQUEST,
   PACE_MS,
+  READBACK_MAX_TABLES,
   TABLES,
 } from './ship-related-persons.mjs';
 
@@ -250,16 +251,35 @@ test('a real ship run leaves the target holding exactly what the work DB held', 
     Array.from({ length: nums.length }, (_, i) => i + 1),
   );
 
-  // The read-back must be the LAST thing the run does, and must count each table from that table.
-  const last = calls.at(-1);
-  assert.ok(last.argv.includes('--command'), 'the read-back must come after the inserts');
-  const sql = last.argv[last.argv.indexOf('--command') + 1];
+  // The read-back must be the LAST thing the run does, and must count each table from that table. It is
+  // no longer ONE query: against a local target the counts are split into chunks, because workerd caps a
+  // compound SELECT at 5 terms and the ship writes six tables. So the tail of the call list is one or
+  // more count queries, and it is their UNION that has to cover every table.
+  const readback = [];
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const ci = calls[i].argv.indexOf('--command');
+    if (ci === -1) break;
+    const q = calls[i].argv[ci + 1];
+    if (!/COUNT\(\*\) AS n FROM/.test(q)) break;
+    readback.unshift(q);
+  }
+  assert.ok(readback.length > 0, 'the read-back must come after the inserts');
+  const sql = readback.join('\n');
   for (const table of TABLES)
     assert.match(
       sql,
       new RegExp(`COUNT\\(\\*\\) AS n FROM "${table}"`),
       `${table} not really counted`,
     );
+  // …and no single query may cross the local engine's cap, which is the whole point of the split: one
+  // over-wide query comes back as an error object, and every table then reads as „no answer".
+  for (const q of readback) {
+    const terms = (q.match(/COUNT\(\*\) AS n FROM/g) ?? []).length;
+    assert.ok(
+      terms <= READBACK_MAX_TABLES,
+      `a read-back query counted ${terms} tables — over the ${READBACK_MAX_TABLES}-table cap`,
+    );
+  }
 });
 
 test('a request that never landed fails the run', (t) => {

--- a/scripts/ship-related-persons.mjs
+++ b/scripts/ship-related-persons.mjs
@@ -73,6 +73,17 @@ export function chunkStatements(statements, maxPerRequest = MAX_STATEMENTS_PER_R
   return chunks;
 }
 
+/**
+ * Define an OWN property, never assign. `obj[k] = v` runs an inherited setter if Object.prototype
+ * carries one for that name, and a hostile or merely broken setter can then swallow the write (leaving
+ * no own entry, so `Object.entries` skips the table entirely) or define entries for keys nobody wrote.
+ * Both the ship summary and the readback merge feed the verification guard, so both must own what they
+ * record — otherwise a table can vanish from the comparison instead of failing it.
+ */
+function setOwn(obj, key, value) {
+  Object.defineProperty(obj, key, { value, enumerable: true, writable: true, configurable: true });
+}
+
 /** Block the (synchronous) ship loop without burning CPU. */
 const sleepSync = (ms) => {
   if (ms > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
@@ -111,10 +122,10 @@ export function runShip({
   for (const table of tables) {
     const read = readTable(table);
     if (!read) {
-      summary[table] = 'absent (skipped)';
+      setOwn(summary, table, 'absent (skipped)');
       continue;
     }
-    summary[table] = read.rowCount;
+    setOwn(summary, table, read.rowCount);
     const chunks = chunkStatements(read.statements, maxStatements);
     chunks.forEach((chunk, i) =>
       applyPaced(chunks.length > 1 ? `${table}.${i + 1}` : table, chunk.join('')),
@@ -316,7 +327,14 @@ export function readCountsWithRetry(attempt, tables, { attempts = 4, sleep = sle
     if (i > 0) sleep(2000 * i);
     try {
       const counts = attempt();
-      if (tables.every((t) => Number.isInteger(counts[t]) && counts[t] >= 0)) return counts;
+      // Object.hasOwn, not a bare lookup: a polluted Object.prototype would otherwise let an INHERITED
+      // integer stand in for a count the target never reported.
+      if (
+        tables.every(
+          (t) => Object.hasOwn(counts, t) && Number.isInteger(counts[t]) && counts[t] >= 0,
+        )
+      )
+        return counts;
       lastErr = new Error('readback returned an incomplete answer');
     } catch (err) {
       lastErr = err instanceof Error ? err : new Error(String(err));
@@ -328,40 +346,102 @@ export function readCountsWithRetry(attempt, tables, { attempts = 4, sleep = sle
   return {};
 }
 
+// How many tables one readback query may cover. The readback asks for every shipped table at once, as
+// `SELECT … UNION ALL SELECT …` — one term per table. SQLite caps the terms in a compound SELECT
+// (SQLITE_MAX_COMPOUND_SELECT); the stock limit is 500, but BOTH D1 runtimes cap it at 5. Measured on
+// each, not assumed — five terms answer, six return `too many terms in compound SELECT: SQLITE_ERROR`;
+// locally through `wrangler d1 execute --local` (workerd) and remotely against a staging database. The
+// terms need not touch a table: `SELECT 1 UNION ALL …` trips it just the same, so this is the engine's
+// limit and not a property of what we ship.
+//
+// The ship writes six tables. So the readback did not fail to READ, it failed to PARSE: wrangler
+// returned an error object, no row carried a count, and the guard reported „target has no answer" for
+// EVERY table — over data that had just shipped correctly — and the run died before the reindex behind
+// it. Exactly the false verdict #335 removed from the flaky-network path, arriving through a different
+// door: not a timeout, a query neither engine will ever accept.
+//
+// That is also why the scheduled workflow had been red at this step since the sixth table landed
+// (#309, 2026-08-14): every run after it failed here, and the 2026-08-31 run — with #335's retries in
+// place — burned all four attempts on the same rejection. A deterministic parse error does not heal
+// with backoff; only splitting the query does.
+//
+// Four leaves room under the measured 5 for a table to be added without silently re-crossing the line.
+export const READBACK_MAX_TABLES = 4;
+
+/** Split into runs of at most `size`, order preserved. Exported so the chunking itself is testable. */
+export function chunkTables(tables, size = READBACK_MAX_TABLES) {
+  const width = Number.isInteger(size) && size > 0 ? size : READBACK_MAX_TABLES;
+  const out = [];
+  for (let i = 0; i < tables.length; i += width) out.push(tables.slice(i, i + width));
+  return out;
+}
+
 // `deps` is a TEST SEAM: prod passes nothing, so `readOnce` is the live wrangler read, `sleep` falls
 // through to the helper's real `sleepSync`, and `attempts` to its default 4. Tests inject a fake reader,
 // a recording sleep, and a small budget to pin the retry WIRING — that readShippedCounts actually wraps
 // the read in readCountsWithRetry with a real backoff, and not a one-shot — without touching wrangler.
+// `readOnce` receives the group it is being asked about, so a test can answer per chunk.
 export function readShippedCounts(d1Name, remote, expected, deps = {}) {
   const tables = Object.entries(expected)
     .filter(([, n]) => typeof n === 'number')
     .map(([t]) => t);
   if (!tables.length) return {};
-  const sql = tables
-    .map((t) => `SELECT ${sqlLiteral(t)} AS t, COUNT(*) AS n FROM ${sqlIdent(t)}`)
-    .join(' UNION ALL ');
-  const readOnce =
-    deps.readOnce ??
-    (() => {
-      const out = execFileSync(
-        'wrangler',
-        ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
-        { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
-      );
-      // `wrangler d1 execute --json` writes its notices („▲ [WARNING] Processing wrangler.jsonc") to
-      // STDERR and leaves stdout as clean JSON, and execFileSync returns stdout alone, so slicing from
-      // the first '[' is safe today. The scan survives a future release that changes that, at one failed
-      // parse if it does.
-      const parsed = parseWranglerJson(out);
-      const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
-      // Only a non-negative integer counts as an answer. `Number(null)` is 0, which would let a
-      // null-valued cell pass for „the table is empty"; anything non-numeric lands as NaN so the retry
-      // treats it as an incomplete answer and assertShippedCounts fails closed if it is the final one.
-      return Object.fromEntries(rows.map((r) => [r.t, typeof r.n === 'number' ? r.n : Number.NaN]));
+  const counts = {};
+  // BOTH targets split. An earlier revision kept the remote path on a single query, on the assumption
+  // that only workerd capped compound SELECT — measuring the remote showed the same cap of 5, which is
+  // precisely why the scheduled ship had been failing verification since the sixth table. The split
+  // costs the remote path one extra invocation and gives up a single-snapshot read; nothing writes to
+  // these tables during verification (the ship itself is the only writer, and the workflow serialises
+  // its runs), and a verification that cannot execute is worth less than one that reads in two parts.
+  const groups = chunkTables(tables);
+  // Each chunk retries on its own. A chunk that exhausts contributes nothing, so its tables are simply
+  // absent from the merged answer — which assertShippedCounts still reads as „no answer" and fails
+  // closed on. Splitting widens no hole: a partial ship is caught by the counts, not by the batching.
+  for (const group of groups) {
+    const sql = group
+      .map((t) => `SELECT ${sqlLiteral(t)} AS t, COUNT(*) AS n FROM ${sqlIdent(t)}`)
+      .join(' UNION ALL ');
+    const readOnce = deps.readOnce
+      ? () => deps.readOnce(group)
+      : () => {
+          const out = execFileSync(
+            'wrangler',
+            ['d1', 'execute', d1Name, remote ? '--remote' : '--local', '--json', '--command', sql],
+            { cwd: resolve('apps/web'), encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+          );
+          // `wrangler d1 execute --json` writes its notices („▲ [WARNING] Processing wrangler.jsonc") to
+          // STDERR and leaves stdout as clean JSON, and execFileSync returns stdout alone, so slicing
+          // from the first '[' is safe today. The scan survives a future release that changes that, at
+          // one failed parse if it does.
+          const parsed = parseWranglerJson(out);
+          const rows = (Array.isArray(parsed) ? parsed[0]?.results : parsed?.results) ?? [];
+          // Only a non-negative integer counts as an answer. `Number(null)` is 0, which would let a
+          // null-valued cell pass for „the table is empty"; anything non-numeric lands as NaN so the
+          // retry treats it as an incomplete answer and assertShippedCounts fails closed if it is final.
+          return Object.fromEntries(
+            rows.map((r) => [r.t, typeof r.n === 'number' ? r.n : Number.NaN]),
+          );
+        };
+    // Pass `sleep`/`attempts` through only when a test overrides them; undefined lets the helper
+    // defaults (the real sleepSync, 4 attempts) apply — so production always gets the backoff.
+    const answer = readCountsWithRetry(readOnce, group, {
+      sleep: deps.sleep,
+      attempts: deps.attempts,
     });
-  // Pass `sleep`/`attempts` through only when a test overrides them; undefined lets the helper defaults
-  // (the real sleepSync, 4 attempts) apply — so production always gets the backoff.
-  return readCountsWithRetry(readOnce, tables, { sleep: deps.sleep, attempts: deps.attempts });
+    // Take ONLY what this group was asked about. readCountsWithRetry validates the group's tables but
+    // hands back whatever the reader returned, so a reader answering beyond its group (a malformed
+    // response, an injected one) could seed a count for a table whose OWN group later dies — and the
+    // guard would then verify a table nobody successfully read. Fail-closed has to hold unconditionally,
+    // not just for well-behaved readers.
+    // defineProperty, not assignment: `counts[t] = …` runs a SETTER if Object.prototype carries one for
+    // that name, and a polluted setter could define own counts for tables no chunk ever read. Reading is
+    // already own-only (Object.hasOwn); writing has to be too, or the accumulator itself is the hole.
+    for (const t of group) {
+      if (!Object.hasOwn(answer, t)) continue;
+      setOwn(counts, t, answer[t]);
+    }
+  }
+  return counts;
 }
 
 function resolveD1Id(d1Name) {
@@ -390,7 +470,13 @@ function resolveD1Id(d1Name) {
 export function assertShippedCounts(expected, actual) {
   const drift = Object.entries(expected)
     .filter(([, n]) => typeof n === 'number')
-    .map(([table, n]) => ({ table, expected: n, actual: actual[table] }))
+    // Object.hasOwn: a table the readback never answered for must read as „no answer" even if a
+    // polluted Object.prototype would happily hand back a plausible integer.
+    .map(([table, n]) => ({
+      table,
+      expected: n,
+      actual: Object.hasOwn(actual, table) ? actual[table] : undefined,
+    }))
     .filter(({ expected: e, actual: a }) => a !== e);
   if (drift.length)
     throw new Error(
@@ -526,10 +612,10 @@ function main() {
       for (const table of TABLES) {
         const read = readTable(table);
         if (!read) {
-          summary[table] = 'absent (skipped)';
+          setOwn(summary, table, 'absent (skipped)');
           continue;
         }
-        summary[table] = read.rowCount;
+        setOwn(summary, table, read.rowCount);
         writeFileSync(resolve(emit, `${table}.sql`), read.statements.join(''));
       }
     } else {

--- a/scripts/ship-related-persons.test.mjs
+++ b/scripts/ship-related-persons.test.mjs
@@ -12,6 +12,8 @@ import {
   assertShippedCounts,
   readCountsWithRetry,
   readShippedCounts,
+  chunkTables,
+  READBACK_MAX_TABLES,
   sqlLiteral,
   sqlIdent,
   TABLES,
@@ -415,6 +417,254 @@ test('readShippedCounts inherits the default 4-attempt budget', () => {
   assert.equal(calls, 4);
 });
 
+// ── the readback must fit the LOCAL engine's compound-SELECT cap ────────────────────────────────────
+// The six shipped tables went out as one six-term UNION ALL. Remote D1 allows 500 terms; the local
+// runtime (workerd) allows 5 — measured: 5 answer, 6 return `too many terms in compound SELECT`. So a
+// local ship read back as „target has no answer" for every table, over data that had just shipped, and
+// the run died before the reindex. These pin the split that keeps every query under the cap.
+const SHIP_TABLES = [
+  'persons',
+  'declarations',
+  'declared_interests',
+  'interest_links',
+  'interest_link_evidence',
+  'interest_link_authorities',
+];
+const SHIP_EXPECTED = Object.fromEntries(SHIP_TABLES.map((t, i) => [t, i + 1]));
+
+test('chunkTables never emits a group wider than the cap, and loses no table', () => {
+  for (const n of [1, 4, 5, 6, 9]) {
+    const tables = SHIP_TABLES.concat(Array.from({ length: 9 }, (_, i) => `t${i}`)).slice(0, n);
+    const groups = chunkTables(tables);
+    assert.ok(
+      groups.every((g) => g.length <= READBACK_MAX_TABLES),
+      `a group exceeded ${READBACK_MAX_TABLES} for n=${n}`,
+    );
+    assert.deepEqual(groups.flat(), tables, `chunking dropped or reordered a table for n=${n}`);
+  }
+});
+
+test('readShippedCounts asks in chunks under the cap — never one six-table query', () => {
+  // The actual regression. A six-term readback is precisely what the local engine refuses.
+  const asked = [];
+  const readOnce = (group) => {
+    asked.push(group);
+    return Object.fromEntries(group.map((t) => [t, SHIP_EXPECTED[t]]));
+  };
+  const out = readShippedCounts('sigma', false, SHIP_EXPECTED, { readOnce, sleep: () => {} });
+  assert.ok(asked.length > 1, 'six tables must not be read in a single query');
+  assert.ok(
+    asked.every((g) => g.length <= READBACK_MAX_TABLES),
+    `a readback asked for more than ${READBACK_MAX_TABLES} tables at once`,
+  );
+  // Merged across chunks, the answer is still the whole picture — so the guard sees every table.
+  assert.deepEqual(out, SHIP_EXPECTED);
+  assert.deepEqual(
+    asked.flat(),
+    SHIP_TABLES,
+    'every shipped table must be asked about exactly once',
+  );
+});
+
+test('a chunk that never answers leaves ITS tables unanswered — the guard still fails closed', () => {
+  // Splitting must not soften the verdict: the tables in a dead chunk have to stay missing, so
+  // assertShippedCounts reports them rather than passing a partial ship.
+  const readOnce = (group) => {
+    if (group.includes('interest_link_evidence')) throw new Error('wrangler timeout');
+    return Object.fromEntries(group.map((t) => [t, SHIP_EXPECTED[t]]));
+  };
+  const out = readShippedCounts('sigma', false, SHIP_EXPECTED, {
+    readOnce,
+    sleep: () => {},
+    attempts: 2,
+  });
+  assert.equal(out.persons, 1, 'a healthy chunk must still report');
+  assert.ok(!('interest_link_evidence' in out), 'a dead chunk must not invent an answer');
+  assert.throws(
+    () => assertShippedCounts(SHIP_EXPECTED, out),
+    /interest_link_evidence: shipped 5, target has no answer/,
+  );
+});
+
+test('a REMOTE readback is chunked too — both engines cap compound SELECT at 5', () => {
+  // An earlier revision kept remote on one query, assuming only workerd capped compound SELECT. Measured
+  // against a staging database, the remote rejects six terms exactly like the local one — which is why
+  // the scheduled ship had been failing verification ever since the sixth table landed. Pinning this
+  // stops the „remote is different" assumption from coming back.
+  const asked = [];
+  const readOnce = (group) => {
+    asked.push(group);
+    return Object.fromEntries(group.map((t) => [t, SHIP_EXPECTED[t]]));
+  };
+  const out = readShippedCounts('sigma-stage-green', true, SHIP_EXPECTED, {
+    readOnce,
+    sleep: () => {},
+  });
+  assert.ok(
+    asked.length > 1,
+    'the remote path must split too — six terms are rejected there as well',
+  );
+  assert.ok(
+    asked.every((g) => g.length <= READBACK_MAX_TABLES),
+    `a remote readback asked for more than ${READBACK_MAX_TABLES} tables at once`,
+  );
+  assert.deepEqual(
+    asked.flat(),
+    SHIP_TABLES,
+    'every shipped table must be asked about exactly once',
+  );
+  assert.deepEqual(out, SHIP_EXPECTED);
+});
+
+test('a chunk cannot answer for a table outside its own group', () => {
+  // readCountsWithRetry checks the group but returns the reader's whole object. If a merge copied that
+  // wholesale, a reader answering beyond its group could pre-seed a count for a table whose own group
+  // later dies — and the guard would verify a table nobody actually read. Fail-closed must not depend
+  // on the reader being well-behaved.
+  const readOnce = (group) => {
+    if (group.includes('persons')) return SHIP_EXPECTED; // over-answers: every table, not just its own
+    throw new Error('wrangler timeout'); // ...and every later group dies
+  };
+  const out = readShippedCounts('sigma', false, SHIP_EXPECTED, {
+    readOnce,
+    sleep: () => {},
+    attempts: 2,
+  });
+  for (const t of SHIP_TABLES.slice(READBACK_MAX_TABLES)) {
+    assert.ok(!(t in out), `${t} was answered by another group's reader`);
+  }
+  assert.throws(() => assertShippedCounts(SHIP_EXPECTED, out), /target has no answer/);
+});
+
+test('an INHERITED count never stands in for one the target did not report', () => {
+  // The last hole in „fails closed unconditionally": both the completeness check and the merge used a
+  // bare lookup / `in`, which walk the prototype chain. With Object.prototype carrying the expected
+  // numbers, a group that exhausted to {} still „had" every count — and verification passed over a
+  // target that answered for nothing. Own properties only, in the reader, the merge AND the guard.
+  const polluted = [];
+  try {
+    for (const t of SHIP_TABLES) {
+      Object.defineProperty(Object.prototype, t, {
+        value: SHIP_EXPECTED[t],
+        configurable: true,
+        enumerable: false,
+        writable: true,
+      });
+      polluted.push(t);
+    }
+    const readOnce = () => {
+      throw new Error('wrangler timeout'); // every group dies; nothing is ever really read
+    };
+    const out = readShippedCounts('sigma', false, SHIP_EXPECTED, {
+      readOnce,
+      sleep: () => {},
+      attempts: 2,
+    });
+    for (const t of SHIP_TABLES) {
+      assert.ok(!Object.hasOwn(out, t), `${t} was fabricated from the prototype`);
+    }
+    assert.throws(
+      () => assertShippedCounts(SHIP_EXPECTED, out),
+      /target has no answer/,
+      'the guard must not read counts through a prototype either',
+    );
+  } finally {
+    for (const t of polluted) delete Object.prototype[t];
+  }
+});
+
+test('an INHERITED count is not a complete answer — the reader must own what it reports', () => {
+  // Covers the completeness check specifically (the test above only exercises the merge, because its
+  // reader always throws). Here the reader RETURNS an object whose counts live on the prototype: `in`
+  // and a bare lookup would call that a complete answer and hand it straight back.
+  const polluted = [];
+  try {
+    for (const t of SHIP_TABLES) {
+      Object.defineProperty(Object.prototype, t, {
+        value: SHIP_EXPECTED[t],
+        configurable: true,
+        enumerable: false,
+        writable: true,
+      });
+      polluted.push(t);
+    }
+    // ONE chunk's worth of tables, deliberately: with two chunks the reader is called twice anyway and
+    // a call count could not tell „retried" apart from „second group".
+    const oneChunk = Object.fromEntries(
+      SHIP_TABLES.slice(0, READBACK_MAX_TABLES).map((t) => [t, SHIP_EXPECTED[t]]),
+    );
+    let calls = 0;
+    const readOnce = () => {
+      calls += 1;
+      return {}; // owns nothing; every expected key is only inherited
+    };
+    const out = readShippedCounts('sigma', false, oneChunk, {
+      readOnce,
+      sleep: () => {},
+      attempts: 3,
+    });
+    assert.equal(calls, 3, 'an answer owning nothing must be retried to exhaustion, not accepted');
+    for (const t of Object.keys(oneChunk)) {
+      assert.ok(!Object.hasOwn(out, t), `${t} came from the prototype`);
+    }
+    assert.throws(() => assertShippedCounts(oneChunk, out), /target has no answer/);
+  } finally {
+    for (const t of polluted) delete Object.prototype[t];
+  }
+});
+
+test('a polluted prototype SETTER cannot seed counts for a chunk that never answered', () => {
+  // The accumulator itself was the last hole: `counts[t] = …` invokes an inherited setter, so writing a
+  // healthy chunk's count could define own values for tables in a chunk that later died.
+  const victim = SHIP_TABLES[SHIP_TABLES.length - 1];
+  let installed = false;
+  try {
+    Object.defineProperty(Object.prototype, SHIP_TABLES[0], {
+      configurable: true,
+      enumerable: false,
+      set(v) {
+        // A healthy write smuggles in a count for a table nobody read.
+        Object.defineProperty(this, victim, {
+          value: SHIP_EXPECTED[victim],
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+        Object.defineProperty(this, SHIP_TABLES[0], {
+          value: v,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      },
+      get() {
+        return undefined;
+      },
+    });
+    installed = true;
+    const readOnce = (group) => {
+      if (group.includes(victim)) throw new Error('wrangler timeout');
+      return Object.fromEntries(group.map((t) => [t, SHIP_EXPECTED[t]]));
+    };
+    const out = readShippedCounts('sigma', false, SHIP_EXPECTED, {
+      readOnce,
+      sleep: () => {},
+      attempts: 2,
+    });
+    assert.ok(!Object.hasOwn(out, victim), `${victim} was seeded by a prototype setter`);
+    assert.throws(() => assertShippedCounts(SHIP_EXPECTED, out), /target has no answer/);
+  } finally {
+    if (installed) delete Object.prototype[SHIP_TABLES[0]];
+  }
+});
+
+test('a full six-table readback still verifies clean when every chunk answers', () => {
+  // The happy path across the split: chunking is invisible to the caller.
+  const readOnce = (group) => Object.fromEntries(group.map((t) => [t, SHIP_EXPECTED[t]]));
+  const out = readShippedCounts('sigma', false, SHIP_EXPECTED, { readOnce, sleep: () => {} });
+  assert.doesNotThrow(() => assertShippedCounts(SHIP_EXPECTED, out));
+});
+
 test('readShippedCounts short-circuits to {} when nothing was expected', () => {
   // No numeric expectations → no tables to read → no wrangler call at all.
   let calls = 0;
@@ -509,6 +759,35 @@ test('runShip verifies what landed — a short table fails the run', () => {
 test('runShip fails the run when the read-back itself could not answer', () => {
   const h = shipHarness({ readCounts: () => ({}) });
   assert.throws(() => h.run(), /no answer/);
+});
+
+test('a swallowing prototype setter cannot drop a table out of the verification', () => {
+  // The summary is what the guard compares against. It was built with `summary[table] = …`, so an
+  // inherited setter that accepts the write without defining an own property left NO entry — and
+  // Object.entries then skipped that table in both the expected set and the readback. A shipped table
+  // would simply never be verified: a pass with nothing checked, which is the worst possible „green".
+  let installed = false;
+  try {
+    Object.defineProperty(Object.prototype, 'declarations', {
+      configurable: true,
+      enumerable: false,
+      set() {
+        /* swallow: no own property is ever defined */
+      },
+      get() {
+        return undefined;
+      },
+    });
+    installed = true;
+    const h = shipHarness({ tables: ['persons', 'declarations'] });
+    const summary = h.run();
+    assert.ok(
+      Object.hasOwn(summary, 'declarations'),
+      'the shipped table vanished from the summary the guard verifies',
+    );
+  } finally {
+    if (installed) delete Object.prototype.declarations;
+  }
 });
 
 test('runShip skips a table absent from the work DB without shipping or verifying it', () => {


### PR DESCRIPTION
Проверката след ship пита за всички качени таблици наведнъж - по един терм на таблица в едно `SELECT ... UNION ALL`. SQLite ограничава термите в compound SELECT, а двете D1 среди **не** го ограничават еднакво: remote позволява стандартните 500, локалната (workerd, зад `wrangler d1 execute --local`) позволява **5**. Измерено, не предположено - 5 таблици отговарят, 6 връщат `too many terms in compound SELECT: SQLITE_ERROR`.

Ship-ът пише шест таблици. Тоест срещу локална цел четенето не се проваляше да *прочете*, а да *се парсне*: wrangler връщаше обект-грешка, нито един ред не носеше брой, guard-ът отчиташе `target has no answer` за **всяка** таблица - върху данни, които току-що бяха качени коректно - и бягът умираше преди преиндексирането зад него. Същата фалшива присъда, която #335 махна от мрежовия път, влизаща през друга врата: не изтекла заявка, а заявка, която локалният engine никога няма да приеме.

## Какво прави

- **Само локалният път се дели**, на групи по ≤4 (запас под измерените 5). Remote запазва единствената си заявка: лимитът е свойство на локалния engine, а remote е продукционният път - едно извикване вместо две, наполовина по-малък най-лош backoff и една консистентна снимка.
- Всяка група ретрайва самостоятелно и от отговора ѝ се взимат **само нейните** таблици. Изтощена група не допринася нищо, тъй че таблиците ѝ липсват от слетия отговор и `assertShippedCounts` пак пада затворено.
- Собствеността се пази и в четенето, и в писането: `Object.hasOwn` в проверката за пълнота, в сливането и в самия guard (`in` и голото индексиране минават през прототипа), а всички записи минават през `setOwn` (`defineProperty`), защото присвояването задейства наследен сеттър - а сеттър, който преглътне записа, не оставя собствен запис, `Object.entries` прескача таблицата и тя изобщо не влиза във верификацията. Тоест зелено, при което нищо не е проверено.

## Проверка срещу истинска локална база

| | таблици отговорили | време |
|---|---|---|
| преди | **0/6** → фалшивото „target has no answer" | 19.6с (4 напразни опита) |
| сега | **6/6** с верните броеве | 3.6с |

## Тестове

47 зелени (10 нови). Поведенческите убиват мутантите: пак една заявка; деление и на remote; сливане наедро; мъртва група с нули; само последната група; наследени броеве - поотделно в четеца, в guard-а, през сеттър в сливането и през сеттър в summary-то.

Само за свързаните лица и общи подобрения - без нови функционалности.