### PR TITLE
build(deps): вдигни browserslist над двете нови уязвимости и махни изчерпаното игнориране

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -9,15 +9,3 @@
 # been raised to (or past) its fixed version, DELETE the entry — do not let suppressions
 # outlive the vulnerability they cover. `pnpm why <package>` shows the resolved version and
 # what pulls it in.
-
-# ── react-router 7.18.0 — GHSA-qwww-vcr4-c8h2 (High, CVSS 7.1), fixed in 8.3.0 ────────────
-# WHY IGNORED: CSRF bypass in react-router's UNSTABLE RSC (React Server Components) code paths
-# only. Sigma runs plain SSR (React Router v7) and uses NO unstable_/RSC APIs — see
-# apps/web/react-router.config.ts (no unstable_ flags) and the note in workers/rate-limit.ts —
-# so the vulnerable path is unreachable. The only fix is 8.3.0, a MAJOR upgrade requiring a
-# planned migration (no 7.x backport exists as of the advisory).
-# REMOVE WHEN: apps/web is migrated to react-router >= 8.3.0, or a 7.x patch ships.
-[[IgnoredVulns]]
-id = "GHSA-qwww-vcr4-c8h2"
-ignoreUntil = 2026-10-01T00:00:00Z
-reason = "CSRF bypass in react-router unstable RSC APIs only; sigma uses plain SSR with no RSC/unstable_ usage, so unreachable. Fix is 8.3.0 (major). Remove on the react-router 8.x migration."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   postcss: ^8.5.18
   valibot: ^1.4.2
   nanoid: ^3.3.17
+  browserslist: ^4.28.7
 
 importers:
 
@@ -1332,8 +1333,8 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
-  baseline-browser-mapping@2.10.31:
-    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1347,8 +1348,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1356,8 +1357,8 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1412,8 +1413,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  electron-to-chromium@1.5.360:
-    resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -1666,8 +1667,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.45:
-    resolution: {integrity: sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   node-sql-parser@5.4.0:
@@ -1887,11 +1888,11 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.28.7
 
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
@@ -2191,7 +2192,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -3071,7 +3072,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  baseline-browser-mapping@2.10.31: {}
+  baseline-browser-mapping@2.11.20: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3081,17 +3082,17 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.31
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.360
-      node-releases: 2.0.45
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   cac@6.7.14: {}
 
-  caniuse-lite@1.0.30001793: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -3129,7 +3130,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  electron-to-chromium@1.5.360: {}
+  electron-to-chromium@1.5.420: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -3384,7 +3385,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  node-releases@2.0.45: {}
+  node-releases@2.0.54: {}
 
   node-sql-parser@5.4.0:
     dependencies:
@@ -3658,9 +3659,9 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,11 @@ overrides:
   #                 only, via vite/vitest — never ships to the Worker.
   nanoid: '^3.3.17'
 
+  #   browserslist <4.28.7 — two HIGH advisories (GHSA-73wf-gq98-2v4g, GHSA-c83g-rgw3-j3cx, CVSS 7.5),
+  #                 via @babel/helper-compilation-targets → build-time only, never ships to the
+  #                 Worker. The range (^4.24.0) already admitted the fix; the lockfile had not moved,
+  #                 so the audit gate went red on main (2026-09-02). The pin is the floor.
+  browserslist: '^4.28.7'
 onlyBuiltDependencies:
   - esbuild
   - workerd


### PR DESCRIPTION
Стъпката **Dependency audit** е червена на `main` от днес (2026-09-02) и блокира всички отворени PR-ове (#336, #337, #254, #220).

## Какво пада

- Две нови High уязвимости срещу `browserslist 4.28.2` (GHSA-73wf-gq98-2v4g, GHSA-c83g-rgw3-j3cx, CVSS 7.5), поправени в 4.28.7. Транзитивна, през `@babel/helper-compilation-targets` — build-time toolchain, не се доставя на Worker-а.
- osv-scanner отчита игнорирането на `GHSA-qwww-vcr4-c8h2` (react-router) като **неизползвано** — react-router е на 7.18.2 и advisory-то вече не съвпада. Сканерът третира неизползвано игнориране като провал.

## Какво прави

- `pnpm update browserslist -r` → 4.28.2 → **4.28.8**. Диапазонът на родителя (`^4.24.0`) вече допускаше поправката; lockfile-ът просто не беше мръднал. Lockfile-ът не е редактиран на ръка — той е изходът на pnpm.
- По установената конвенция на `overrides` в `pnpm-workspace.yaml` (същият случай като `undici`): под `browserslist: ^4.28.7`, документиран, за да не може бъдещ dependent да върне уязвима версия.
- Записът за `GHSA-qwww-vcr4-c8h2` отпада по собствената политика на `osv-scanner.toml` („REMOVE WHEN … a 7.x patch ships").

## Проверка

- osv-scanner **2.4.0** със същия sha като CI: `No issues found`
- `pnpm install --frozen-lockfile`: минава
- lint, typecheck, целият тестов пакет (turbo): зелени

Само зависимости и конфигурация — нула продукционен код. Първи от три PR-а за подредба на зависимостите; следват catalog за споделените версии и единна версия на Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pBk7JaPgpsgELYGZgnkwt