### PR TITLE
fix(etl): прекъснат derive да не се бърка с първо пускане

### DIFF
--- a/scripts/import-catchup.test.mjs
+++ b/scripts/import-catchup.test.mjs
@@ -10,7 +10,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -49,7 +57,17 @@ if (ci !== -1) {
     process.exit(1);
   }
   if (/data_freshness/.test(sql)) {
-    process.stdout.write(JSON.stringify([{ results: [{ max_loaded_date: '2026-07-27' }], success: true }]));
+    // CU_NO_FRESHNESS models an INTERRUPTED derive: refresh-slice.sql NULLed as_of in its first batch
+    // and never reached the last one that rewrites it. The column is there; the date is not.
+    const date = process.env.CU_NO_FRESHNESS ? null : '2026-07-27';
+    process.stdout.write(JSON.stringify([{ results: [{ max_loaded_date: date }], success: true }]));
+    process.exit(0);
+  }
+  // The served-corpus probe: a COUNT, never a date. Checked AFTER raw_contracts above, which matches
+  // first and exits, so this only ever sees the contracts query. CU_COLD models an empty database.
+  if (/FROM\\s+contracts/.test(sql)) {
+    const n = process.env.CU_COLD ? 0 : 199723;
+    process.stdout.write(JSON.stringify([{ results: [{ n }], success: true }]));
     process.exit(0);
   }
   process.stdout.write(JSON.stringify([{ results: [], success: true }]));
@@ -61,6 +79,15 @@ process.exit(0);
 // here rather than reaching the network. The parent runs under process.execPath, so it keeps the real
 // node while the child's PATH lookup finds this.
 const FAKE_NODE = `#!${process.execPath}
+import { appendFileSync } from 'node:fs';
+appendFileSync(process.env.CU_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');
+process.exit(0);
+`;
+
+// Same idea for sqlite3: the --work-db path applies the migrations to a throwaway work DB before it ever
+// reaches the catch-up planning we are testing. Nothing here inspects that DB, so a no-op keeps the test
+// about planning rather than about schema.
+const FAKE_SQLITE3 = `#!${process.execPath}
 process.exit(0);
 `;
 
@@ -73,6 +100,7 @@ function runImport(args, env = {}) {
     for (const [name, src] of [
       ['wrangler', FAKE_WRANGLER],
       ['node', FAKE_NODE],
+      ['sqlite3', FAKE_SQLITE3],
     ]) {
       writeFileSync(join(binDir, name), src);
       chmodSync(join(binDir, name), 0o755);
@@ -114,4 +142,171 @@ test('an error that is NOT a missing table still propagates', () => {
   // as one would let the catch-up plan be computed from a lie.
   const r = runImport(['--catchup', '--plan-only'], { CU_OTHER_ERROR: '1' });
   assert.notEqual(r.status, 0, 'a SQLITE_BUSY must not be swallowed as an empty result');
+});
+
+// ── an INTERRUPTED derive must not be mistaken for a first run ──────────────────────────────────────
+// Both watermark witnesses are transient and can be empty at once: raw_contracts is torn down after
+// every load, and refresh-slice.sql NULLs data_freshness.as_of in its first batch and rewrites it only
+// in its last few. Over a POPULATED surface that is not "nothing is loaded", it is "the last derive was
+// interrupted" — and planning from the default start would re-derive the whole feed over live data.
+
+test('an interrupted derive over a populated surface refuses instead of re-deriving everything', () => {
+  const r = runImport(['--catchup', '--plan-only'], { CU_NO_FRESHNESS: '1' });
+  assert.notEqual(r.status, 0, 'planning must refuse when the watermark is gone but data is not');
+  assert.match(r.stderr, /no load watermark, but the served surface is not empty/);
+  // The refusal has to be actionable, or an operator just re-runs it and gets the same wall.
+  assert.match(r.stderr, /--from=YYYY-MM-DD/);
+  assert.doesNotMatch(r.stdout, /derive=full/, 'it must not have planned a full re-derive anyway');
+});
+
+test('the served-corpus probe is a COUNT, and runs only as a last resort', () => {
+  // Two things at once: the probe is reached when both watermarks are silent, and it asks HOW MANY —
+  // never MAX(published_at). Publication dates are not the bucket days the window is computed from, so
+  // a date from here could move the window past buckets that were never loaded and skip them silently.
+  const interrupted = runImport(['--catchup', '--plan-only'], { CU_NO_FRESHNESS: '1' });
+  const probe = interrupted.calls
+    .map((c) => String(c[c.length - 1]))
+    .find((sql) => /FROM\s+contracts/.test(sql) && !/raw_contracts/.test(sql));
+  assert.ok(probe, 'nothing probed the served corpus after freshness came back NULL');
+  assert.match(probe, /COUNT\(\*\)/, 'the probe must count rows');
+  assert.doesNotMatch(probe, /MAX\s*\(/, 'the served corpus must never be read as a watermark');
+
+  const healthy = runImport(['--catchup', '--plan-only']);
+  const probedWhenHealthy = healthy.calls
+    .map((c) => String(c[c.length - 1]))
+    .some((sql) => /FROM\s+contracts/.test(sql) && !/raw_contracts/.test(sql));
+  assert.ok(!probedWhenHealthy, 'data_freshness answered; the served corpus must not be probed');
+});
+
+test('a genuinely cold database still plans the full backfill', () => {
+  // The honest first run: no watermark AND no corpus. That one really does want the whole feed, and the
+  // refusal must not stand in its way.
+  const r = runImport(['--catchup', '--plan-only'], { CU_NO_FRESHNESS: '1', CU_COLD: '1' });
+  assert.equal(r.status, 0, `a cold database must still plan:\n${r.stderr}`);
+  assert.match(r.stdout, /derive=full/);
+});
+
+test('an explicit --from is the escape hatch and is honoured', () => {
+  // An operator who knows where the interrupted run got to can say so, and the refusal steps aside.
+  const r = runImport(['--catchup', '--plan-only', '--from=2026-08-20'], { CU_NO_FRESHNESS: '1' });
+  assert.equal(r.status, 0, `--from should let planning proceed:\n${r.stderr}`);
+  assert.match(r.stdout, /from=2026-08-20/);
+});
+
+test('the advertised recovery is EXECUTABLE — a narrow --from window can be a slice', () => {
+  // The recovery the refusal recommends has to survive past planning. This branch used to hardcode
+  // derive=full, so `--from=<recent>` printed a fine plan and the live run then hit the full-derive
+  // guard (a narrow window + full derive rebuilds from staging and drops everything older). Advice that
+  // only works under --plan-only is worse than no advice, so the plan must carry the slice through.
+  const r = runImport(['--catchup', '--plan-only', '--from=2026-08-20', '--derive=slice'], {
+    CU_NO_FRESHNESS: '1',
+  });
+  assert.equal(r.status, 0, `the recommended recovery must plan:\n${r.stderr}`);
+  assert.match(r.stdout, /derive=slice/, 'an explicit --derive=slice must reach the plan');
+  assert.doesNotMatch(r.stdout, /derive=full/);
+});
+
+test('without an explicit --derive the no-watermark branch still defaults to full', () => {
+  // The cold-start default is unchanged: a first run over the whole feed is a full derive.
+  const r = runImport(['--catchup', '--plan-only'], { CU_NO_FRESHNESS: '1', CU_COLD: '1' });
+  assert.match(r.stdout, /derive=full/);
+});
+
+test('the refusal names the recovery it actually supports', () => {
+  // Pins the message to the flags the code honours, so the two cannot drift apart again.
+  const r = runImport(['--catchup', '--plan-only'], { CU_NO_FRESHNESS: '1' });
+  assert.match(r.stderr, /--from=YYYY-MM-DD --derive=slice/);
+});
+
+// ── the recommended slice must not be silently swallowed by --work-db ───────────────────────────────
+// That path rebuilds a fresh work DB from the window and ships it WHOLESALE, so it acts as a full derive
+// whatever the plan says — it prints `derive` it does not obey. Fine for a window reaching the start of
+// the feed; for the tail the refusal above recommends, it would replace the served corpus with that tail.
+
+function withWorkDb(args, env, { seed = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'catchup-workdb-'));
+  const workDb = join(dir, 'w.sqlite');
+  try {
+    // `seed` puts a pre-existing work DB in place, so a test can prove the refusal did not destroy it.
+    if (seed) writeFileSync(workDb, 'PRE-EXISTING');
+    const r = runImport([...args, `--work-db=${workDb}`], env);
+    // Read the outcome BEFORE the finally below removes the directory — the assertions run afterwards.
+    const workDbSurvived = existsSync(workDb);
+    return {
+      ...r,
+      workDb,
+      workDbSurvived,
+      workDbContent: workDbSurvived ? readFileSync(workDb, 'utf8') : null,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('--work-db catch-up refuses a slice instead of shipping the tail wholesale', () => {
+  const r = withWorkDb(['--catchup', '--from=2026-08-20', '--derive=slice'], {
+    CU_NO_FRESHNESS: '1',
+  });
+  assert.notEqual(r.status, 0, 'a slice this path cannot honour must not proceed');
+  assert.match(r.stderr, /--work-db catch-up can only run a full derive \(got --derive=slice\)/);
+  assert.match(r.stderr, /dropped from the served surface/, 'it must say what would be lost');
+  // And it must stop before doing ANY of the work it would have to undo. The fake `node` logs its argv,
+  // so an actual load would show up in the call log.
+  assert.ok(
+    !r.calls.some((c) => c.join(' ').includes('load-eop')),
+    'it must refuse before the load runs',
+  );
+  assert.ok(
+    !r.calls.some((c) => c.join(' ').includes('ship-domain')),
+    'it must refuse before shipping',
+  );
+});
+
+test('--work-db catch-up refuses WITHOUT destroying the existing work DB', () => {
+  // The refusal used to arrive after the path had already deleted the caller's work DB and re-applied
+  // the migrations — announcing „I will not proceed" once the damage was done.
+  const r = withWorkDb(
+    ['--catchup', '--from=2026-08-20', '--derive=slice'],
+    { CU_NO_FRESHNESS: '1' },
+    { seed: true },
+  );
+  assert.notEqual(r.status, 0);
+  assert.ok(r.workDbSurvived, 'the refusal deleted the work DB it refused to fill');
+  assert.equal(r.workDbContent, 'PRE-EXISTING', 'the work DB was rewritten anyway');
+});
+
+test('--work-db catch-up refuses an UNRECOGNISED derive too, not just a slice', () => {
+  // The allowlist (review ydimitrof, #337). validateDeriveMode runs on the live path only, so a
+  // slice-only check would let `--derive=typo` through to the wholesale ship — the same silent
+  // replacement of the served corpus, reached by a value nobody spelled correctly.
+  const r = withWorkDb(['--catchup', '--from=2026-08-20', '--derive=typo'], {
+    CU_NO_FRESHNESS: '1',
+  });
+  assert.notEqual(r.status, 0, 'an unrecognised derive must not reach the wholesale ship');
+  assert.match(r.stderr, /can only run a full derive \(got --derive=typo\)/);
+  assert.ok(
+    !r.calls.some((c) => c.join(' ').includes('load-eop')),
+    'it must refuse before the load runs',
+  );
+});
+
+test('a bare --from is not a window — the refusal still explains itself', () => {
+  // `--from` with no value parses as `true` (review lyubomir-bozhinov, #337). Counted as present, it
+  // skipped the refusal and the operator hit validateDay's „windowFrom must be YYYY-MM-DD" much later,
+  // which explains nothing about the interrupted derive that actually caused it.
+  const r = runImport(['--catchup', '--plan-only', '--from'], { CU_NO_FRESHNESS: '1' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /no load watermark, but the served surface is not empty/);
+  assert.doesNotMatch(
+    r.stderr,
+    /windowFrom must be/,
+    'the cryptic error must not be what surfaces',
+  );
+});
+
+test('--work-db catch-up still runs when the plan is a full derive', () => {
+  // The guard is aimed at the one unsafe combination, not at the path itself.
+  const r = withWorkDb(['--catchup', '--derive=full'], { CU_NO_FRESHNESS: '1', CU_COLD: '1' });
+  assert.equal(r.status, 0, `a full-window catch-up must still run:\n${r.stderr}`);
+  assert.doesNotMatch(r.stderr, /cannot honour --derive=slice/);
 });

--- a/scripts/import.mjs
+++ b/scripts/import.mjs
@@ -206,14 +206,76 @@ function latestLoadedDate() {
   return fallback[0]?.max_loaded_date ?? null;
 }
 
+/**
+ * Does the served surface already hold an EOP/OCDS corpus? A COUNT, deliberately — never a date. It
+ * exists only to tell „first run" apart from „a derive was interrupted"; see the refusal below for why
+ * the same table must not be used to derive a watermark. Scoped to the two id namespaces so a seeded or
+ * hand-imported row cannot make an empty database look populated.
+ */
+function servedCorpusRows() {
+  const rows = safeD1(`
+    SELECT COUNT(*) AS n
+    FROM contracts
+    WHERE id LIKE 'c:e:%' OR id LIKE 'c:o:%'
+  `);
+  return Number(rows[0]?.n ?? 0);
+}
+
 function resolveCatchupPlan() {
+  const rawFrom = arg('from');
   const today = String(arg('today') || todayUtc());
   const lookbackDays = Number(arg('lookback-days') || DEFAULT_LOOKBACK_DAYS);
   const maxLoadedDate = latestLoadedDate();
   if (!maxLoadedDate) {
-    const from = String(arg('from') || DEFAULT_FROM);
+    // No watermark. That reads as „nothing is loaded" — and for a first run it IS, so the full backfill
+    // below is right. But the two witnesses latestLoadedDate consults are both transient, and they can
+    // fall silent together for a completely different reason:
+    //   • raw_contracts is the transient staging, torn down in a finally after every load;
+    //   • refresh-slice.sql NULLs data_freshness.as_of in its FIRST batch (`setup`, so a half-refreshed
+    //     surface never advertises freshness) and rewrites it only in `globals`, eighteen batches later.
+    //     Every batch is its own atomic statement group, so ANY failure in between leaves as_of NULL.
+    // So an INTERRUPTED derive is indistinguishable from a cold start by watermark alone, and the
+    // consequences differ sharply: a cold start wants the whole feed, while an interrupted derive over a
+    // populated surface would silently re-derive from DEFAULT_FROM — a 2020→today rebuild opening with
+    // DELETE FROM contracts on the live path, and on the --work-db path a narrow tail window that ships
+    // wholesale over the served tables. Neither is what an interrupted run asked for.
+    //
+    // The served corpus tells the two apart, used ONLY as a yes/no — never as a date. It deliberately
+    // does not become a third watermark: `contracts` carries publication dates, not the bucket days the
+    // window is computed from (the served schema has no `source` column at all), and a publication date
+    // that runs ahead of its bucket would move the window PAST buckets that were never loaded — silently
+    // skipping them, which is worse than any rebuild. So: rows but no watermark ⇒ refuse and say why.
+    // An operator who knows how far the interrupted run got states it with --from --derive=slice.
+    // `--from` with no value parses as `true`, which is not a window (review lyubomir-bozhinov, #337).
+    // Treated as present, it skipped this refusal and produced from="true", so the operator got
+    // validateDay's cryptic „windowFrom must be YYYY-MM-DD" instead of the message that explains what
+    // actually happened. Fail-closed either way, but only one of the two tells them what to do.
+    const explicitFrom = typeof rawFrom === 'string' ? rawFrom : null;
+    if (!explicitFrom && servedCorpusRows() > 0) {
+      throw new Error(
+        'catch-up cannot plan: no load watermark, but the served surface is not empty.\n' +
+          '  Both witnesses are transient and empty right now — raw_contracts (torn down after each\n' +
+          '  load) and data_freshness.as_of (NULLed by refresh-slice.sql until its final batches). That\n' +
+          '  is what an INTERRUPTED derive looks like, and it is indistinguishable here from a first run.\n' +
+          '  Refusing rather than guessing: planning from the default start would re-derive the whole\n' +
+          '  feed over a populated surface.\n' +
+          '  Fix, in order of preference:\n' +
+          '    1. Re-run the interrupted derive to completion — it rewrites the watermark.\n' +
+          '    2. State the tail explicitly: --from=YYYY-MM-DD --derive=slice (a narrow window MUST be\n' +
+          '       a slice; a full derive rebuilds from staging and would drop everything older).\n' +
+          '    3. --derive=full only with a window that reaches the start of the feed.',
+      );
+    }
+    const from = String(explicitFrom || DEFAULT_FROM);
     const to = String(arg('to') || today);
-    return { from, to, maxLoadedDate, gapDays: daysInWindow(from, to), derive: 'full' };
+    // Honour an explicit --derive here too. This branch defaults to `full` because its default window
+    // starts at the feed's beginning — but the refusal above sends an operator here WITH a --from, and a
+    // narrow window forced to a full derive is exactly the combination assertDeriveWindowSafe refuses.
+    // Hardcoding `full` made the advertised recovery unusable: the plan printed fine and the live run
+    // then refused it. So the recovery `--from=… --derive=slice` has to reach the dispatcher intact.
+    const requestedDerive = arg('derive');
+    const derive = requestedDerive && requestedDerive !== true ? String(requestedDerive) : 'full';
+    return { from, to, maxLoadedDate, gapDays: daysInWindow(from, to), derive };
   }
   const window = computeCatchupWindow({ maxLoadedDate, today, lookbackDays });
   const from = String(arg('from') || window.from);
@@ -336,6 +398,36 @@ async function runWorkBackfill() {
     rawWorkDb === true
       ? resolve(root, 'data/work/backfill.sqlite')
       : resolve(root, String(rawWorkDb));
+  // Resolve the plan BEFORE touching anything. Both the catch-up refusal below and the one inside
+  // resolveCatchupPlan are „do not proceed" verdicts, and proceeding far enough to delete the caller's
+  // existing work DB and re-apply the migrations before announcing one is its own small act of damage.
+  const plan = catchup ? resolveCatchupPlan() : null;
+  if (plan) {
+    console.log(
+      `==> catchup window ${plan.from}..${plan.to} (${plan.gapDays} days, latest=${plan.maxLoadedDate || 'none'}, derive=${plan.derive})`,
+    );
+    // This path builds a FRESH work DB from the window and then ships it wholesale, so it always behaves
+    // as a full derive no matter what the plan says — the line above prints a `derive` it does not act
+    // on. That is survivable for a window reaching the start of the feed, and destructive for a tail:
+    // everything outside it would be replaced by the tail. The refusal in resolveCatchupPlan recommends
+    // exactly such a tail (`--from=… --derive=slice`), which is right for the live path and wrong here —
+    // so refuse the contradiction loudly rather than silently ignoring the slice.
+    // ALLOWLIST, not a denylist (review ydimitrof, #337). `!== 'full'` rather than `=== 'slice'`:
+    // validateDeriveMode runs on the live path only — this function never reaches it — so an
+    // unrecognised --derive would sail past a slice-only check and straight into the wholesale ship
+    // below. „Anything I do not positively recognise" is the only safe default when the failure mode is
+    // silent replacement of the served corpus.
+    if (plan.derive !== 'full') {
+      throw new Error(
+        `--work-db catch-up can only run a full derive (got --derive=${plan.derive}): it rebuilds a\n` +
+          `  fresh work DB from the window (${plan.from}..${plan.to}) and ships it WHOLESALE, so anything\n` +
+          `  outside the window would be dropped from the served surface.\n` +
+          `  Either run the slice against the live database (without --work-db), or widen the window to\n` +
+          `  the start of the feed and state --derive=full.`,
+      );
+    }
+  }
+
   const workDir = dirname(workDb);
   mkdirSync(workDir, { recursive: true });
   if (existsSync(workDb)) rmSync(workDb, { force: true });
@@ -348,14 +440,7 @@ async function runWorkBackfill() {
   for (const migration of migrations) sqliteFile(workDb, resolve(migrationsDir, migration));
   sqliteFile(workDb, resolve(root, 'scripts/work-staging-schema.sql'));
 
-  let loadFlags = explicitRangeFlags();
-  if (catchup) {
-    const plan = resolveCatchupPlan();
-    loadFlags = rangeFlags(plan.from, plan.to);
-    console.log(
-      `==> catchup window ${plan.from}..${plan.to} (${plan.gapDays} days, latest=${plan.maxLoadedDate || 'none'}, derive=${plan.derive})`,
-    );
-  }
+  const loadFlags = plan ? rangeFlags(plan.from, plan.to) : explicitRangeFlags();
 
   // Derive intermediate-SQL filenames from the work-DB basename so two backfills sharing a work
   // directory (e.g. a convergence harness running full + windowed loads side by side) never clobber


### PR DESCRIPTION
Планировчикът на `--catchup` се допитва до два свидетеля за докъде е стигнало зареждането, и **двата са преходни по устройство**:

- `raw_contracts` е временният staging, който се събаря след всяко зареждане;
- `refresh-slice.sql` зачерква `data_freshness.as_of` в **първия** си батч (`setup`, за да не твърди полуопреснена повърхност свежест) и го възстановява чак в `globals` - **осемнайсет батча по-късно**. Всеки батч е отделна атомарна група, тъй че всеки провал между тях оставя `as_of` празен.

Тогава и двата мълчат едновременно, и това е неразличимо от студена база - макар последствията да са различни. Студено пускане наистина иска целия поток. Прекъснат derive върху пълна повърхност обаче преизгражда от `DEFAULT_FROM`: 2020 - днес, започвайки с `DELETE FROM contracts`. Не това е поискал прекъснатият бяг. Наблюдавано локално: прекъснат `amendments` батч направи следващия catchup пълно преизграждане, което после гръмна на FOREIGN KEY.

## Какво прави

- Сервираният корпус различава двата случая - използван **само като да/не, никога като дата**. Нарочно не става трети воден знак: `contracts` носи дати на публикуване, не дните на кофите, от които се смята прозорецът (сервираната схема изобщо няма колона `source`), а дата на публикуване, изпреварваща своята кофа, би преместила прозореца **отвъд** кофи, които никога не са зареждани - тихо прескачане, което е по-лошо от всяко преизграждане. Затова: има редове, няма воден знак → отказваме и казваме защо.
- Отказът сочи възстановяване, което **наистина работи**. Клонът без воден знак заковаваше `derive: full`, тъй че препоръчаното `--from` печаташе редовен план, а живият бяг после се отказваше от него (тесен прозорец + пълен derive е точно комбинацията, която `assertDeriveWindowSafe` брани). Сега клонът уважава изричен `--derive`; по подразбиране пак `full`, защото неговият подразбиращ прозорец тръгва от началото на потока.
- Пътят с `--work-db` печата `plan.derive`, без да му се подчинява: строи нова work база от прозореца и я изпраща **наедро**. За опашката, която отказът препоръчва, това би заменило сервирания корпус с тази опашка. Там `slice` вече се отказва - и планът се смята **преди** пътят да изтрие заварената work база и да приложи миграциите, защото „няма да продължа" след нанесена щета не е отказ.

Студената база пак планира пълен backfill - това е заковано с тест.

## Тестове

13 зелени (10 нови): отказ върху пълна повърхност със съобщение, което насочва; сондата е `COUNT`, не `MAX`, и само като последна инстанция; студена база пак планира пълен backfill; `--from` е аварийният изход; препоръчаното възстановяване е изпълнимо; съобщението назовава точно уважаваните флагове; `--work-db` отказва slice преди зареждане и без да трие заварената база, а пълен derive минава.

Фалшивият `node` в харнеса вече логва argv - иначе проверката „отказва преди зареждането" беше куха и не можеше да се провали.

Само за свързаните лица и общи подобрения - без нови функционалности.