### PR TITLE
fix(etl): раздели преизчислението на стойностите, за да спре да прелива паметта на D1

### DIFF
--- a/packages/ingest/src/refresh-statement-shape.test.ts
+++ b/packages/ingest/src/refresh-statement-shape.test.ts
@@ -1,0 +1,119 @@
+// A tripwire on the SHAPE of refresh-slice.sql, not on its results.
+//
+// On 2026-08-14 the `amendments` batch began failing on D1 with `out of memory: SQLITE_NOMEM` and kept
+// failing every six hours for nineteen days. The data was not at fault — it OOMed even when the slice
+// matched zero rows — and neither was raw size: the two biggest statements in the `contracts` batch
+// (349 and 363 lines) run fine, while the one that died was 308.
+//
+// What it was: a large `UPDATE … FROM <cte>`. SQLite is free to flatten an unhinted CTE rather than
+// materialise it, and the old statement's local plan indeed shows no MATERIALIZE node — so the honest
+// description is not "SQLite must materialise the chain" but "the planner's expansion of this shape, at
+// this size, exceeded what D1 would allocate". Splitting the heavy half into a real table acts as an
+// optimisation fence and keeps the surviving statement small.
+//
+// The failure was invisible from outside: `@refresh-batch setup` NULLs home_totals.as_of and only
+// `globals` restores it, so a death in between leaves the surface with no freshness marker at all
+// rather than an error anyone would notice.
+//
+// LIMITS OF THIS TEST, stated plainly: it reads SQL with regexes. It catches the shape in the forms
+// we have seen or would routinely write — a bare name, `FROM x alias`, `FROM x AS a`, `FROM x JOIN …`,
+// quoted names, column-list CTEs, `WITH RECURSIVE`, `AS [NOT] MATERIALIZED (`. It does NOT catch: a
+// `FROM` that is not at the start of its line, a CTE reached only from the right-hand side of a JOIN,
+// or a derived-table source (`FROM (SELECT …)`); and it strips `--` comments but not `/* … */` blocks,
+// so a block comment still counts toward the line threshold. Extend the patterns before relying on
+// any of those. It cannot prove a statement fits D1's budget. It is a tripwire against drift, not a
+// proof of safety.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { refreshSliceStatementGroups } from './refresh';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SQL = readFileSync(join(ROOT, 'scripts/refresh-slice.sql'), 'utf8');
+
+/** Statement text with comments and blank lines removed — so prose cannot move a size threshold. */
+function code(sql: string): string {
+  return sql
+    .split('\n')
+    .map((l) => l.replace(/--.*$/, '').trimEnd())
+    .filter((l) => l.trim() !== '')
+    .join('\n');
+}
+
+/** CTE names introduced by `WITH x AS (`, `WITH RECURSIVE x AS (`, `), y AS (`, incl. column lists. */
+function cteNames(sql: string): Set<string> {
+  const re =
+    /(?:^\s*WITH(?:\s+RECURSIVE)?|\)\s*,)\s*"?([a-z_][a-z0-9_]*)"?\s*(?:\([^)]*\))?\s+AS\s*(?:MATERIALIZED\s+|NOT\s+MATERIALIZED\s+)?\(/gim;
+  return new Set([...sql.matchAll(re)].flatMap((m) => (m[1] ? [m[1].toLowerCase()] : [])));
+}
+
+/**
+ * Does this UPDATE take rows from one of its own CTEs? Covers `FROM x`, `FROM x alias`, `FROM x AS a`
+ * and `FROM x JOIN …` — the forms a routine edit would produce. A derived-table source (`FROM (SELECT …)`)
+ * is deliberately not matched: it is a different shape and has not been observed here.
+ */
+function updatesFromOwnCte(sql: string): string[] {
+  if (!/^\s*UPDATE\b/im.test(sql)) return [];
+  const ctes = cteNames(sql);
+  return [...sql.matchAll(/^\s*FROM\s+"?([a-z_][a-z0-9_]*)"?\b/gim)]
+    .flatMap((m) => (m[1] ? [m[1].toLowerCase()] : []))
+    .filter((name) => ctes.has(name));
+}
+
+describe('refresh-slice statement shape', () => {
+  it('keeps every UPDATE … FROM <cte> small enough that the planner survived it', () => {
+    // The band is measured, not guessed — all three points observed on this file:
+    // (code lines = comments and blank lines stripped, exactly as `code()` below counts them):
+    //   lot-values  ·  30 code lines ·  1 nested SELECT  · runs fine (since 2026-06)
+    //   amendments  · 105 code lines ·  5 nested SELECTs · runs fine (after this split)
+    //   amendments  · 247 code lines · 19 nested SELECTs · OOMed D1 for nineteen days
+    const offenders = refreshSliceStatementGroups(SQL)
+      .flatMap((g) => g.statements.map((sql) => ({ group: g.name, sql })))
+      .filter(({ sql }) => updatesFromOwnCte(sql).length > 0)
+      .map(({ group, sql }) => {
+        const body = code(sql);
+        return {
+          group,
+          lines: body.split('\n').length,
+          subqueries: (body.match(/\(\s*SELECT\b/gi) ?? []).length,
+        };
+      })
+      .filter((s) => s.lines > 160 || s.subqueries > 12);
+
+    expect(
+      offenders,
+      'An `UPDATE … FROM <cte>` in refresh-slice.sql has grown back past the size that exhausted D1 on\n' +
+        '2026-08-14 (SQLITE_NOMEM, nineteen days of silent staleness). Move the heavy half into a\n' +
+        'transient table first, the way amend_contract_base does, rather than raising these numbers.',
+    ).toEqual([]);
+  });
+
+  it('materialises contract_base, and the consumer reads the table it creates', () => {
+    expect(SQL).not.toMatch(/^WITH contract_base AS \(/m);
+    const create = SQL.indexOf('CREATE TABLE amend_contract_base AS');
+    const read = SQL.indexOf('FROM amend_contract_base');
+    expect(create, 'the transient table is no longer created').toBeGreaterThan(-1);
+    expect(read, 'nothing reads amend_contract_base — the split lost its consumer').toBeGreaterThan(
+      create,
+    );
+  });
+
+  it('guards the transient table on both sides of its use, in order', () => {
+    const create = SQL.indexOf('CREATE TABLE amend_contract_base AS');
+    const drops = [...SQL.matchAll(/DROP TABLE IF EXISTS amend_contract_base\b/g)].map(
+      (m) => m.index,
+    );
+    expect((SQL.match(/CREATE TABLE amend_contract_base\b/g) ?? []).length).toBe(1);
+    // one before the CREATE (so a re-run cannot read a stale slice) and one after the consumer
+    expect(drops.filter((i) => i < create)).toHaveLength(1);
+    expect(drops.filter((i) => i > SQL.indexOf('FROM amend_contract_base'))).toHaveLength(1);
+  });
+
+  it('registers the transient table so an aborted run is swept', () => {
+    // Without this, a run that dies between CREATE and DROP leaves the table in D1 until the next
+    // refresh happens to reach its DROP — exactly the kind of silent residue this batch already bit us with.
+    const refreshTs = readFileSync(join(ROOT, 'packages/ingest/src/refresh.ts'), 'utf8');
+    expect(refreshTs).toMatch(/SCRATCH_TABLES\s*=\s*\[[^\]]*'amend_contract_base'/);
+  });
+});

--- a/packages/ingest/src/refresh.test.ts
+++ b/packages/ingest/src/refresh.test.ts
@@ -126,7 +126,7 @@ describe('transient staging statements', () => {
 
   it('drops every transient + legacy table in reverse of the declared order', () => {
     // [...scratch, ...current, ...legacy].reverse() → legacy first, then current back-to-front, and
-    // the derive-step scratch table last.
+    // the derive-step scratch tables last.
     expect(dropTransientStagingStatements()).toEqual([
       'DROP TABLE IF EXISTS raw_egov_amendments',
       'DROP TABLE IF EXISTS raw_egov_tenders',
@@ -136,6 +136,7 @@ describe('transient staging statements', () => {
       'DROP TABLE IF EXISTS raw_amendments',
       'DROP TABLE IF EXISTS raw_tenders',
       'DROP TABLE IF EXISTS raw_contracts',
+      'DROP TABLE IF EXISTS amend_contract_base',
       'DROP TABLE IF EXISTS amendment_contract_resolve',
     ]);
   });

--- a/packages/ingest/src/refresh.ts
+++ b/packages/ingest/src/refresh.ts
@@ -102,7 +102,7 @@ const LEGACY_TRANSIENT_STAGING_TABLES = [
 // its own script, so it self-heals on the next run; listing it here also sweeps it after an aborted run so
 // it never lingers in D1 (review nikimilenkov LOW 2 — #306's value-resolver scratch table). Not part of
 // work-staging-schema.sql, so it stays out of transientStagingStatements' recreate path.
-const SCRATCH_TABLES = ['amendment_contract_resolve'] as const;
+const SCRATCH_TABLES = ['amendment_contract_resolve', 'amend_contract_base'] as const;
 
 function touchesTransientStaging(statement: string): boolean {
   return TRANSIENT_STAGING_TABLES.some((table) => statement.includes(table));

--- a/scripts/refresh-slice.sql
+++ b/scripts/refresh-slice.sql
@@ -2061,7 +2061,31 @@ WHERE (id GLOB 'c:[eo]:*' AND EXISTS (
         AND ra.contract_number = contracts.contract_number
    );
 
-WITH contract_base AS (
+-- The value recomputation used to be ONE statement: `WITH contract_base AS (…), base, calc,
+-- recalculated UPDATE contracts … FROM recalculated`. On 2026-08-14 it began failing on D1 with
+-- `D1_ERROR: out of memory: SQLITE_NOMEM`, and kept failing every six hours for nineteen days.
+--
+-- What is measured, and only that: it OOMs even when the slice matches ZERO rows, so the data is not
+-- the cause. Raw size is not the discriminator either — the two largest statements in the `contracts`
+-- batch (349 and 363 lines, 28-29 nested SELECTs, not all of them correlated) run fine, while this one
+-- was 308 lines with 19. Those are `INSERT … SELECT`; this was a large `UPDATE … FROM <cte>`. That
+-- shape alone is not fatal — lot-values above has used it since 2026-06 at 30 lines — but at this size
+-- it was. SQLite is free to flatten an unhinted CTE instead of materialising it (the old statement's
+-- local plan has no MATERIALIZE node at all), so the honest reading is that the planner's expansion of
+-- this shape at this size exceeded what D1 would allocate. Persisting the heavy half into a real table
+-- acts as an optimisation fence and leaves a small statement behind: 247 code lines → 105.
+--
+-- The failure was silent in the worst way. `@refresh-batch setup` NULLs home_totals.as_of and only
+-- `globals` — eighteen batches later — restores it, so a death in between leaves the surface with no
+-- freshness at all: staging's footer simply dropped „последен договор" and froze at 14.08.
+--
+-- So contract_base is materialised into a transient table first — the same idiom contractor_identity
+-- above already uses. Verified equivalent, not assumed: original vs split, run under sqlite3 (no
+-- memory ceiling) over the same 199 723 contracts, gave 0 differences across all five updated columns
+-- (value_flag, amount, amount_eur, signing_value_eur, current_value_eur).
+DROP TABLE IF EXISTS amend_contract_base;
+
+CREATE TABLE amend_contract_base AS
   SELECT c.id, c.currency, c.signing_value, c.current_value, c.current_value_currency, c.fx_rate, c.value_flag,
     te.estimated_value AS proc_est_native,
     CASE
@@ -2094,19 +2118,11 @@ WITH contract_base AS (
         LIMIT 1
       )
     END AS proc_est_eur,
-    te.estimated_value AS tender_estimated_value,
-    COALESCE((
-      SELECT rc.estimated_value
-      FROM raw_contracts rc
-      WHERE rc.unp = substr(c.tender_id, 3)
-        AND rc.contract_number = c.contract_number
-        AND (
-          (c.id LIKE 'c:e:%' AND rc.source LIKE 'eop:%')
-          OR (c.id LIKE 'c:o:%' AND rc.source LIKE 'ocds:%')
-        )
-      ORDER BY rc.source DESC, rc.id DESC
-      LIMIT 1
-    ), te.estimated_value) AS classifier_estimated_value,
+    -- tender_estimated_value and classifier_estimated_value used to be projected here. The old CTE was
+    -- flattened by the planner, so neither column cost anything when nothing downstream read them;
+    -- persisting the row into a table makes every projected column real work — the classifier one
+    -- carries a correlated raw_contracts lookup with its own ORDER BY. Both are unread by the
+    -- consumer below (review), so they are not materialised.
     c.signed_at,
     -- The contract row's OWN estimate and the currency it is denominated in, for the стотинки band's
     -- own-row arm (#247). Deliberately WITHOUT the procedure fallback classifier_estimated_value carries:
@@ -2250,7 +2266,9 @@ WITH contract_base AS (
       WHERE a.unp = substr(c.tender_id, 3)
         AND a.contract_number = c.contract_number
     )
-), base AS (
+;
+
+WITH base AS (
   SELECT id, currency, signing_value, current_value, current_value_currency, fx_rate, proc_est_eur, proc_est_native,
     CASE
       WHEN c.value_flag NOT IN ('annex_suspect', 'annex_total_suspect')
@@ -2298,7 +2316,7 @@ WITH contract_base AS (
           LIMIT 1
         )
       END AS own_est_eur
-    FROM contract_base cb
+    FROM amend_contract_base cb
   ) c
 ), calc AS (
   SELECT id, new_value_flag, proc_est_eur,
@@ -2369,6 +2387,10 @@ SET
   current_value_eur = recalculated.new_current_value_eur
 FROM recalculated
 WHERE recalculated.id = contracts.id;
+
+-- The transient table exists only for the statement above; drop it so a later batch
+-- (or a re-run) never reads a stale slice.
+DROP TABLE IF EXISTS amend_contract_base;
 
 INSERT OR IGNORE INTO refresh_touched_contracts (id)
 SELECT DISTINCT c.id


### PR DESCRIPTION
## Какво е счупено

Насроченият refresh на **stage** пада от 14.08 с `D1_ERROR: out of memory: SQLITE_NOMEM` - 76 поредни бяга на всеки шест часа, деветнайсет дни. Спира на стъпка `derive-slice:amendments`.

Провалът беше невидим: батчът `setup` зачерква `home_totals.as_of`, а го възстановява чак `globals` осемнайсет батча по-късно. Смърт между двете оставя повърхността без маркер за свежест - футърът на stage изгуби реда „последен договор" и замръзна на 14.08, докато workflow-ът вървеше червен.

Продукцията е незасегната **само** защото `sigma-etl` не е деплойван от 15.06 и върви код отпреди 14.08.

## Защо

Формата на един израз, не данните и не размерът:

- гърми и когато срезът избира **нула** реда - данните не са причината;
- двата най-големи израза в батча `contracts` (349 и 363 реда, 28-29 вложени SELECT-а) минават, а счупеният беше 308 реда с 19 - размерът сам по себе си не е причината;
- онези са `INSERT ... SELECT`; този беше голям `UPDATE ... FROM <cte>`. Формата сама по себе си също не е фатална - `lot-values` я ползва от 07.06 при 30 реда - но при този размер беше.

SQLite не е длъжен да материализира CTE - плановчикът може да го разгъне, и планът на стария израз няма нито един `MATERIALIZE` възел. Точното твърдение е, че разгъването на тази форма при този размер надхвърля това, което D1 отпуска.

## Какво прави

- `contract_base` се материализира в преходна таблица `amend_contract_base` (същият идиом като `contractor_identity`), а остатъкът чете от нея. Изразът пада от 247 на 105 реда код.
- Две колони, които консуматорът не чете (`tender_estimated_value`, `classifier_estimated_value`), не се пренасят - в таблица всяка проектирана колона е истинска работа, а класификаторната носи корелирана справка със собствен `ORDER BY`.
- Таблицата е в `SCRATCH_TABLES`, за да я помита `dropTransientStagingStatements()` след прекъснат бяг.
- Нов тест-тришка `refresh-statement-shape.test.ts`: заковава лентата (30/1 минава, 105/5 минава, 247/19 падаше), жизнения цикъл на преходната таблица **по ред** (drop → create → консуматор → drop) и вписването в регистъра. Казва точно какво хваща (псевдоним, join, цитирани имена, CTE с колони, RECURSIVE, MATERIALIZED) и какво не.

## Доказателство за еквивалентност

Оригиналът и разделената версия, пуснати през `sqlite3` (без таван на паметта) върху едни и същи 199 723 договора: **0 разлики** по всичките пет обновявани колони (`value_flag`, `amount`, `amount_eur`, `signing_value_eur`, `current_value_eur`). Повторено след махането на двете колони. Поправеният батч е пуснат и през истинския механизъм (`emit-refresh-group` + `wrangler d1 execute --local`) - минава, чисти преходната таблица, пак 0 разлики.

## Ревю

Три независими Codex-ревюта. Първите две върнаха находки (заобиколим тест, липсващо вписване в регистъра, неточни причинни твърдения и числа, две мъртви колони) - всички поправени. Третото потвърди поправките и числата; единствената му забележка беше забранен от AGENTS.md трейлър в комита, махнат.

## След мърдж

Проверка **само на stage** - следващият насрочен `sigma-refresh-stage` трябва да мине през `derive-slice:amendments` и футърът да се размрази. Нищо не се пипа на prod - деплоят там е отделно решение.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pBk7JaPgpsgELYGZgnkwt
